### PR TITLE
Simplify Insight model and add evidence verification

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -6,25 +6,42 @@ of the asp package. They are only used by tools/generate_schemas.py.
 
 from models.analysis import Analysis, Decision, Evidence, Input, Option, Output
 from models.insight import (
-    AnalysisSource,
+    ArxivSource,
+    DoiSource,
+    FigureSelector,
+    FragmentSelector,
     Insight,
     InsightCollection,
-    InsightEvidence,
-    PaperSource,
+    InsightSource,
+    TableSelector,
+    TextQuoteSelector,
+)
+from models.insight import (
+    Evidence as InsightEvidence,
 )
 from models.universe import Universe
 
 __all__ = [
+    # Analysis
     "Analysis",
-    "AnalysisSource",
     "Decision",
     "Evidence",
     "Input",
+    "Option",
+    "Output",
+    # Universe
+    "Universe",
+    # Insight - Sources
+    "ArxivSource",
+    "DoiSource",
+    "InsightSource",
+    # Insight - W3C Selectors
+    "TextQuoteSelector",
+    "FragmentSelector",
+    "FigureSelector",
+    "TableSelector",
+    # Insight - Core
     "Insight",
     "InsightCollection",
     "InsightEvidence",
-    "Option",
-    "Output",
-    "PaperSource",
-    "Universe",
 ]

--- a/models/insight.py
+++ b/models/insight.py
@@ -1,187 +1,292 @@
-"""Pydantic models for scientific insights."""
+"""Pydantic models for scientific insights.
+
+Simplified insight model with W3C Web Annotation-compliant selectors
+for referencing content in scientific papers.
+
+W3C Web Annotation compliance:
+- TextQuoteSelector: https://www.w3.org/TR/annotation-model/#text-quote-selector
+- FragmentSelector: https://www.w3.org/TR/annotation-model/#fragment-selector
+"""
 
 from __future__ import annotations
 
+from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Annotated, Literal
 
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+# =============================================================================
+# W3C Web Annotation Selectors
+# =============================================================================
 
-class PaperSource(BaseModel):
-    """Source reference to a scientific paper."""
 
-    model_config = ConfigDict(extra="forbid")
+class TextQuoteSelector(BaseModel):
+    """W3C TextQuoteSelector for locating text in a document.
 
+    See: https://www.w3.org/TR/annotation-model/#text-quote-selector
+
+    The authoritative anchor for verification. Text should be normalized
+    (HTML/XML tags removed, entities decoded).
+    """
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    type: Literal["TextQuoteSelector"] = "TextQuoteSelector"
+    exact: str = Field(min_length=1, description="Exact quoted text (1-3 sentences)")
+    prefix: str | None = Field(
+        default=None, description="~20-100 chars before for disambiguation"
+    )
+    suffix: str | None = Field(
+        default=None, description="~20-100 chars after for disambiguation"
+    )
+
+
+class FragmentSelector(BaseModel):
+    """W3C FragmentSelector for PDF locations.
+
+    See: https://www.w3.org/TR/annotation-model/#fragment-selector
+    Conforms to RFC 3778/8118 for PDF fragments.
+    """
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    type: Literal["FragmentSelector"] = "FragmentSelector"
+    conforms_to: Literal["http://tools.ietf.org/rfc/rfc3778"] = Field(
+        default="http://tools.ietf.org/rfc/rfc3778",
+        alias="conformsTo",
+    )
+    value: str | None = Field(default=None, description="Fragment (e.g., 'page=6')")
+    page: int | None = Field(default=None, ge=1, description="1-indexed page number")
+
+
+class FigureSelector(BaseModel):
+    """Selector for referencing figures in scientific papers.
+
+    Extension of W3C selector pattern for scientific literature.
+    The label is the authoritative identifier (e.g., "Figure 3a").
+    """
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    type: Literal["FigureSelector"] = "FigureSelector"
+    label: str = Field(min_length=1, description="Figure label (e.g., 'Figure 3a', 'Fig. 1')")
+    caption: str | None = Field(default=None, description="Caption text for verification")
+
+
+class TableSelector(BaseModel):
+    """Selector for referencing tables in scientific papers.
+
+    Extension of W3C selector pattern for scientific literature.
+    The label is the authoritative identifier (e.g., "Table 2").
+    """
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    type: Literal["TableSelector"] = "TableSelector"
+    label: str = Field(min_length=1, description="Table label (e.g., 'Table 1', 'Tab. 2')")
+    caption: str | None = Field(default=None, description="Caption/header text for verification")
+    region: str | None = Field(default=None, description="Specific region (e.g., 'row 3')")
+
+
+# =============================================================================
+# Sources
+# =============================================================================
+
+
+class ArxivSource(BaseModel):
+    """Versioned arXiv paper source for reproducible references.
+
+    The version is mandatory to ensure reproducibility - arXiv papers
+    can be updated, and we need to reference a specific snapshot.
+    """
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    id: str = Field(min_length=1, description="Local ID for evidence references")
+    type: Literal["arxiv"] = "arxiv"
+    arxiv_id: str = Field(
+        pattern=r"^\d{4}\.\d{4,5}$|^[a-z-]+/\d{7}$",
+        description="arXiv ID without version (e.g., '1706.03762')",
+    )
+    version: int = Field(ge=1, description="arXiv version number")
+
+    # Verification
+    content_sha256: str | None = Field(
+        default=None,
+        pattern=r"^[a-fA-F0-9]{64}$",
+        description="SHA-256 of PDF bytes for verification",
+    )
+    retrieved_at: datetime | None = Field(default=None, description="When PDF was fetched")
+
+    # Optional metadata
+    title: str | None = Field(default=None)
+    authors: list[str] | None = Field(default=None)
+
+    @property
+    def canonical(self) -> str:
+        """Canonical arXiv reference (e.g., 'arXiv:1706.03762v7')."""
+        return f"arXiv:{self.arxiv_id}v{self.version}"
+
+    @property
+    def abs_url(self) -> str:
+        """Versioned abstract URL."""
+        return f"https://arxiv.org/abs/{self.arxiv_id}v{self.version}"
+
+    @property
+    def pdf_url(self) -> str:
+        """Versioned PDF URL."""
+        return f"https://arxiv.org/pdf/{self.arxiv_id}v{self.version}"
+
+
+class DoiSource(BaseModel):
+    """DOI-based paper source for non-arXiv publications."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    id: str = Field(min_length=1, description="Local ID for evidence references")
+    type: Literal["doi"] = "doi"
     doi: str = Field(
         pattern=r"^10\.\d{4,}/.*$",
-        description="DOI of the paper (e.g., '10.1038/s41586-023-06221-2')",
+        description="DOI (e.g., '10.1038/s41586-023-06221-2')",
     )
 
+    # Optional metadata
+    title: str | None = Field(default=None)
+    authors: list[str] | None = Field(default=None)
 
-class AnalysisSource(BaseModel):
-    """Source reference to a previous ASP analysis."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    analysis: str = Field(description="Reference to the analysis (e.g., 'org/analysis-name')")
-    version: str | None = Field(default=None, description="Version of the analysis")
-    universe: str | None = Field(default=None, description="Specific universe used")
-
-
-class FigureEvidence(BaseModel):
-    """Evidence from a figure."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    figure: str = Field(description="Figure reference (e.g., 'Figure 3a')")
-    caption: str | None = Field(default=None, description="Figure caption or description")
+    @property
+    def url(self) -> str:
+        """DOI resolver URL."""
+        return f"https://doi.org/{self.doi}"
 
 
-class QuoteEvidence(BaseModel):
-    """Evidence from a direct quote."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    quote: str = Field(description="The exact quoted text")
-    location: str | None = Field(
-        default=None, description="Location in source (e.g., 'Section 2.1, p.3')"
-    )
+# Discriminated union for type-safe source parsing
+InsightSource = Annotated[
+    ArxivSource | DoiSource,
+    Field(discriminator="type"),
+]
 
 
-class TableEvidence(BaseModel):
-    """Evidence from a table."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    table: str = Field(description="Table reference (e.g., 'Table 1')")
-    location: str | None = Field(default=None, description="Specific row/column if applicable")
-    value: str | None = Field(default=None, description="The specific value referenced")
+# =============================================================================
+# Evidence
+# =============================================================================
 
 
-class EquationEvidence(BaseModel):
-    """Evidence from an equation."""
+class Evidence(BaseModel):
+    """Evidence from scientific literature with W3C-compliant selectors.
 
