### PR TITLE
Evidence can come from artifacts, not just papers

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -4,9 +4,8 @@ These models are used for schema generation and are NOT installed as part
 of the asp package. They are only used by tools/generate_schemas.py.
 """
 
-from models.analysis import Analysis, Decision, Input, Option, Output
+from models.analysis import Analysis, Checksum, Decision, Input, Option, Output
 from models.insight import (
-    Checksum,
     Evidence,
     FigureSelector,
     FragmentSelector,
@@ -20,6 +19,7 @@ from models.universe import Universe, UniverseNode
 __all__ = [
     # Analysis
     "Analysis",
+    "Checksum",
     "Decision",
     "Input",
     "Option",
@@ -33,7 +33,6 @@ __all__ = [
     "FigureSelector",
     "TableSelector",
     # Insight - Core
-    "Checksum",
     "Evidence",
     "Insight",
     "InsightCollection",

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -6,6 +6,7 @@ of the asp package. They are only used by tools/generate_schemas.py.
 
 from models.analysis import Analysis, Decision, Input, Option, Output
 from models.insight import (
+    Checksum,
     Evidence,
     FigureSelector,
     FragmentSelector,
@@ -32,6 +33,7 @@ __all__ = [
     "FigureSelector",
     "TableSelector",
     # Insight - Core
+    "Checksum",
     "Evidence",
     "Insight",
     "InsightCollection",

--- a/models/analysis.py
+++ b/models/analysis.py
@@ -6,16 +6,7 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from models.insight import Insight
-
-
-class Checksum(BaseModel):
-    """Checksum for data integrity verification."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    algorithm: Literal["sha256", "sha512", "md5"] = Field(description="Hash algorithm")
-    value: str = Field(description="Hash value")
+from models.insight import Checksum, Insight
 
 
 class Input(BaseModel):

--- a/models/analysis.py
+++ b/models/analysis.py
@@ -6,7 +6,14 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from models.insight import Checksum, Insight
+
+class Checksum(BaseModel):
+    """Checksum for data integrity verification."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    algorithm: Literal["sha256", "sha512", "md5"] = Field(description="Hash algorithm")
+    value: str = Field(description="Hash value")
 
 
 class Input(BaseModel):
@@ -242,5 +249,8 @@ class Analysis(BaseModel):
     )
 
 
-# Required for Pydantic self-referencing models
+# Resolve forward references to Insight from models.insight.
+# Imported here (at module bottom) to avoid circular imports at module load time.
+from models.insight import Insight  # noqa: E402
+
 Analysis.model_rebuild()

--- a/models/insight.py
+++ b/models/insight.py
@@ -91,20 +91,6 @@ class TableSelector(BaseModel):
 
 
 # =============================================================================
-# Checksum
-# =============================================================================
-
-
-class Checksum(BaseModel):
-    """Checksum for data integrity verification."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    algorithm: Literal["sha256", "sha512", "md5"] = Field(description="Hash algorithm")
-    value: str = Field(description="Hash value")
-
-
-# =============================================================================
 # Evidence
 # =============================================================================
 
@@ -119,8 +105,10 @@ class Evidence(BaseModel):
       ``10.48550/arXiv.{id}`` and set ``version``.
 
     - **Analysis artifact** (``artifact``): An output produced by a recipe
-      in this analysis. The ``produced_by`` field identifies the recipe,
-      and an optional ``checksum`` ensures artifact integrity.
+      in this analysis. The ``artifact`` field is an ``Output`` object —
+      the same type used to declare outputs in the analysis — so artifact
+      evidence is structurally identical to declared outputs. The optional
+      ``checksum`` ensures artifact integrity.
 
     Exactly one of ``doi`` or ``artifact`` must be set.
     At least one content selector (quote, figure, or table) is required.
@@ -136,10 +124,9 @@ class Evidence(BaseModel):
                     "properties": {"doi": {"type": "string"}},
                 },
                 {
-                    "required": ["artifact", "produced_by"],
+                    "required": ["artifact"],
                     "properties": {
-                        "artifact": {"type": "string"},
-                        "produced_by": {"type": "string"},
+                        "artifact": {"type": "object"},
                     },
                 },
             ]
