### PR TITLE
Make claude-code the default agent for asp init

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,11 @@ my-analysis/
 │   └── evaluation/
 ├── scripts/              # Implementation scripts
 ├── results/              # Execution outputs (gitignored)
+├── .claude/              # Claude Code agent configuration (default)
+│   ├── skills/
+│   │   └── asp-analysis/ # ASP-specific skill for Claude Code
+│   └── agents/
+│       └── asp.md        # ASP agent configuration
 └── .asp/
     └── branches.yaml     # Branch metadata
 ```

--- a/src/asp/cli.py
+++ b/src/asp/cli.py
@@ -138,7 +138,10 @@ __pycache__/
             )
         except FileNotFoundError:
             console.print("[red]Error:[/red] Claude Code CLI not found.")
-            console.print("Install Claude Code or run [cyan]claude[/cyan] manually in the project.")
+            console.print("\nASP currently only supports Claude Code for AI agent integration.")
+            console.print("To proceed without agent configuration, run:")
+            console.print("  [cyan]asp init --agent=none[/cyan]")
+            console.print("\nOr install Claude Code from: https://claude.ai/code")
             raise SystemExit(1)
     else:
         console.print("\n[bold]Next steps:[/bold]")

--- a/src/asp/cli.py
+++ b/src/asp/cli.py
@@ -58,21 +58,22 @@ def main() -> None:
 @click.argument("directory", type=click.Path(path_type=Path), default=".")
 @click.option(
     "--agent",
-    type=click.Choice(["claude-code"]),
-    help="Set up project for a specific AI agent (creates agent-specific config)",
+    type=click.Choice(["claude-code", "none"]),
+    default="claude-code",
+    help="AI agent to configure (default: claude-code). Use --agent=none for no agent config.",
 )
 @click.option("--no-git", is_flag=True, help="Don't initialize git repository")
-def init(directory: Path, agent: str | None, no_git: bool) -> None:
+def init(directory: Path, agent: str, no_git: bool) -> None:
     """Create a new ASP analysis project.
 
-    Creates the project scaffolding for an ASP analysis. Use --agent to
-    configure the project for a specific AI agent.
+    Creates the project scaffolding for an ASP analysis with Claude Code
+    configuration by default.
 
     DIRECTORY is the project folder to create (default: current directory).
 
     Examples:
-        asp init my-analysis                      # Basic scaffolding
-        asp init my-analysis --agent claude-code  # With Claude Code skill
+        asp init my-analysis              # With Claude Code skill (default)
+        asp init my-analysis --agent none # Without AI agent config
     """
     # Create project directory
     if directory != Path("."):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -247,7 +247,7 @@ class TestInitCommand:
         project_dir = tmp_path / "my-analysis"
         result = runner.invoke(
             main,
-            ["init", str(project_dir), "--no-git"],
+            ["init", str(project_dir), "--agent=none", "--no-git"],
         )
         assert result.exit_code == 0
         assert "Created ASP analysis project" in result.output
@@ -275,7 +275,7 @@ class TestInitCommand:
         project_dir = tmp_path / "content-test"
         result = runner.invoke(
             main,
-            ["init", str(project_dir), "--no-git"],
+            ["init", str(project_dir), "--agent=none", "--no-git"],
         )
         assert result.exit_code == 0
         assert (project_dir / "asp.yaml").exists()
@@ -292,7 +292,7 @@ class TestInitCommand:
         project_dir = tmp_path / "gitignore-test"
         result = runner.invoke(
             main,
-            ["init", str(project_dir), "--no-git"],
+            ["init", str(project_dir), "--agent=none", "--no-git"],
         )
         assert result.exit_code == 0
 
@@ -375,7 +375,7 @@ class TestInitCommand:
 
         result = runner.invoke(
             main,
-            ["init", str(project_dir), "--no-git"],
+            ["init", str(project_dir), "--agent=none", "--no-git"],
             input="n\n",  # Decline to continue
         )
         assert result.exit_code == 0
@@ -390,7 +390,7 @@ class TestInitCommand:
 
         result = runner.invoke(
             main,
-            ["init", str(project_dir), "--no-git"],
+            ["init", str(project_dir), "--agent=none", "--no-git"],
             input="y\n",  # Confirm to continue
         )
         assert result.exit_code == 0
@@ -407,7 +407,7 @@ class TestInitCommand:
             os.chdir(tmp_path)
             result = runner.invoke(
                 main,
-                ["init", "--no-git"],
+                ["init", "--agent=none", "--no-git"],
             )
             assert result.exit_code == 0
             assert (tmp_path / "asp.yaml").exists()
@@ -419,7 +419,7 @@ class TestInitCommand:
         project_dir = tmp_path / "valid-test"
         runner.invoke(
             main,
-            ["init", str(project_dir), "--no-git"],
+            ["init", str(project_dir), "--agent=none", "--no-git"],
         )
 
         # Validate the generated asp.yaml
@@ -445,7 +445,7 @@ class TestInitCommand:
         project_dir = tmp_path / "git-test"
         result = runner.invoke(
             main,
-            ["init", str(project_dir)],
+            ["init", str(project_dir), "--agent=none"],
         )
         assert result.exit_code == 0
 
@@ -458,7 +458,7 @@ class TestInitCommand:
         project_dir = tmp_path / "no-git-test"
         result = runner.invoke(
             main,
-            ["init", str(project_dir), "--no-git"],
+            ["init", str(project_dir), "--agent=none", "--no-git"],
         )
         assert result.exit_code == 0
         # Git directory should NOT exist


### PR DESCRIPTION
Previously, users had to explicitly specify --agent claude-code to get the .claude directory with Claude Code skill configuration. Now claude-code is the default, so `asp init my-analysis` creates the full setup including .claude/skills/asp-analysis/ and .claude/agents/.

Users can opt out with --agent=none if they don't want AI agent config.