-    model_config = ConfigDict(extra="forbid")
+    At least one content selector (quote, figure, or table) is required.
+    The FragmentSelector provides optional PDF location hints.
+    """
 
-    equation: str = Field(description="Equation reference (e.g., 'Equation 7')")
-    expression: str | None = Field(default=None, description="The mathematical expression")
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
+    id: str = Field(min_length=1, description="Evidence ID")
+    source_ref: str = Field(min_length=1, description="References source.id")
 
-class ResultEvidence(BaseModel):
-    """Evidence from a numerical result."""
+    # Content selectors (at least one required)
+    quote: TextQuoteSelector | None = Field(default=None, description="Text quote anchor")
+    figure: FigureSelector | None = Field(default=None, description="Figure reference")
+    table: TableSelector | None = Field(default=None, description="Table reference")
 
-    model_config = ConfigDict(extra="forbid")
+    # Location hint
+    location: FragmentSelector | None = Field(default=None, description="PDF location hint")
 
-    result: str = Field(description="Description of the result")
-    location: str | None = Field(default=None, description="Where in the source")
-    value: Any | None = Field(default=None, description="The numerical value")
-
-
-class MetricEvidence(BaseModel):
-    """Evidence from an analysis metric output."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    metric: str = Field(description="Name of the metric")
-    value: Any = Field(description="The metric value(s)")
-
-
-class OutputEvidence(BaseModel):
-    """Evidence from an analysis output artifact."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    output: str = Field(description="Output ID or path")
+    @model_validator(mode="after")
+    def require_at_least_one_selector(self) -> Evidence:
+        """Ensure at least one content selector is provided."""
+        if not (self.quote or self.figure or self.table):
+            raise ValueError(
+                "Evidence must have at least one content selector: quote, figure, or table"
+            )
+        return self
 
 
-# Union type for all evidence types
-InsightEvidence = (
-    FigureEvidence
-    | QuoteEvidence
-    | TableEvidence
-    | EquationEvidence
-    | ResultEvidence
-    | MetricEvidence
-    | OutputEvidence
-)
+# =============================================================================
+# Insight
+# =============================================================================
 
 
 class Insight(BaseModel):
     """A scientific insight with provenance and supporting evidence.
 
-    An insight is a discrete unit of scientific knowledge that can come from
-    either literature (papers) or computation (previous analyses).
+    Represents a discrete unit of scientific knowledge extracted from
+    literature, with full traceability to source material via W3C-compliant
+    text selectors.
     """
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
-    claim: str = Field(description="The insight content - what we learned (1-2 sentences)")
-    source: PaperSource | AnalysisSource = Field(
-        description="Where this insight comes from (paper DOI or analysis reference)"
-    )
-    evidence: list[InsightEvidence] = Field(
-        default_factory=list,
-        description="Supporting evidence for this insight (figures, quotes, tables, etc.)",
-    )
-    scope: str | None = Field(
-        default=None,
-        description="Context or conditions where this insight applies",
-    )
+    # Required
+    id: str = Field(min_length=1, description="Unique identifier")
+    claim: str = Field(min_length=1, description="What we learned (1-2 sentences)")
+    created_at: datetime = Field(description="Creation timestamp (ISO 8601)")
+    sources: list[InsightSource] = Field(min_length=1, description="Source paper(s)")
+    evidence: list[Evidence] = Field(min_length=1, description="Supporting evidence")
+
+    # Optional classification
+    confidence: float | None = Field(default=None, ge=0.0, le=1.0, description="Confidence [0,1]")
+    derived: bool = Field(default=False, description="True if synthesized/inferred")
+
+    # Optional context
+    scope: str | None = Field(default=None, description="Applicability conditions")
+    tags: list[str] = Field(default_factory=list, description="Categorization tags")
+    notes: str | None = Field(default=None, description="Reasoning notes")
 
     @model_validator(mode="after")
-    def validate_evidence_types(self) -> Insight:
-        """Validate that evidence types match the source type."""
-        is_paper = isinstance(self.source, PaperSource)
+    def validate_evidence_refs(self) -> Insight:
+        """Validate evidence source references exist."""
+        source_ids = {s.id for s in self.sources}
 
         for ev in self.evidence:
-            # Analysis-specific evidence types
-            analysis_types = (MetricEvidence, OutputEvidence)
-
-            if is_paper and isinstance(ev, analysis_types):
+            if ev.source_ref not in source_ids:
                 raise ValueError(
-                    f"Evidence type '{type(ev).__name__}' is not valid for paper sources. "
-                    "Use figure, quote, table, equation, or result evidence."
+                    f"Evidence '{ev.id}' references unknown source '{ev.source_ref}'. "
+                    f"Available: {source_ids}"
                 )
 
         return self
 
 
-class InsightCollection(BaseModel):
-    """A collection of scientific insights.
+# =============================================================================
+# Collection
+# =============================================================================
 