@@ -154,9 +141,9 @@ class Evidence(BaseModel):
         pattern=r"^10\.\d{4,}/.*$",
         description="DOI of the source paper (e.g., '10.48550/arXiv.1706.03762')",
     )
-    artifact: str | None = Field(
+    artifact: Output | None = Field(
         default=None,
-        description="Output ID of the analysis-generated artifact that constitutes evidence",
+        description="The analysis output that constitutes evidence — same type as declared outputs",
     )
 
     # Literature-specific
@@ -167,10 +154,6 @@ class Evidence(BaseModel):
     )
 
     # Artifact-specific
-    produced_by: str | None = Field(
-        default=None,
-        description="Recipe ID that produces the artifact (required for artifact evidence)",
-    )
     checksum: Checksum | None = Field(
         default=None,
         description="Checksum of the artifact for integrity verification",
@@ -194,12 +177,6 @@ class Evidence(BaseModel):
 
         if has_doi == has_artifact:
             raise ValueError("Evidence must have exactly one of 'doi' (literature) or 'artifact'")
-
-        if has_artifact and self.produced_by is None:
-            raise ValueError("Artifact evidence requires 'produced_by' (recipe ID)")
-
-        if has_doi and self.produced_by is not None:
-            raise ValueError("'produced_by' is only valid for artifact evidence, not literature")
 
         if has_doi and self.checksum is not None:
             raise ValueError("'checksum' is only valid for artifact evidence, not literature")
@@ -309,3 +286,12 @@ class InsightCollection(BaseModel):
     def get_insight(self, insight_id: str) -> Insight | None:
         """Get insight by ID."""
         return self.insights.get(insight_id)
+
+
+# Resolve forward references to Output and Checksum from models.analysis.
+# Imported here (at module bottom) to avoid circular imports at module load time.
+from models.analysis import Checksum, Output  # noqa: E402
+
+Evidence.model_rebuild()
+Insight.model_rebuild()
+InsightCollection.model_rebuild()

--- a/models/insight.py
+++ b/models/insight.py
@@ -1,7 +1,11 @@
 """Pydantic models for scientific insights.
 
-Simplified insight model with W3C Web Annotation-compliant selectors
-for referencing content in scientific papers.
+Insight model with W3C Web Annotation-compliant selectors for referencing
+content in scientific papers AND analysis-generated artifacts.
+
+Evidence can come from two sources:
+- **Literature**: Referenced by DOI with W3C selectors into PDFs
+- **Analysis artifacts**: Referenced by output ID with a producing recipe
 
 W3C Web Annotation compliance:
 - TextQuoteSelector: https://www.w3.org/TR/annotation-model/#text-quote-selector
@@ -87,32 +91,89 @@ class TableSelector(BaseModel):
 
 
 # =============================================================================
+# Checksum
+# =============================================================================
+
+
+class Checksum(BaseModel):
+    """Checksum for data integrity verification."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    algorithm: Literal["sha256", "sha512", "md5"] = Field(description="Hash algorithm")
+    value: str = Field(description="Hash value")
+
+
+# =============================================================================
 # Evidence
 # =============================================================================
 
 
 class Evidence(BaseModel):
-    """Evidence from scientific literature with W3C-compliant selectors.
+    """Evidence from a source with W3C-compliant selectors.
 
-    References papers directly by DOI. At least one content selector
-    (quote, figure, or table) is required. The FragmentSelector provides
-    optional PDF location hints.
+    Evidence can reference two kinds of sources:
 
-    For arXiv papers, the DOI format is: 10.48550/arXiv.{id}
-    The version field is used for arXiv papers where version matters.
+    - **Literature** (``doi``): A paper referenced by DOI, with W3C selectors
+      pointing into the PDF. For arXiv papers, use DOI format
+      ``10.48550/arXiv.{id}`` and set ``version``.
+
+    - **Analysis artifact** (``artifact``): An output produced by a recipe
+      in this analysis. The ``produced_by`` field identifies the recipe,
+      and an optional ``checksum`` ensures artifact integrity.
+
+    Exactly one of ``doi`` or ``artifact`` must be set.
+    At least one content selector (quote, figure, or table) is required.
     """
 
-    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+        json_schema_extra={
+            "oneOf": [
+                {
+                    "required": ["doi"],
+                    "properties": {"doi": {"type": "string"}},
+                },
+                {
+                    "required": ["artifact", "produced_by"],
+                    "properties": {
+                        "artifact": {"type": "string"},
+                        "produced_by": {"type": "string"},
+                    },
+                },
+            ]
+        },
+    )
 
     id: str = Field(min_length=1, description="Evidence ID")
-    doi: str = Field(
+
+    # Source: exactly one of doi or artifact
+    doi: str | None = Field(
+        default=None,
         pattern=r"^10\.\d{4,}/.*$",
         description="DOI of the source paper (e.g., '10.48550/arXiv.1706.03762')",
     )
+    artifact: str | None = Field(
+        default=None,
+        description="Output ID of the analysis-generated artifact that constitutes evidence",
+    )
+
+    # Literature-specific
     version: int | None = Field(
         default=None,
         ge=1,
         description="Paper version for arXiv papers (version matters for reproducibility)",
+    )
+
+    # Artifact-specific
+    produced_by: str | None = Field(
+        default=None,
+        description="Recipe ID that produces the artifact (required for artifact evidence)",
+    )
+    checksum: Checksum | None = Field(
+        default=None,
+        description="Checksum of the artifact for integrity verification",
     )
 
     # Content selectors (at least one required)
@@ -121,11 +182,31 @@ class Evidence(BaseModel):
     table: TableSelector | None = Field(default=None, description="Table reference")
 
     # Location hint
-    location: FragmentSelector | None = Field(default=None, description="PDF location hint")
+    location: FragmentSelector | None = Field(
+        default=None, description="Location hint (page number for PDFs/reports)"
+    )
 
     @model_validator(mode="after")
-    def require_at_least_one_selector(self) -> Evidence:
-        """Ensure at least one content selector is provided."""
+    def validate_source(self) -> Evidence:
+        """Ensure exactly one source type and at least one content selector."""
+        has_doi = self.doi is not None
+        has_artifact = self.artifact is not None
+
+        if has_doi == has_artifact:
+            raise ValueError("Evidence must have exactly one of 'doi' (literature) or 'artifact'")
+
+        if has_artifact and self.produced_by is None:
+            raise ValueError("Artifact evidence requires 'produced_by' (recipe ID)")
+
+        if has_doi and self.produced_by is not None:
+            raise ValueError("'produced_by' is only valid for artifact evidence, not literature")
+
+        if has_doi and self.checksum is not None:
+            raise ValueError("'checksum' is only valid for artifact evidence, not literature")
+
+        if has_artifact and self.version is not None:
+            raise ValueError("'version' is only valid for literature evidence, not artifacts")
+
         if not (self.quote or self.figure or self.table):
             raise ValueError(
                 "Evidence must have at least one content selector: quote, figure, or table"
@@ -133,14 +214,25 @@ class Evidence(BaseModel):
         return self
 
     @property
+    def is_literature(self) -> bool:
+        """Check if this evidence references a paper."""
+        return self.doi is not None
+
+    @property
+    def is_artifact(self) -> bool:
+        """Check if this evidence references an analysis artifact."""
+        return self.artifact is not None
+
+    @property
     def is_arxiv(self) -> bool:
         """Check if this evidence references an arXiv paper."""
-        return self.doi.startswith("10.48550/arXiv.")
+        return self.doi is not None and self.doi.startswith("10.48550/arXiv.")
 
     @property
     def arxiv_id(self) -> str | None:
         """Extract arXiv ID from DOI if this is an arXiv paper."""
         if self.is_arxiv:
+            assert self.doi is not None
             return self.doi.replace("10.48550/arXiv.", "")
         return None
 
@@ -153,9 +245,10 @@ class Evidence(BaseModel):
 class Insight(BaseModel):
     """A scientific insight with provenance and supporting evidence.
 
-    Represents a discrete unit of scientific knowledge extracted from
-    literature, with full traceability to source material via W3C-compliant
-    text selectors. Evidence directly references papers by DOI.
+    Represents a discrete unit of scientific knowledge with full
+    traceability to source material. Evidence can come from literature
+    (papers referenced by DOI) or from analysis artifacts (outputs
+    produced by recipes), both using W3C-compliant selectors.
     """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True)

--- a/spec/draft/analysis.schema.json
+++ b/spec/draft/analysis.schema.json
@@ -497,7 +497,33 @@
     },
     "Evidence": {
       "additionalProperties": false,
-      "description": "Evidence from scientific literature with W3C-compliant selectors.\n\nReferences papers directly by DOI. At least one content selector\n(quote, figure, or table) is required. The FragmentSelector provides\noptional PDF location hints.\n\nFor arXiv papers, the DOI format is: 10.48550/arXiv.{id}\nThe version field is used for arXiv papers where version matters.",
+      "description": "Evidence from a source with W3C-compliant selectors.\n\nEvidence can reference two kinds of sources:\n\n- **Literature** (``doi``): A paper referenced by DOI, with W3C selectors\n  pointing into the PDF. For arXiv papers, use DOI format\n  ``10.48550/arXiv.{id}`` and set ``version``.\n\n- **Analysis artifact** (``artifact``): An output produced by a recipe\n  in this analysis. The ``produced_by`` field identifies the recipe,\n  and an optional ``checksum`` ensures artifact integrity.\n\nExactly one of ``doi`` or ``artifact`` must be set.\nAt least one content selector (quote, figure, or table) is required.",
+      "oneOf": [
+        {
+          "properties": {
+            "doi": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "doi"
+          ]
+        },
+        {
+          "properties": {
+            "artifact": {
+              "type": "string"
+            },
+            "produced_by": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "artifact",
+            "produced_by"
+          ]
+        }
+      ],
       "properties": {
         "id": {
           "description": "Evidence ID",
@@ -506,10 +532,31 @@
           "type": "string"
         },
         "doi": {
+          "anyOf": [
+            {
+              "pattern": "^10\\.\\d{4,}/.*$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
           "description": "DOI of the source paper (e.g., '10.48550/arXiv.1706.03762')",
-          "pattern": "^10\\.\\d{4,}/.*$",
-          "title": "Doi",
-          "type": "string"
+          "title": "Doi"
+        },
+        "artifact": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Output ID of the analysis-generated artifact that constitutes evidence",
+          "title": "Artifact"
         },
         "version": {
           "anyOf": [
@@ -524,6 +571,31 @@
           "default": null,
           "description": "Paper version for arXiv papers (version matters for reproducibility)",
           "title": "Version"
+        },
+        "produced_by": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Recipe ID that produces the artifact (required for artifact evidence)",
+          "title": "Produced By"
+        },
+        "checksum": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Checksum"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Checksum of the artifact for integrity verification"
         },
         "quote": {
           "anyOf": [
@@ -571,12 +643,11 @@
             }
           ],
           "default": null,
-          "description": "PDF location hint"
+          "description": "Location hint (page number for PDFs/reports)"
         }
       },
       "required": [
-        "id",
-        "doi"
+        "id"
       ],
       "title": "Evidence",
       "type": "object"
@@ -786,7 +857,7 @@
     },
     "Insight": {
       "additionalProperties": false,
-      "description": "A scientific insight with provenance and supporting evidence.\n\nRepresents a discrete unit of scientific knowledge extracted from\nliterature, with full traceability to source material via W3C-compliant\ntext selectors. Evidence directly references papers by DOI.",
+      "description": "A scientific insight with provenance and supporting evidence.\n\nRepresents a discrete unit of scientific knowledge with full\ntraceability to source material. Evidence can come from literature\n(papers referenced by DOI) or from analysis artifacts (outputs\nproduced by recipes), both using W3C-compliant selectors.",
       "properties": {
         "id": {
           "description": "Unique identifier",

--- a/spec/draft/analysis.schema.json
+++ b/spec/draft/analysis.schema.json
@@ -497,7 +497,7 @@
     },
     "Evidence": {
       "additionalProperties": false,
-      "description": "Evidence from a source with W3C-compliant selectors.\n\nEvidence can reference two kinds of sources:\n\n- **Literature** (``doi``): A paper referenced by DOI, with W3C selectors\n  pointing into the PDF. For arXiv papers, use DOI format\n  ``10.48550/arXiv.{id}`` and set ``version``.\n\n- **Analysis artifact** (``artifact``): An output produced by a recipe\n  in this analysis. The ``produced_by`` field identifies the recipe,\n  and an optional ``checksum`` ensures artifact integrity.\n\nExactly one of ``doi`` or ``artifact`` must be set.\nAt least one content selector (quote, figure, or table) is required.",
+      "description": "Evidence from a source with W3C-compliant selectors.\n\nEvidence can reference two kinds of sources:\n\n- **Literature** (``doi``): A paper referenced by DOI, with W3C selectors\n  pointing into the PDF. For arXiv papers, use DOI format\n  ``10.48550/arXiv.{id}`` and set ``version``.\n\n- **Analysis artifact** (``artifact``): An output produced by a recipe\n  in this analysis. The ``artifact`` field is an ``Output`` object \u2014\n  the same type used to declare outputs in the analysis \u2014 so artifact\n  evidence is structurally identical to declared outputs. The optional\n  ``checksum`` ensures artifact integrity.\n\nExactly one of ``doi`` or ``artifact`` must be set.\nAt least one content selector (quote, figure, or table) is required.",
       "oneOf": [
         {
           "properties": {
@@ -512,15 +512,11 @@
         {
           "properties": {
             "artifact": {
-              "type": "string"
-            },
-            "produced_by": {
-              "type": "string"
+              "type": "object"
             }
           },
           "required": [
-            "artifact",
-            "produced_by"
+            "artifact"
           ]
         }
       ],
@@ -548,15 +544,14 @@
         "artifact": {
           "anyOf": [
             {
-              "type": "string"
+              "$ref": "#/$defs/Output"
             },
             {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Output ID of the analysis-generated artifact that constitutes evidence",
-          "title": "Artifact"
+          "description": "The analysis output that constitutes evidence \u2014 same type as declared outputs"
         },
         "version": {
           "anyOf": [
@@ -571,19 +566,6 @@
           "default": null,
           "description": "Paper version for arXiv papers (version matters for reproducibility)",
           "title": "Version"
-        },
-        "produced_by": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Recipe ID that produces the artifact (required for artifact evidence)",
-          "title": "Produced By"
         },
         "checksum": {
           "anyOf": [

--- a/spec/draft/insights.schema.json
+++ b/spec/draft/insights.schema.json
@@ -1,8 +1,61 @@
 {
   "$defs": {
+    "Checksum": {
+      "additionalProperties": false,
+      "description": "Checksum for data integrity verification.",
+      "properties": {
+        "algorithm": {
+          "description": "Hash algorithm",
+          "enum": [
+            "sha256",
+            "sha512",
+            "md5"
+          ],
+          "title": "Algorithm",
+          "type": "string"
+        },
+        "value": {
+          "description": "Hash value",
+          "title": "Value",
+          "type": "string"
+        }
+      },
+      "required": [
+        "algorithm",
+        "value"
+      ],
+      "title": "Checksum",
+      "type": "object"
+    },
     "Evidence": {
       "additionalProperties": false,
-      "description": "Evidence from scientific literature with W3C-compliant selectors.\n\nReferences papers directly by DOI. At least one content selector\n(quote, figure, or table) is required. The FragmentSelector provides\noptional PDF location hints.\n\nFor arXiv papers, the DOI format is: 10.48550/arXiv.{id}\nThe version field is used for arXiv papers where version matters.",
+      "description": "Evidence from a source with W3C-compliant selectors.\n\nEvidence can reference two kinds of sources:\n\n- **Literature** (``doi``): A paper referenced by DOI, with W3C selectors\n  pointing into the PDF. For arXiv papers, use DOI format\n  ``10.48550/arXiv.{id}`` and set ``version``.\n\n- **Analysis artifact** (``artifact``): An output produced by a recipe\n  in this analysis. The ``produced_by`` field identifies the recipe,\n  and an optional ``checksum`` ensures artifact integrity.\n\nExactly one of ``doi`` or ``artifact`` must be set.\nAt least one content selector (quote, figure, or table) is required.",
+      "oneOf": [
+        {
+          "properties": {
+            "doi": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "doi"
+          ]
+        },
+        {
+          "properties": {
+            "artifact": {
+              "type": "string"
+            },
+            "produced_by": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "artifact",
+            "produced_by"
+          ]
+        }
+      ],
       "properties": {
         "id": {
           "description": "Evidence ID",
@@ -11,10 +64,31 @@
           "type": "string"
         },
         "doi": {
+          "anyOf": [
+            {
+              "pattern": "^10\\.\\d{4,}/.*$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
           "description": "DOI of the source paper (e.g., '10.48550/arXiv.1706.03762')",
-          "pattern": "^10\\.\\d{4,}/.*$",
-          "title": "Doi",
-          "type": "string"
+          "title": "Doi"
+        },
+        "artifact": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Output ID of the analysis-generated artifact that constitutes evidence",
+          "title": "Artifact"
         },
         "version": {
           "anyOf": [
@@ -29,6 +103,31 @@
           "default": null,
           "description": "Paper version for arXiv papers (version matters for reproducibility)",
           "title": "Version"
+        },
+        "produced_by": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Recipe ID that produces the artifact (required for artifact evidence)",
+          "title": "Produced By"
+        },
+        "checksum": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Checksum"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Checksum of the artifact for integrity verification"
         },
         "quote": {
           "anyOf": [
@@ -76,12 +175,11 @@
             }
           ],
           "default": null,
-          "description": "PDF location hint"
+          "description": "Location hint (page number for PDFs/reports)"
         }
       },
       "required": [
-        "id",
-        "doi"
+        "id"
       ],
       "title": "Evidence",
       "type": "object"
@@ -171,7 +269,7 @@
     },
     "Insight": {
       "additionalProperties": false,
-      "description": "A scientific insight with provenance and supporting evidence.\n\nRepresents a discrete unit of scientific knowledge extracted from\nliterature, with full traceability to source material via W3C-compliant\ntext selectors. Evidence directly references papers by DOI.",
+      "description": "A scientific insight with provenance and supporting evidence.\n\nRepresents a discrete unit of scientific knowledge with full\ntraceability to source material. Evidence can come from literature\n(papers referenced by DOI) or from analysis artifacts (outputs\nproduced by recipes), both using W3C-compliant selectors.",
       "properties": {
         "id": {
           "description": "Unique identifier",

--- a/spec/draft/insights.schema.json
+++ b/spec/draft/insights.schema.json
@@ -1,35 +1,8 @@
 {
   "$defs": {
-    "Checksum": {
-      "additionalProperties": false,
-      "description": "Checksum for data integrity verification.",
-      "properties": {
-        "algorithm": {
-          "description": "Hash algorithm",
-          "enum": [
-            "sha256",
-            "sha512",
-            "md5"
-          ],
-          "title": "Algorithm",
-          "type": "string"
-        },
-        "value": {
-          "description": "Hash value",
-          "title": "Value",
-          "type": "string"
-        }
-      },
-      "required": [
-        "algorithm",
-        "value"
-      ],
-      "title": "Checksum",
-      "type": "object"
-    },
     "Evidence": {
       "additionalProperties": false,
-      "description": "Evidence from a source with W3C-compliant selectors.\n\nEvidence can reference two kinds of sources:\n\n- **Literature** (``doi``): A paper referenced by DOI, with W3C selectors\n  pointing into the PDF. For arXiv papers, use DOI format\n  ``10.48550/arXiv.{id}`` and set ``version``.\n\n- **Analysis artifact** (``artifact``): An output produced by a recipe\n  in this analysis. The ``produced_by`` field identifies the recipe,\n  and an optional ``checksum`` ensures artifact integrity.\n\nExactly one of ``doi`` or ``artifact`` must be set.\nAt least one content selector (quote, figure, or table) is required.",
+      "description": "Evidence from a source with W3C-compliant selectors.\n\nEvidence can reference two kinds of sources:\n\n- **Literature** (``doi``): A paper referenced by DOI, with W3C selectors\n  pointing into the PDF. For arXiv papers, use DOI format\n  ``10.48550/arXiv.{id}`` and set ``version``.\n\n- **Analysis artifact** (``artifact``): An output produced by a recipe\n  in this analysis. The ``artifact`` field is an ``Output`` object \u2014\n  the same type used to declare outputs in the analysis \u2014 so artifact\n  evidence is structurally identical to declared outputs. The optional\n  ``checksum`` ensures artifact integrity.\n\nExactly one of ``doi`` or ``artifact`` must be set.\nAt least one content selector (quote, figure, or table) is required.",
       "oneOf": [
         {
           "properties": {
@@ -44,15 +17,11 @@
         {
           "properties": {
             "artifact": {
-              "type": "string"
-            },
-            "produced_by": {
-              "type": "string"
+              "type": "object"
             }
           },
           "required": [
-            "artifact",
-            "produced_by"
+            "artifact"
           ]
         }
       ],
@@ -80,15 +49,14 @@
         "artifact": {
           "anyOf": [
             {
-              "type": "string"
+              "$ref": "#/$defs/Output"
             },
             {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Output ID of the analysis-generated artifact that constitutes evidence",
-          "title": "Artifact"
+          "description": "The analysis output that constitutes evidence \u2014 same type as declared outputs"
         },
         "version": {
           "anyOf": [
@@ -103,19 +71,6 @@
           "default": null,
           "description": "Paper version for arXiv papers (version matters for reproducibility)",
           "title": "Version"
-        },
-        "produced_by": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Recipe ID that produces the artifact (required for artifact evidence)",
-          "title": "Produced By"
         },
         "checksum": {
           "anyOf": [
@@ -182,6 +137,33 @@
         "id"
       ],
       "title": "Evidence",
+      "type": "object"
+    },
+    "Checksum": {
+      "additionalProperties": false,
+      "description": "Checksum for data integrity verification.",
+      "properties": {
+        "algorithm": {
+          "description": "Hash algorithm",
+          "enum": [
+            "sha256",
+            "sha512",
+            "md5"
+          ],
+          "title": "Algorithm",
+          "type": "string"
+        },
+        "value": {
+          "description": "Hash value",
+          "title": "Value",
+          "type": "string"
+        }
+      },
+      "required": [
+        "algorithm",
+        "value"
+      ],
+      "title": "Checksum",
       "type": "object"
     },
     "FigureSelector": {
@@ -361,6 +343,62 @@
         "evidence"
       ],
       "title": "Insight",
+      "type": "object"
+    },
+    "Output": {
+      "additionalProperties": false,
+      "description": "An expected output from the analysis.\n\nOutputs can declare their provenance via ``from`` to trace which\nsub-analysis produces them (e.g., ``from: inference.posterior``).",
+      "properties": {
+        "id": {
+          "description": "Unique identifier for the output",
+          "pattern": "^[a-z][a-z0-9_]*$",
+          "title": "Id",
+          "type": "string"
+        },
+        "type": {
+          "description": "Type of output",
+          "enum": [
+            "metric",
+            "figure",
+            "table",
+            "data",
+            "report"
+          ],
+          "title": "Type",
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Description of the output",
+          "title": "Description"
+        },
+        "from": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Sub-analysis output that produces this (e.g., 'sub_analysis.output_id')",
+          "title": "From"
+        }
+      },
+      "required": [
+        "id",
+        "type"
+      ],
+      "title": "Output",
       "type": "object"
     },
     "TableSelector": {


### PR DESCRIPTION
Extends Evidence to support analysis-generated artifacts (figures, tables, etc.) as a source, not just literature DOIs. The idea: evidence is evidence regardless of where it comes from.

**What changed:**
- Evidence now has `artifact` + `produced_by` as an alternative to `doi`
- Added `oneOf` constraint to the JSON schema so the doi-vs-artifact invariant is enforced at the schema level, not just in Pydantic
- `version` is now properly rejected on artifact evidence (was previously allowed by accident)
- Moved `Checksum` to the insight module since it's used by both Evidence and Input
- Updated `location` field description to not be PDF-specific