-    Can be used as a standalone file or embedded in an analysis.
-    """
+
+class InsightCollection(BaseModel):
+    """Collection of insights, usable standalone or embedded in an analysis."""
 
     model_config = ConfigDict(
         extra="forbid",
+        populate_by_name=True,
         json_schema_extra={
-            "$schema": "http://json-schema.org/draft-07/schema#",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://asp-spec.org/v1/insights.schema.json",
             "title": "ASP Insights Collection",
         },
     )
 
-    schema_: str | None = Field(default=None, alias="$schema", description="JSON Schema reference")
-    insights: dict[str, Insight] = Field(
-        default_factory=dict,
-        description="Map of insight IDs to insight specifications",
-    )
+    schema_: str | None = Field(default=None, alias="$schema")
+    insights: dict[str, Insight] = Field(default_factory=dict)
 
     @classmethod
     def from_yaml(cls, path: str | Path) -> InsightCollection:
-        """Load insights from a YAML file."""
+        """Load from YAML file."""
         with open(path) as f:
-            data = yaml.safe_load(f)
-        return cls.model_validate(data)
+            return cls.model_validate(yaml.safe_load(f))
 
     def to_yaml(self, path: str | Path) -> None:
-        """Save insights to a YAML file."""
-        data = self.model_dump(by_alias=True, exclude_none=True)
+        """Save to YAML file."""
         with open(path, "w") as f:
-            yaml.safe_dump(data, f, sort_keys=False, allow_unicode=True)
+            yaml.safe_dump(
+                self.model_dump(by_alias=True, exclude_none=True, mode="json"),
+                f,
+                sort_keys=False,
+                allow_unicode=True,
+            )
 
     def get_insight(self, insight_id: str) -> Insight | None:
-        """Get an insight by ID."""
+        """Get insight by ID."""
         return self.insights.get(insight_id)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,10 @@ workflow = [
     "snakemake>=8.0",
     "graphviz",  # Python bindings; also requires system graphviz (brew install graphviz / apt install graphviz)
 ]
+verify = [
+    "pdftext>=0.6",
+    "httpx>=0.27",
+]
 
 [project.scripts]
 asp = "asp.cli:main"

--- a/spec/draft/analysis.schema.json
+++ b/spec/draft/analysis.schema.json
@@ -85,29 +85,63 @@
       "title": "AnalysisContent",
       "type": "object"
     },
-    "AnalysisSource": {
+    "ArxivSource": {
       "additionalProperties": false,
-      "description": "Source reference to a previous ASP analysis.",
+      "description": "Versioned arXiv paper source for reproducible references.\n\nThe version is mandatory to ensure reproducibility - arXiv papers\ncan be updated, and we need to reference a specific snapshot.",
       "properties": {
-        "analysis": {
-          "description": "Reference to the analysis (e.g., 'org/analysis-name')",
-          "title": "Analysis",
+        "id": {
+          "description": "Local ID for evidence references",
+          "minLength": 1,
+          "title": "Id",
+          "type": "string"
+        },
+        "type": {
+          "const": "arxiv",
+          "default": "arxiv",
+          "title": "Type",
+          "type": "string"
+        },
+        "arxiv_id": {
+          "description": "arXiv ID without version (e.g., '1706.03762')",
+          "pattern": "^\\d{4}\\.\\d{4,5}$|^[a-z-]+/\\d{7}$",
+          "title": "Arxiv Id",
           "type": "string"
         },
         "version": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Version of the analysis",
-          "title": "Version"
+          "description": "arXiv version number",
+          "minimum": 1,
+          "title": "Version",
+          "type": "integer"
         },
-        "universe": {
+        "content_sha256": {
+          "anyOf": [
+            {
+              "pattern": "^[a-fA-F0-9]{64}$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "SHA-256 of PDF bytes for verification",
+          "title": "Content Sha256"
+        },
+        "retrieved_at": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "When PDF was fetched",
+          "title": "Retrieved At"
+        },
+        "title": {
           "anyOf": [
             {
               "type": "string"
@@ -117,14 +151,30 @@
             }
           ],
           "default": null,
-          "description": "Specific universe used",
-          "title": "Universe"
+          "title": "Title"
+        },
+        "authors": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Authors"
         }
       },
       "required": [
-        "analysis"
+        "id",
+        "arxiv_id",
+        "version"
       ],
-      "title": "AnalysisSource",
+      "title": "ArxivSource",
       "type": "object"
     },
     "Checksum": {
@@ -224,16 +274,29 @@
       "title": "Decision",
       "type": "object"
     },
-    "EquationEvidence": {
+    "DoiSource": {
       "additionalProperties": false,
-      "description": "Evidence from an equation.",
+      "description": "DOI-based paper source for non-arXiv publications.",
       "properties": {
-        "equation": {
-          "description": "Equation reference (e.g., 'Equation 7')",
-          "title": "Equation",
+        "id": {
+          "description": "Local ID for evidence references",
+          "minLength": 1,
+          "title": "Id",
           "type": "string"
         },
-        "expression": {
+        "type": {
+          "const": "doi",
+          "default": "doi",
+          "title": "Type",
+          "type": "string"
+        },
+        "doi": {
+          "description": "DOI (e.g., '10.1038/s41586-023-06221-2')",
+          "pattern": "^10\\.\\d{4,}/.*$",
+          "title": "Doi",
+          "type": "string"
+        },
+        "title": {
           "anyOf": [
             {
               "type": "string"
@@ -243,70 +306,45 @@
             }
           ],
           "default": null,
-          "description": "The mathematical expression",
-          "title": "Expression"
+          "title": "Title"
+        },
+        "authors": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Authors"
         }
       },
       "required": [
-        "equation"
+        "id",
+        "doi"
       ],
-      "title": "EquationEvidence",
+      "title": "DoiSource",
       "type": "object"
     },
-    "Evidence": {
+    "FigureSelector": {
       "additionalProperties": false,
-      "description": "Evidence supporting a decision option.\n\nCan reference either:\n- An insight by ID (preferred): `insight: insight_id`\n- A legacy input reference: `ref: inputs.study_name` with `finding`",
+      "description": "Selector for referencing figures in scientific papers.\n\nExtension of W3C selector pattern for scientific literature.\nThe label is the authoritative identifier (e.g., \"Figure 3a\").",
       "properties": {
-        "insight": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Reference to an insight by ID (e.g., 'compute_scaling')",
-          "title": "Insight"
+        "type": {
+          "const": "FigureSelector",
+          "default": "FigureSelector",
+          "title": "Type",
+          "type": "string"
         },
-        "ref": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Reference to an input (e.g., 'inputs.study_name') - deprecated, use insight",
-          "title": "Ref"
-        },
-        "finding": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "What the evidence shows - required when using ref",
-          "title": "Finding"
-        }
-      },
-      "title": "Evidence",
-      "type": "object"
-    },
-    "FigureEvidence": {
-      "additionalProperties": false,
-      "description": "Evidence from a figure.",
-      "properties": {
-        "figure": {
-          "description": "Figure reference (e.g., 'Figure 3a')",
-          "title": "Figure",
+        "label": {
+          "description": "Figure label (e.g., 'Figure 3a', 'Fig. 1')",
+          "minLength": 1,
+          "title": "Label",
           "type": "string"
         },
         "caption": {
@@ -319,14 +357,61 @@
             }
           ],
           "default": null,
-          "description": "Figure caption or description",
+          "description": "Caption text for verification",
           "title": "Caption"
         }
       },
       "required": [
-        "figure"
+        "label"
       ],
-      "title": "FigureEvidence",
+      "title": "FigureSelector",
+      "type": "object"
+    },
+    "FragmentSelector": {
+      "additionalProperties": false,
+      "description": "W3C FragmentSelector for PDF locations.\n\nSee: https://www.w3.org/TR/annotation-model/#fragment-selector\nConforms to RFC 3778/8118 for PDF fragments.",
+      "properties": {
+        "type": {
+          "const": "FragmentSelector",
+          "default": "FragmentSelector",
+          "title": "Type",
+          "type": "string"
+        },
+        "conformsTo": {
+          "const": "http://tools.ietf.org/rfc/rfc3778",
+          "default": "http://tools.ietf.org/rfc/rfc3778",
+          "title": "Conformsto",
+          "type": "string"
+        },
+        "value": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Fragment (e.g., 'page=6')",
+          "title": "Value"
+        },
+        "page": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "1-indexed page number",
+          "title": "Page"
+        }
+      },
+      "title": "FragmentSelector",
       "type": "object"
     },
     "Input": {
@@ -430,54 +515,78 @@
     },
     "Insight": {
       "additionalProperties": false,
-      "description": "A scientific insight with provenance and supporting evidence.\n\nAn insight is a discrete unit of scientific knowledge that can come from\neither literature (papers) or computation (previous analyses).",
+      "description": "A scientific insight with provenance and supporting evidence.\n\nRepresents a discrete unit of scientific knowledge extracted from\nliterature, with full traceability to source material via W3C-compliant\ntext selectors.",
       "properties": {
+        "id": {
+          "description": "Unique identifier",
+          "minLength": 1,
+          "title": "Id",
+          "type": "string"
+        },
         "claim": {
-          "description": "The insight content - what we learned (1-2 sentences)",
+          "description": "What we learned (1-2 sentences)",
+          "minLength": 1,
           "title": "Claim",
           "type": "string"
         },
-        "source": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/PaperSource"
-            },
-            {
-              "$ref": "#/$defs/AnalysisSource"
-            }
-          ],
-          "description": "Where this insight comes from (paper DOI or analysis reference)",
-          "title": "Source"
+        "created_at": {
+          "description": "Creation timestamp (ISO 8601)",
+          "format": "date-time",
+          "title": "Created At",
+          "type": "string"
         },
-        "evidence": {
-          "description": "Supporting evidence for this insight (figures, quotes, tables, etc.)",
+        "sources": {
+          "description": "Source paper(s)",
           "items": {
-            "anyOf": [
+            "discriminator": {
+              "mapping": {
+                "arxiv": "#/$defs/ArxivSource",
+                "doi": "#/$defs/DoiSource"
+              },
+              "propertyName": "type"
+            },
+            "oneOf": [
               {
-                "$ref": "#/$defs/FigureEvidence"
+                "$ref": "#/$defs/ArxivSource"
               },
               {
-                "$ref": "#/$defs/QuoteEvidence"
-              },
-              {
-                "$ref": "#/$defs/TableEvidence"
-              },
-              {
-                "$ref": "#/$defs/EquationEvidence"
-              },
-              {
-                "$ref": "#/$defs/ResultEvidence"
-              },
-              {
-                "$ref": "#/$defs/MetricEvidence"
-              },
-              {
-                "$ref": "#/$defs/OutputEvidence"
+                "$ref": "#/$defs/DoiSource"
               }
             ]
           },
+          "minItems": 1,
+          "title": "Sources",
+          "type": "array"
+        },
+        "evidence": {
+          "description": "Supporting evidence",
+          "items": {
+            "$ref": "#/$defs/models__insight__Evidence"
+          },
+          "minItems": 1,
           "title": "Evidence",
           "type": "array"
+        },
+        "confidence": {
+          "anyOf": [
+            {
+              "maximum": 1.0,
+              "minimum": 0.0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Confidence [0,1]",
+          "title": "Confidence"
+        },
+        "derived": {
+          "default": false,
+          "description": "True if synthesized/inferred",
+          "title": "Derived",
+          "type": "boolean"
         },
         "scope": {
           "anyOf": [
@@ -489,36 +598,39 @@
             }
           ],
           "default": null,
-          "description": "Context or conditions where this insight applies",
+          "description": "Applicability conditions",
           "title": "Scope"
+        },
+        "tags": {
+          "description": "Categorization tags",
+          "items": {
+            "type": "string"
+          },
+          "title": "Tags",
+          "type": "array"
+        },
+        "notes": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Reasoning notes",
+          "title": "Notes"
         }
       },
       "required": [
+        "id",
         "claim",
-        "source"
+        "created_at",
+        "sources",
+        "evidence"
       ],
       "title": "Insight",
-      "type": "object"
-    },
-    "MetricEvidence": {
-      "additionalProperties": false,
-      "description": "Evidence from an analysis metric output.",
-      "properties": {
-        "metric": {
-          "description": "Name of the metric",
-          "title": "Metric",
-          "type": "string"
-        },
-        "value": {
-          "description": "The metric value(s)",
-          "title": "Value"
-        }
-      },
-      "required": [
-        "metric",
-        "value"
-      ],
-      "title": "MetricEvidence",
       "type": "object"
     },
     "Option": {
@@ -558,7 +670,7 @@
           "anyOf": [
             {
               "items": {
-                "$ref": "#/$defs/Evidence"
+                "$ref": "#/$defs/models__analysis__Evidence"
               },
               "type": "array"
             },
@@ -715,108 +827,6 @@
         "type"
       ],
       "title": "Output",
-      "type": "object"
-    },
-    "OutputEvidence": {
-      "additionalProperties": false,
-      "description": "Evidence from an analysis output artifact.",
-      "properties": {
-        "output": {
-          "description": "Output ID or path",
-          "title": "Output",
-          "type": "string"
-        }
-      },
-      "required": [
-        "output"
-      ],
-      "title": "OutputEvidence",
-      "type": "object"
-    },
-    "PaperSource": {
-      "additionalProperties": false,
-      "description": "Source reference to a scientific paper.",
-      "properties": {
-        "doi": {
-          "description": "DOI of the paper (e.g., '10.1038/s41586-023-06221-2')",
-          "pattern": "^10\\.\\d{4,}/.*$",
-          "title": "Doi",
-          "type": "string"
-        }
-      },
-      "required": [
-        "doi"
-      ],
-      "title": "PaperSource",
-      "type": "object"
-    },
-    "QuoteEvidence": {
-      "additionalProperties": false,
-      "description": "Evidence from a direct quote.",
-      "properties": {
-        "quote": {
-          "description": "The exact quoted text",
-          "title": "Quote",
-          "type": "string"
-        },
-        "location": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Location in source (e.g., 'Section 2.1, p.3')",
-          "title": "Location"
-        }
-      },
-      "required": [
-        "quote"
-      ],
-      "title": "QuoteEvidence",
-      "type": "object"
-    },
-    "ResultEvidence": {
-      "additionalProperties": false,
-      "description": "Evidence from a numerical result.",
-      "properties": {
-        "result": {
-          "description": "Description of the result",
-          "title": "Result",
-          "type": "string"
-        },
-        "location": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Where in the source",
-          "title": "Location"
-        },
-        "value": {
-          "anyOf": [
-            {},
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The numerical value",
-          "title": "Value"
-        }
-      },
-      "required": [
-        "result"
-      ],
-      "title": "ResultEvidence",
       "type": "object"
     },
     "Source": {
@@ -997,46 +1007,221 @@
       "title": "Source",
       "type": "object"
     },
-    "TableEvidence": {
+    "TableSelector": {
       "additionalProperties": false,
-      "description": "Evidence from a table.",
+      "description": "Selector for referencing tables in scientific papers.\n\nExtension of W3C selector pattern for scientific literature.\nThe label is the authoritative identifier (e.g., \"Table 2\").",
       "properties": {
-        "table": {
-          "description": "Table reference (e.g., 'Table 1')",
-          "title": "Table",
+        "type": {
+          "const": "TableSelector",
+          "default": "TableSelector",
+          "title": "Type",
           "type": "string"
+        },
+        "label": {
+          "description": "Table label (e.g., 'Table 1', 'Tab. 2')",
+          "minLength": 1,
+          "title": "Label",
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Caption/header text for verification",
+          "title": "Caption"
+        },
+        "region": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Specific region (e.g., 'row 3')",
+          "title": "Region"
+        }
+      },
+      "required": [
+        "label"
+      ],
+      "title": "TableSelector",
+      "type": "object"
+    },
+    "TextQuoteSelector": {
+      "additionalProperties": false,
+      "description": "W3C TextQuoteSelector for locating text in a document.\n\nSee: https://www.w3.org/TR/annotation-model/#text-quote-selector\n\nThe authoritative anchor for verification. Text should be normalized\n(HTML/XML tags removed, entities decoded).",
+      "properties": {
+        "type": {
+          "const": "TextQuoteSelector",
+          "default": "TextQuoteSelector",
+          "title": "Type",
+          "type": "string"
+        },
+        "exact": {
+          "description": "Exact quoted text (1-3 sentences)",
+          "minLength": 1,
+          "title": "Exact",
+          "type": "string"
+        },
+        "prefix": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "~20-100 chars before for disambiguation",
+          "title": "Prefix"
+        },
+        "suffix": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "~20-100 chars after for disambiguation",
+          "title": "Suffix"
+        }
+      },
+      "required": [
+        "exact"
+      ],
+      "title": "TextQuoteSelector",
+      "type": "object"
+    },
+    "models__analysis__Evidence": {
+      "additionalProperties": false,
+      "description": "Evidence supporting a decision option.\n\nCan reference either:\n- An insight by ID (preferred): `insight: insight_id`\n- A legacy input reference: `ref: inputs.study_name` with `finding`",
+      "properties": {
+        "insight": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Reference to an insight by ID (e.g., 'compute_scaling')",
+          "title": "Insight"
+        },
+        "ref": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Reference to an input (e.g., 'inputs.study_name') - deprecated, use insight",
+          "title": "Ref"
+        },
+        "finding": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "What the evidence shows - required when using ref",
+          "title": "Finding"
+        }
+      },
+      "title": "Evidence",
+      "type": "object"
+    },
+    "models__insight__Evidence": {
+      "additionalProperties": false,
+      "description": "Evidence from scientific literature with W3C-compliant selectors.\n\nAt least one content selector (quote, figure, or table) is required.\nThe FragmentSelector provides optional PDF location hints.",
+      "properties": {
+        "id": {
+          "description": "Evidence ID",
+          "minLength": 1,
+          "title": "Id",
+          "type": "string"
+        },
+        "source_ref": {
+          "description": "References source.id",
+          "minLength": 1,
+          "title": "Source Ref",
+          "type": "string"
+        },
+        "quote": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TextQuoteSelector"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Text quote anchor"
+        },
+        "figure": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FigureSelector"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Figure reference"
+        },
+        "table": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TableSelector"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Table reference"
         },
         "location": {
           "anyOf": [
             {
-              "type": "string"
+              "$ref": "#/$defs/FragmentSelector"
             },
             {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Specific row/column if applicable",
-          "title": "Location"
-        },
-        "value": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The specific value referenced",
-          "title": "Value"
+          "description": "PDF location hint"
         }
       },
       "required": [
-        "table"
+        "id",
+        "source_ref"
       ],
-      "title": "TableEvidence",
+      "title": "Evidence",
       "type": "object"
     }
   },

--- a/spec/draft/insights.schema.json
+++ b/spec/draft/insights.schema.json
@@ -1,28 +1,62 @@
 {
   "$defs": {
-    "AnalysisSource": {
+    "ArxivSource": {
       "additionalProperties": false,
-      "description": "Source reference to a previous ASP analysis.",
+      "description": "Versioned arXiv paper source for reproducible references.\n\nThe version is mandatory to ensure reproducibility - arXiv papers\ncan be updated, and we need to reference a specific snapshot.",
       "properties": {
-        "analysis": {
-          "description": "Reference to the analysis (e.g., 'org/analysis-name')",
-          "title": "Analysis",
+        "id": {
+          "description": "Local ID for evidence references",
+          "minLength": 1,
+          "title": "Id",
+          "type": "string"
+        },
+        "type": {
+          "const": "arxiv",
+          "default": "arxiv",
+          "title": "Type",
+          "type": "string"
+        },
+        "arxiv_id": {
+          "description": "arXiv ID without version (e.g., '1706.03762')",
+          "pattern": "^\\d{4}\\.\\d{4,5}$|^[a-z-]+/\\d{7}$",
+          "title": "Arxiv Id",
           "type": "string"
         },
         "version": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Version of the analysis",
-          "title": "Version"
+          "description": "arXiv version number",
+          "minimum": 1,
+          "title": "Version",
+          "type": "integer"
         },
-        "universe": {
+        "content_sha256": {
+          "anyOf": [
+            {
+              "pattern": "^[a-fA-F0-9]{64}$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "SHA-256 of PDF bytes for verification",
+          "title": "Content Sha256"
+        },
+        "retrieved_at": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "When PDF was fetched",
+          "title": "Retrieved At"
+        },
+        "title": {
           "anyOf": [
             {
               "type": "string"
@@ -32,26 +66,55 @@
             }
           ],
           "default": null,
-          "description": "Specific universe used",
-          "title": "Universe"
+          "title": "Title"
+        },
+        "authors": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Authors"
         }
       },
       "required": [
-        "analysis"
+        "id",
+        "arxiv_id",
+        "version"
       ],
-      "title": "AnalysisSource",
+      "title": "ArxivSource",
       "type": "object"
     },
-    "EquationEvidence": {
+    "DoiSource": {
       "additionalProperties": false,
-      "description": "Evidence from an equation.",
+      "description": "DOI-based paper source for non-arXiv publications.",
       "properties": {
-        "equation": {
-          "description": "Equation reference (e.g., 'Equation 7')",
-          "title": "Equation",
+        "id": {
+          "description": "Local ID for evidence references",
+          "minLength": 1,
+          "title": "Id",
           "type": "string"
         },
-        "expression": {
+        "type": {
+          "const": "doi",
+          "default": "doi",
+          "title": "Type",
+          "type": "string"
+        },
+        "doi": {
+          "description": "DOI (e.g., '10.1038/s41586-023-06221-2')",
+          "pattern": "^10\\.\\d{4,}/.*$",
+          "title": "Doi",
+          "type": "string"
+        },
+        "title": {
           "anyOf": [
             {
               "type": "string"
@@ -61,23 +124,117 @@
             }
           ],
           "default": null,
-          "description": "The mathematical expression",
-          "title": "Expression"
+          "title": "Title"
+        },
+        "authors": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Authors"
         }
       },
       "required": [
-        "equation"
+        "id",
+        "doi"
       ],
-      "title": "EquationEvidence",
+      "title": "DoiSource",
       "type": "object"
     },
-    "FigureEvidence": {
+    "Evidence": {
       "additionalProperties": false,
-      "description": "Evidence from a figure.",
+      "description": "Evidence from scientific literature with W3C-compliant selectors.\n\nAt least one content selector (quote, figure, or table) is required.\nThe FragmentSelector provides optional PDF location hints.",
       "properties": {
+        "id": {
+          "description": "Evidence ID",
+          "minLength": 1,
+          "title": "Id",
+          "type": "string"
+        },
+        "source_ref": {
+          "description": "References source.id",
+          "minLength": 1,
+          "title": "Source Ref",
+          "type": "string"
+        },
+        "quote": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TextQuoteSelector"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Text quote anchor"
+        },
         "figure": {
-          "description": "Figure reference (e.g., 'Figure 3a')",
-          "title": "Figure",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FigureSelector"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Figure reference"
+        },
+        "table": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TableSelector"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Table reference"
+        },
+        "location": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FragmentSelector"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "PDF location hint"
+        }
+      },
+      "required": [
+        "id",
+        "source_ref"
+      ],
+      "title": "Evidence",
+      "type": "object"
+    },
+    "FigureSelector": {
+      "additionalProperties": false,
+      "description": "Selector for referencing figures in scientific papers.\n\nExtension of W3C selector pattern for scientific literature.\nThe label is the authoritative identifier (e.g., \"Figure 3a\").",
+      "properties": {
+        "type": {
+          "const": "FigureSelector",
+          "default": "FigureSelector",
+          "title": "Type",
+          "type": "string"
+        },
+        "label": {
+          "description": "Figure label (e.g., 'Figure 3a', 'Fig. 1')",
+          "minLength": 1,
+          "title": "Label",
           "type": "string"
         },
         "caption": {
@@ -90,66 +247,137 @@
             }
           ],
           "default": null,
-          "description": "Figure caption or description",
+          "description": "Caption text for verification",
           "title": "Caption"
         }
       },
       "required": [
-        "figure"
+        "label"
       ],
-      "title": "FigureEvidence",
+      "title": "FigureSelector",
+      "type": "object"
+    },
+    "FragmentSelector": {
+      "additionalProperties": false,
+      "description": "W3C FragmentSelector for PDF locations.\n\nSee: https://www.w3.org/TR/annotation-model/#fragment-selector\nConforms to RFC 3778/8118 for PDF fragments.",
+      "properties": {
+        "type": {
+          "const": "FragmentSelector",
+          "default": "FragmentSelector",
+          "title": "Type",
+          "type": "string"
+        },
+        "conformsTo": {
+          "const": "http://tools.ietf.org/rfc/rfc3778",
+          "default": "http://tools.ietf.org/rfc/rfc3778",
+          "title": "Conformsto",
+          "type": "string"
+        },
+        "value": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Fragment (e.g., 'page=6')",
+          "title": "Value"
+        },
+        "page": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "1-indexed page number",
+          "title": "Page"
+        }
+      },
+      "title": "FragmentSelector",
       "type": "object"
     },
     "Insight": {
       "additionalProperties": false,
-      "description": "A scientific insight with provenance and supporting evidence.\n\nAn insight is a discrete unit of scientific knowledge that can come from\neither literature (papers) or computation (previous analyses).",
+      "description": "A scientific insight with provenance and supporting evidence.\n\nRepresents a discrete unit of scientific knowledge extracted from\nliterature, with full traceability to source material via W3C-compliant\ntext selectors.",
       "properties": {
+        "id": {
+          "description": "Unique identifier",
+          "minLength": 1,
+          "title": "Id",
+          "type": "string"
+        },
         "claim": {
-          "description": "The insight content - what we learned (1-2 sentences)",
+          "description": "What we learned (1-2 sentences)",
+          "minLength": 1,
           "title": "Claim",
           "type": "string"
         },
-        "source": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/PaperSource"
-            },
-            {
-              "$ref": "#/$defs/AnalysisSource"
-            }
-          ],
-          "description": "Where this insight comes from (paper DOI or analysis reference)",
-          "title": "Source"
+        "created_at": {
+          "description": "Creation timestamp (ISO 8601)",
+          "format": "date-time",
+          "title": "Created At",
+          "type": "string"
         },
-        "evidence": {
-          "description": "Supporting evidence for this insight (figures, quotes, tables, etc.)",
+        "sources": {
+          "description": "Source paper(s)",
           "items": {
-            "anyOf": [
+            "discriminator": {
+              "mapping": {
+                "arxiv": "#/$defs/ArxivSource",
+                "doi": "#/$defs/DoiSource"
+              },
+              "propertyName": "type"
+            },
+            "oneOf": [
               {
-                "$ref": "#/$defs/FigureEvidence"
+                "$ref": "#/$defs/ArxivSource"
               },
               {
-                "$ref": "#/$defs/QuoteEvidence"
-              },
-              {
-                "$ref": "#/$defs/TableEvidence"
-              },
-              {
-                "$ref": "#/$defs/EquationEvidence"
-              },
-              {
-                "$ref": "#/$defs/ResultEvidence"
-              },
-              {
-                "$ref": "#/$defs/MetricEvidence"
-              },
-              {
-                "$ref": "#/$defs/OutputEvidence"
+                "$ref": "#/$defs/DoiSource"
               }
             ]
           },
+          "minItems": 1,
+          "title": "Sources",
+          "type": "array"
+        },
+        "evidence": {
+          "description": "Supporting evidence",
+          "items": {
+            "$ref": "#/$defs/Evidence"
+          },
+          "minItems": 1,
           "title": "Evidence",
           "type": "array"
+        },
+        "confidence": {
+          "anyOf": [
+            {
+              "maximum": 1.0,
+              "minimum": 0.0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Confidence [0,1]",
+          "title": "Confidence"
+        },
+        "derived": {
+          "default": false,
+          "description": "True if synthesized/inferred",
+          "title": "Derived",
+          "type": "boolean"
         },
         "scope": {
           "anyOf": [
@@ -161,81 +389,58 @@
             }
           ],
           "default": null,
-          "description": "Context or conditions where this insight applies",
+          "description": "Applicability conditions",
           "title": "Scope"
+        },
+        "tags": {
+          "description": "Categorization tags",
+          "items": {
+            "type": "string"
+          },
+          "title": "Tags",
+          "type": "array"
+        },
+        "notes": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Reasoning notes",
+          "title": "Notes"
         }
       },
       "required": [
+        "id",
         "claim",
-        "source"
+        "created_at",
+        "sources",
+        "evidence"
       ],
       "title": "Insight",
       "type": "object"
     },
-    "MetricEvidence": {
+    "TableSelector": {
       "additionalProperties": false,
-      "description": "Evidence from an analysis metric output.",
+      "description": "Selector for referencing tables in scientific papers.\n\nExtension of W3C selector pattern for scientific literature.\nThe label is the authoritative identifier (e.g., \"Table 2\").",
       "properties": {
-        "metric": {
-          "description": "Name of the metric",
-          "title": "Metric",
+        "type": {
+          "const": "TableSelector",
+          "default": "TableSelector",
+          "title": "Type",
           "type": "string"
         },
-        "value": {
-          "description": "The metric value(s)",
-          "title": "Value"
-        }
-      },
-      "required": [
-        "metric",
-        "value"
-      ],
-      "title": "MetricEvidence",
-      "type": "object"
-    },
-    "OutputEvidence": {
-      "additionalProperties": false,
-      "description": "Evidence from an analysis output artifact.",
-      "properties": {
-        "output": {
-          "description": "Output ID or path",
-          "title": "Output",
-          "type": "string"
-        }
-      },
-      "required": [
-        "output"
-      ],
-      "title": "OutputEvidence",
-      "type": "object"
-    },
-    "PaperSource": {
-      "additionalProperties": false,
-      "description": "Source reference to a scientific paper.",
-      "properties": {
-        "doi": {
-          "description": "DOI of the paper (e.g., '10.1038/s41586-023-06221-2')",
-          "pattern": "^10\\.\\d{4,}/.*$",
-          "title": "Doi",
-          "type": "string"
-        }
-      },
-      "required": [
-        "doi"
-      ],
-      "title": "PaperSource",
-      "type": "object"
-    },
-    "QuoteEvidence": {
-      "additionalProperties": false,
-      "description": "Evidence from a direct quote.",
-      "properties": {
-        "quote": {
-          "description": "The exact quoted text",
-          "title": "Quote",
+        "label": {
+          "description": "Table label (e.g., 'Table 1', 'Tab. 2')",
+          "minLength": 1,
+          "title": "Label",
           "type": "string"
         },
-        "location": {
+        "caption": {
           "anyOf": [
             {
               "type": "string"
@@ -245,26 +450,46 @@
             }
           ],
           "default": null,
-          "description": "Location in source (e.g., 'Section 2.1, p.3')",
-          "title": "Location"
+          "description": "Caption/header text for verification",
+          "title": "Caption"
+        },
+        "region": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Specific region (e.g., 'row 3')",
+          "title": "Region"
         }
       },
       "required": [
-        "quote"
+        "label"
       ],
-      "title": "QuoteEvidence",
+      "title": "TableSelector",
       "type": "object"
     },
-    "ResultEvidence": {
+    "TextQuoteSelector": {
       "additionalProperties": false,
-      "description": "Evidence from a numerical result.",
+      "description": "W3C TextQuoteSelector for locating text in a document.\n\nSee: https://www.w3.org/TR/annotation-model/#text-quote-selector\n\nThe authoritative anchor for verification. Text should be normalized\n(HTML/XML tags removed, entities decoded).",
       "properties": {
-        "result": {
-          "description": "Description of the result",
-          "title": "Result",
+        "type": {
+          "const": "TextQuoteSelector",
+          "default": "TextQuoteSelector",
+          "title": "Type",
           "type": "string"
         },
-        "location": {
+        "exact": {
+          "description": "Exact quoted text (1-3 sentences)",
+          "minLength": 1,
+          "title": "Exact",
+          "type": "string"
+        },
+        "prefix": {
           "anyOf": [
             {
               "type": "string"
@@ -274,74 +499,34 @@
             }
           ],
           "default": null,
-          "description": "Where in the source",
-          "title": "Location"
+          "description": "~20-100 chars before for disambiguation",
+          "title": "Prefix"
         },
-        "value": {
+        "suffix": {
           "anyOf": [
-            {},
+            {
+              "type": "string"
+            },
             {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "The numerical value",
-          "title": "Value"
+          "description": "~20-100 chars after for disambiguation",
+          "title": "Suffix"
         }
       },
       "required": [
-        "result"
+        "exact"
       ],
-      "title": "ResultEvidence",
-      "type": "object"
-    },
-    "TableEvidence": {
-      "additionalProperties": false,
-      "description": "Evidence from a table.",
-      "properties": {
-        "table": {
-          "description": "Table reference (e.g., 'Table 1')",
-          "title": "Table",
-          "type": "string"
-        },
-        "location": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Specific row/column if applicable",
-          "title": "Location"
-        },
-        "value": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The specific value referenced",
-          "title": "Value"
-        }
-      },
-      "required": [
-        "table"
-      ],
-      "title": "TableEvidence",
+      "title": "TextQuoteSelector",
       "type": "object"
     }
   },
   "$id": "https://asp-spec.org/v1/insights.schema.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
-  "description": "A collection of scientific insights.\n\nCan be used as a standalone file or embedded in an analysis.",
+  "description": "Collection of insights, usable standalone or embedded in an analysis.",
   "properties": {
     "$schema": {
       "anyOf": [
@@ -353,14 +538,12 @@
         }
       ],
       "default": null,
-      "description": "JSON Schema reference",
       "title": "$Schema"
     },
     "insights": {
       "additionalProperties": {
         "$ref": "#/$defs/Insight"
       },
-      "description": "Map of insight IDs to insight specifications",
       "title": "Insights",
       "type": "object"
     }

--- a/src/asp/verification/__init__.py
+++ b/src/asp/verification/__init__.py
@@ -1,0 +1,33 @@
+"""Evidence verification for ASP insights.
+
+Provides functionality to verify that evidence (quotes, figures, tables)
+actually exists in the referenced source documents.
+
+Requires optional dependencies: pip install asp[verify]
+"""
+
+from asp.verification.core import (
+    EvidenceVerification,
+    InsightVerification,
+    VerificationStatus,
+    verify_evidence,
+    verify_insight,
+)
+from asp.verification.pdf import (
+    PDFDocument,
+    extract_text_from_pdf,
+    get_arxiv_pdf,
+)
+
+__all__ = [
+    # Verification
+    "EvidenceVerification",
+    "InsightVerification",
+    "VerificationStatus",
+    "verify_evidence",
+    "verify_insight",
+    # PDF utilities
+    "PDFDocument",
+    "extract_text_from_pdf",
+    "get_arxiv_pdf",
+]

--- a/src/asp/verification/core.py
+++ b/src/asp/verification/core.py
@@ -75,9 +75,7 @@ class InsightVerification:
     @property
     def verified_count(self) -> int:
         """Count of verified evidence items."""
-        return sum(
-            1 for ev in self.evidence_results if ev.status == VerificationStatus.VERIFIED
-        )
+        return sum(1 for ev in self.evidence_results if ev.status == VerificationStatus.VERIFIED)
 
     @property
     def failed_count(self) -> int:
@@ -131,9 +129,7 @@ def verify_evidence(
             result.quote_status = VerificationStatus.WRONG_PAGE
             result.quote_found_pages = found_pages
             result.status = VerificationStatus.WRONG_PAGE
-            result.message = (
-                f"Quote found on page(s) {found_pages}, expected page {hint_page}"
-            )
+            result.message = f"Quote found on page(s) {found_pages}, expected page {hint_page}"
         else:
             result.quote_status = VerificationStatus.VERIFIED
             result.quote_found_pages = found_pages

--- a/src/asp/verification/core.py
+++ b/src/asp/verification/core.py
@@ -1,0 +1,251 @@
+"""Core verification logic for ASP insights.
+
+Verifies that evidence (quotes, figures, tables) exists in source documents.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+from asp.verification.pdf import PDFDocument, extract_text_from_pdf, get_arxiv_pdf
+
+
+class VerificationStatus(str, Enum):
+    """Status of a verification check."""
+
+    VERIFIED = "verified"  # Evidence found in source
+    NOT_FOUND = "not_found"  # Evidence not found in source
+    WRONG_PAGE = "wrong_page"  # Found but on different page
+    SKIPPED = "skipped"  # Could not verify (e.g., DOI source, figure/table)
+    ERROR = "error"  # Error during verification
+
+
+@dataclass
+class EvidenceVerification:
+    """Result of verifying a single piece of evidence.
+
+    Attributes:
+        evidence_id: ID of the evidence being verified.
+        status: Overall verification status.
+        quote_status: Status of quote verification (if quote present).
+        quote_found_pages: Pages where quote was found (1-indexed).
+        expected_page: Expected page from location hint.
+        message: Human-readable description of result.
+    """
+
+    evidence_id: str
+    status: VerificationStatus
+    quote_status: VerificationStatus | None = None
+    quote_found_pages: list[int] = field(default_factory=list)
+    expected_page: int | None = None
+    message: str = ""
+
+    @property
+    def is_valid(self) -> bool:
+        """Check if evidence is verified or skipped (not an error)."""
+        return self.status in (VerificationStatus.VERIFIED, VerificationStatus.SKIPPED)
+
+
+@dataclass
+class InsightVerification:
+    """Result of verifying all evidence for an insight.
+
+    Attributes:
+        insight_id: ID of the insight being verified.
+        source_id: ID of the source document.
+        pdf_sha256: SHA-256 of the PDF used for verification.
+        evidence_results: Verification results for each piece of evidence.
+        overall_status: Overall verification status.
+    """
+
+    insight_id: str
+    source_id: str
+    pdf_sha256: str = ""
+    evidence_results: list[EvidenceVerification] = field(default_factory=list)
+    overall_status: VerificationStatus = VerificationStatus.VERIFIED
+
+    @property
+    def is_valid(self) -> bool:
+        """Check if all evidence is valid."""
+        return all(ev.is_valid for ev in self.evidence_results)
+
+    @property
+    def verified_count(self) -> int:
+        """Count of verified evidence items."""
+        return sum(
+            1 for ev in self.evidence_results if ev.status == VerificationStatus.VERIFIED
+        )
+
+    @property
+    def failed_count(self) -> int:
+        """Count of failed evidence items."""
+        return sum(1 for ev in self.evidence_results if not ev.is_valid)
+
+
+def _get_attr(obj: Any, key: str, default: Any = None) -> Any:
+    """Get attribute from dict or object."""
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+def verify_evidence(
+    evidence: Any,
+    pdf: PDFDocument,
+) -> EvidenceVerification:
+    """Verify a single piece of evidence against a PDF.
+
+    Args:
+        evidence: The evidence to verify (dict or Evidence object).
+        pdf: PDFDocument with extracted text.
+
+    Returns:
+        EvidenceVerification with results.
+    """
+    evidence_id = _get_attr(evidence, "id", "unknown")
+    location = _get_attr(evidence, "location")
+    expected_page = _get_attr(location, "page") if location else None
+
+    result = EvidenceVerification(
+        evidence_id=evidence_id,
+        status=VerificationStatus.VERIFIED,
+        expected_page=expected_page,
+    )
+
+    # Check quote if present
+    quote = _get_attr(evidence, "quote")
+    if quote:
+        quote_text = _get_attr(quote, "exact", "")
+        hint_page = expected_page
+
+        found_pages = pdf.find_quote(quote_text, page=hint_page)
+
+        if not found_pages:
+            result.quote_status = VerificationStatus.NOT_FOUND
+            result.status = VerificationStatus.NOT_FOUND
+            result.message = f"Quote not found in PDF: '{quote_text[:50]}...'"
+        elif hint_page and hint_page not in found_pages:
+            result.quote_status = VerificationStatus.WRONG_PAGE
+            result.quote_found_pages = found_pages
+            result.status = VerificationStatus.WRONG_PAGE
+            result.message = (
+                f"Quote found on page(s) {found_pages}, expected page {hint_page}"
+            )
+        else:
+            result.quote_status = VerificationStatus.VERIFIED
+            result.quote_found_pages = found_pages
+            result.message = f"Quote verified on page(s) {found_pages}"
+
+    # Figure/table verification - skip for now
+    elif _get_attr(evidence, "figure"):
+        figure = _get_attr(evidence, "figure")
+        label = _get_attr(figure, "label", "unknown")
+        result.status = VerificationStatus.SKIPPED
+        result.message = f"Figure verification not yet implemented: {label}"
+
+    elif _get_attr(evidence, "table"):
+        table = _get_attr(evidence, "table")
+        label = _get_attr(table, "label", "unknown")
+        result.status = VerificationStatus.SKIPPED
+        result.message = f"Table verification not yet implemented: {label}"
+
+    return result
+
+
+def verify_insight(
+    insight: Any,
+    cache_dir: Path | None = None,
+) -> InsightVerification:
+    """Verify all evidence for an insight.
+
+    Downloads the source PDF (if arXiv) and verifies each piece of evidence.
+
+    Args:
+        insight: The insight to verify (dict or Insight object).
+        cache_dir: Directory to cache PDFs.
+
+    Returns:
+        InsightVerification with results for all evidence.
+    """
+    insight_id = _get_attr(insight, "id", "unknown")
+    sources = _get_attr(insight, "sources", [])
+    evidence_list = _get_attr(insight, "evidence", [])
+
+    # Get the first arXiv source (we verify against primary source)
+    arxiv_sources = [s for s in sources if _get_attr(s, "type") == "arxiv"]
+
+    if not arxiv_sources:
+        first_source_id = _get_attr(sources[0], "id", "unknown") if sources else "unknown"
+        return InsightVerification(
+            insight_id=insight_id,
+            source_id=first_source_id,
+            overall_status=VerificationStatus.SKIPPED,
+            evidence_results=[
+                EvidenceVerification(
+                    evidence_id=_get_attr(ev, "id", "unknown"),
+                    status=VerificationStatus.SKIPPED,
+                    message="Only arXiv sources are currently supported for verification",
+                )
+                for ev in evidence_list
+            ],
+        )
+
+    source = arxiv_sources[0]
+    source_id = _get_attr(source, "id", "unknown")
+
+    try:
+        # Download and extract PDF
+        pdf_path = get_arxiv_pdf(source, cache_dir=cache_dir)
+        pdf = extract_text_from_pdf(pdf_path)
+    except Exception as e:
+        return InsightVerification(
+            insight_id=insight_id,
+            source_id=source_id,
+            overall_status=VerificationStatus.ERROR,
+            evidence_results=[
+                EvidenceVerification(
+                    evidence_id=_get_attr(ev, "id", "unknown"),
+                    status=VerificationStatus.ERROR,
+                    message=f"Failed to download/extract PDF: {e}",
+                )
+                for ev in evidence_list
+            ],
+        )
+
+    # Verify each piece of evidence
+    evidence_results = []
+    for ev in evidence_list:
+        # Only verify evidence that references this source
+        ev_source_ref = _get_attr(ev, "source_ref", "")
+        if ev_source_ref == source_id:
+            result = verify_evidence(ev, pdf)
+        else:
+            result = EvidenceVerification(
+                evidence_id=_get_attr(ev, "id", "unknown"),
+                status=VerificationStatus.SKIPPED,
+                message=f"Evidence references different source: {ev_source_ref}",
+            )
+        evidence_results.append(result)
+
+    # Determine overall status
+    if any(r.status == VerificationStatus.ERROR for r in evidence_results):
+        overall = VerificationStatus.ERROR
+    elif any(r.status == VerificationStatus.NOT_FOUND for r in evidence_results):
+        overall = VerificationStatus.NOT_FOUND
+    elif any(r.status == VerificationStatus.WRONG_PAGE for r in evidence_results):
+        overall = VerificationStatus.WRONG_PAGE
+    elif all(r.status == VerificationStatus.SKIPPED for r in evidence_results):
+        overall = VerificationStatus.SKIPPED
+    else:
+        overall = VerificationStatus.VERIFIED
+
+    return InsightVerification(
+        insight_id=insight_id,
+        source_id=source_id,
+        pdf_sha256=pdf.sha256,
+        evidence_results=evidence_results,
+        overall_status=overall,
+    )

--- a/src/asp/verification/pdf.py
+++ b/src/asp/verification/pdf.py
@@ -1,0 +1,258 @@
+"""PDF handling for evidence verification.
+
+Downloads arXiv PDFs and extracts text for quote verification.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+# Check for optional dependencies
+try:
+    import httpx
+except ImportError:
+    httpx = None  # type: ignore[assignment]
+
+try:
+    import pdftext.extraction
+except ImportError:
+    pdftext = None  # type: ignore[assignment]
+
+
+def _check_dependencies() -> None:
+    """Raise ImportError if verification dependencies are missing."""
+    missing = []
+    if httpx is None:
+        missing.append("httpx")
+    if pdftext is None:
+        missing.append("pdftext")
+    if missing:
+        raise ImportError(
+            f"Missing verification dependencies: {', '.join(missing)}. "
+            "Install with: pip install asp[verify]"
+        )
+
+
+@dataclass
+class PDFDocument:
+    """A PDF document with extracted text by page.
+
+    Attributes:
+        path: Path to the PDF file.
+        pages: List of text content per page (0-indexed).
+        num_pages: Total number of pages.
+        sha256: SHA-256 hash of the PDF content.
+    """
+
+    path: Path
+    pages: list[str] = field(default_factory=list)
+    num_pages: int = 0
+    sha256: str = ""
+
+    def get_page_text(self, page: int) -> str | None:
+        """Get text for a specific page (1-indexed as per FragmentSelector).
+
+        Args:
+            page: 1-indexed page number.
+
+        Returns:
+            Text content of the page, or None if page is out of range.
+        """
+        if page < 1 or page > self.num_pages:
+            return None
+        return self.pages[page - 1]
+
+    def get_full_text(self) -> str:
+        """Get concatenated text from all pages."""
+        return "\n\n".join(self.pages)
+
+    def find_quote(
+        self,
+        quote: str,
+        page: int | None = None,
+        min_match_ratio: float = 0.7,
+    ) -> list[int]:
+        """Find pages containing a quote.
+
+        Uses fuzzy matching to handle OCR/extraction differences.
+
+        Args:
+            quote: The quote to search for.
+            page: Optional page hint (1-indexed). If provided, searches this page first.
+            min_match_ratio: Minimum similarity ratio for fuzzy matching.
+
+        Returns:
+            List of 1-indexed page numbers where quote was found.
+        """
+        found_pages = []
+        normalized_quote = _normalize_text(quote)
+
+        # Search pages (prioritize hint page if provided)
+        pages_to_search = list(range(self.num_pages))
+        if page is not None and 1 <= page <= self.num_pages:
+            # Move hint page to front
+            pages_to_search.remove(page - 1)
+            pages_to_search.insert(0, page - 1)
+
+        for page_idx in pages_to_search:
+            page_text = _normalize_text(self.pages[page_idx])
+
+            # Exact match
+            if normalized_quote in page_text:
+                found_pages.append(page_idx + 1)
+                continue
+
+            # Fuzzy match using simple similarity
+            if _fuzzy_contains(page_text, normalized_quote, min_match_ratio):
+                found_pages.append(page_idx + 1)
+
+        return found_pages
+
+
+def _normalize_text(text: str) -> str:
+    """Normalize text for comparison.
+
+    Handles common PDF extraction issues:
+    - Unicode normalization
+    - Whitespace normalization
+    - Common character substitutions
+    """
+    # Normalize whitespace
+    text = re.sub(r"\s+", " ", text.strip())
+
+    # Common Unicode -> ASCII substitutions for scientific text
+    replacements = {
+        "\u2013": "-",  # en-dash
+        "\u2014": "--",  # em-dash
+        "\u2018": "'",  # left single quote
+        "\u2019": "'",  # right single quote
+        "\u201c": '"',  # left double quote
+        "\u201d": '"',  # right double quote
+        "\u00b1": "+-",  # plus-minus
+        "\u00d7": "x",  # multiplication
+        "\u03c3": "sigma",  # sigma
+        "\u03b1": "alpha",  # alpha
+        "\u03b2": "beta",  # beta
+        "\u2264": "<=",  # less than or equal
+        "\u2265": ">=",  # greater than or equal
+        "\ufb01": "fi",  # fi ligature
+        "\ufb02": "fl",  # fl ligature
+    }
+    for old, new in replacements.items():
+        text = text.replace(old, new)
+
+    return text.lower()
+
+
+def _fuzzy_contains(haystack: str, needle: str, min_ratio: float) -> bool:
+    """Check if haystack contains needle with fuzzy matching.
+
+    Uses a simple sliding window approach.
+    """
+    if len(needle) > len(haystack):
+        return False
+
+    # Slide a window of needle's length across haystack
+    window_size = len(needle)
+
+    for i in range(len(haystack) - window_size + 1):
+        window = haystack[i : i + window_size]
+        ratio = _similarity_ratio(window, needle)
+        if ratio >= min_ratio:
+            return True
+
+    return False
+
+
+def _similarity_ratio(s1: str, s2: str) -> float:
+    """Calculate similarity ratio between two strings."""
+    if not s1 or not s2:
+        return 0.0
+
+    # Simple character-based similarity
+    matches = sum(1 for a, b in zip(s1, s2) if a == b)
+    return matches / max(len(s1), len(s2))
+
+
+def get_arxiv_pdf(
+    source: Any,
+    cache_dir: Path | None = None,
+) -> Path:
+    """Download an arXiv PDF.
+
+    Args:
+        source: ArxivSource dict or object with arxiv_id and version.
+        cache_dir: Directory to cache PDFs. Defaults to ~/.cache/asp/pdfs.
+
+    Returns:
+        Path to the downloaded PDF.
+
+    Raises:
+        ImportError: If httpx is not installed.
+        httpx.HTTPError: If download fails.
+    """
+    _check_dependencies()
+    import httpx as _httpx  # noqa: F811
+
+    # Handle both dict and object
+    if isinstance(source, dict):
+        arxiv_id = source["arxiv_id"]
+        version = source["version"]
+    else:
+        arxiv_id = source.arxiv_id
+        version = source.version
+
+    # Set up cache directory
+    if cache_dir is None:
+        cache_dir = Path.home() / ".cache" / "asp" / "pdfs"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    # Check cache
+    filename = f"{arxiv_id.replace('/', '_')}v{version}.pdf"
+    cached_path = cache_dir / filename
+
+    if cached_path.exists():
+        return cached_path
+
+    # Download
+    url = f"https://arxiv.org/pdf/{arxiv_id}v{version}.pdf"
+    response = _httpx.get(url, follow_redirects=True, timeout=60.0)
+    response.raise_for_status()
+
+    # Save to cache
+    cached_path.write_bytes(response.content)
+
+    return cached_path
+
+
+def extract_text_from_pdf(pdf_path: Path) -> PDFDocument:
+    """Extract text from a PDF file.
+
+    Args:
+        pdf_path: Path to the PDF file.
+
+    Returns:
+        PDFDocument with extracted text and metadata.
+
+    Raises:
+        ImportError: If pdftext is not installed.
+    """
+    _check_dependencies()
+    import pdftext.extraction as _pdftext  # noqa: F811
+
+    # Calculate SHA-256
+    sha256 = hashlib.sha256(pdf_path.read_bytes()).hexdigest()
+
+    # Extract text by page
+    pages = _pdftext.plain_text_output(str(pdf_path), sort=True, hyphens=False)
+
+    return PDFDocument(
+        path=pdf_path,
+        pages=pages,
+        num_pages=len(pages),
+        sha256=sha256,
+    )

--- a/src/asp/verification/pdf.py
+++ b/src/asp/verification/pdf.py
@@ -12,15 +12,23 @@ from pathlib import Path
 from typing import Any
 
 # Check for optional dependencies
-try:
-    import httpx
-except ImportError:
-    httpx = None  # type: ignore[assignment]
+# These are optional and may not be installed
+httpx: Any = None
+pdftext: Any = None
 
 try:
-    import pdftext.extraction
+    import httpx as _httpx  # type: ignore[import-not-found]
+
+    httpx = _httpx
 except ImportError:
-    pdftext = None  # type: ignore[assignment]
+    pass
+
+try:
+    import pdftext as _pdftext  # type: ignore[import-not-found]
+
+    pdftext = _pdftext
+except ImportError:
+    pass
 
 
 def _check_dependencies() -> None:
@@ -196,7 +204,6 @@ def get_arxiv_pdf(
         httpx.HTTPError: If download fails.
     """
     _check_dependencies()
-    import httpx as _httpx  # noqa: F811
 
     # Handle both dict and object
     if isinstance(source, dict):
@@ -220,7 +227,7 @@ def get_arxiv_pdf(
 
     # Download
     url = f"https://arxiv.org/pdf/{arxiv_id}v{version}.pdf"
-    response = _httpx.get(url, follow_redirects=True, timeout=60.0)
+    response = httpx.get(url, follow_redirects=True, timeout=60.0)
     response.raise_for_status()
 
     # Save to cache
@@ -242,13 +249,12 @@ def extract_text_from_pdf(pdf_path: Path) -> PDFDocument:
         ImportError: If pdftext is not installed.
     """
     _check_dependencies()
-    import pdftext.extraction as _pdftext  # noqa: F811
 
     # Calculate SHA-256
     sha256 = hashlib.sha256(pdf_path.read_bytes()).hexdigest()
 
     # Extract text by page
-    pages = _pdftext.plain_text_output(str(pdf_path), sort=True, hyphens=False)
+    pages = pdftext.extraction.plain_text_output(str(pdf_path), sort=True, hyphens=False)
 
     return PDFDocument(
         path=pdf_path,


### PR DESCRIPTION
## Summary

This PR significantly simplifies the Insight/Evidence model and adds optional evidence verification capabilities.

### Model Simplifications

- **Replaced PaperSource/AnalysisSource** with ArxivSource/DoiSource for more precise source tracking
- **Removed analysis-based evidence** - Now only supports literature-based evidence with proper citations
- **Simplified Evidence model** - Uses W3C-compliant selectors instead of multiple evidence type classes

### W3C Web Annotation Selectors

Added W3C-compliant selectors for referencing content in scientific papers:

- **`TextQuoteSelector`** - For text quotes with `exact`, `prefix`, `suffix` fields
- **`FigureSelector`** - For referencing figures with `label` and `caption`
- **`TableSelector`** - For referencing tables with `label`, `caption`, and `region`
- **`FragmentSelector`** - For PDF page location hints

These selectors are compatible with tools like [Hypothesis](https://web.hypothes.is/) for browser-based PDF annotation.

### Evidence Verification Module

Added optional verification module (`pip install asp[verify]`) that can:

- Download and cache arXiv PDFs
- Extract text from PDFs using `pdftext`
- Verify that quoted text actually exists in source documents
- Handle Unicode → ASCII normalization for scientific symbols (±, ×, σ, etc.)
- Fuzzy matching for quotes that don't extract perfectly

### New Files

- `src/asp/verification/__init__.py` - Module exports
- `src/asp/verification/core.py` - Verification logic and result models
- `src/asp/verification/pdf.py` - PDF download, extraction, and quote matching

### Updated Files

- `models/insight.py` - Simplified Insight/Evidence models with new selectors
- `models/__init__.py` - Updated exports
- `pyproject.toml` - Added `[verify]` optional dependency group
- `spec/draft/insights.schema.json` - Regenerated schema
- `spec/draft/analysis.schema.json` - Regenerated schema (includes insight definitions)

## Test Plan

- [x] Schema tests pass
- [x] Validation tests pass
- [x] Ruff linter passes
- [x] Evidence validation ensures at least one selector is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)