### PR TITLE
Add structured success criteria with output references

### DIFF
--- a/models/analysis.py
+++ b/models/analysis.py
@@ -200,6 +200,29 @@ class Decision(BaseModel):
         return self
 
 
+class SuccessCriterion(BaseModel):
+    """A structured criterion linking a claim to an output and condition."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    claim: str = Field(description="Human-readable statement of the criterion")
+    output: str | None = Field(
+        default=None,
+        description="ID of the output to check against",
+    )
+    condition: str | None = Field(
+        default=None,
+        description="Condition to evaluate, e.g. 'value > 0.95'",
+    )
+
+    @model_validator(mode="after")
+    def validate_condition_requires_output(self) -> SuccessCriterion:
+        """Ensure condition is only set when output is also set."""
+        if self.condition is not None and self.output is None:
+            raise ValueError("'condition' requires 'output' to be set")
+        return self
+
+
 class Analysis(BaseModel):
     """A self-similar analysis specification.
 
@@ -237,9 +260,10 @@ class Analysis(BaseModel):
     description: str | None = Field(
         default=None, description="Detailed description of this analysis"
     )
-    success_criteria: list[str] | None = Field(
+    success_criteria: list[SuccessCriterion] | None = Field(
         default=None,
-        description="Concrete criteria for determining if this analysis succeeded.",
+        description="Concrete criteria for determining if this analysis succeeded. "
+        "Each criterion is a structured object with a claim and optional output reference.",
     )
     inputs: list[Input] | None = Field(
         default=None,

--- a/spec/draft/analysis.schema.json
+++ b/spec/draft/analysis.schema.json
@@ -93,7 +93,7 @@
       "anyOf": [
         {
           "items": {
-            "type": "string"
+            "$ref": "#/$defs/SuccessCriterion"
           },
           "type": "array"
         },
@@ -102,7 +102,7 @@
         }
       ],
       "default": null,
-      "description": "Concrete criteria for determining if this analysis succeeded.",
+      "description": "Concrete criteria for determining if this analysis succeeded. Each criterion is a structured object with a claim and optional output reference.",
       "title": "Success Criteria"
     },
     "inputs": {
@@ -284,7 +284,7 @@
           "anyOf": [
             {
               "items": {
-                "type": "string"
+                "$ref": "#/$defs/SuccessCriterion"
               },
               "type": "array"
             },
@@ -293,7 +293,7 @@
             }
           ],
           "default": null,
-          "description": "Concrete criteria for determining if this analysis succeeded.",
+          "description": "Concrete criteria for determining if this analysis succeeded. Each criterion is a structured object with a claim and optional output reference.",
           "title": "Success Criteria"
         },
         "inputs": {
@@ -1267,6 +1267,48 @@
         }
       },
       "title": "Resources",
+      "type": "object"
+    },
+    "SuccessCriterion": {
+      "additionalProperties": false,
+      "description": "A structured criterion linking a claim to an output and condition.",
+      "properties": {
+        "claim": {
+          "description": "Human-readable statement of the criterion",
+          "title": "Claim",
+          "type": "string"
+        },
+        "output": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "ID of the output to check against",
+          "title": "Output"
+        },
+        "condition": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Condition to evaluate, e.g. 'value > 0.95'",
+          "title": "Condition"
+        }
+      },
+      "required": [
+        "claim"
+      ],
+      "title": "SuccessCriterion",
       "type": "object"
     },
     "TableSelector": {

--- a/src/asp/validation/semantic.py
+++ b/src/asp/validation/semantic.py
@@ -88,6 +88,9 @@ def validate_analysis(data: dict[str, Any]) -> list[SemanticError]:
         if out_id:
             output_ids.add(out_id)
 
+    # Validate success criteria output references
+    errors.extend(_validate_success_criteria(data.get("success_criteria"), output_ids, ""))
+
     # Collect all decisions
     root_decisions = _collect_node_decisions(data)
 
@@ -184,6 +187,10 @@ def _validate_analysis_node(
         if out_id:
             node_output_ids.add(out_id)
 
+    # Validate success criteria output references
+    criteria = node.get("success_criteria")
+    errors.extend(_validate_success_criteria(criteria, node_output_ids, node_path))
+
     # Validate decisions
     # Include parent decisions declared via parent_decisions for constraint resolution
     node_decisions = _collect_node_decisions(node)
@@ -212,6 +219,47 @@ def _validate_analysis_node(
             )
         )
 
+    return errors
+
+
+def _validate_success_criteria(
+    success_criteria: list[Any] | None,
+    output_ids: set[str],
+    path_prefix: str,
+) -> list[SemanticError]:
+    """Validate success criteria output references.
+
+    Structured criteria with an ``output`` field must reference a declared output ID.
+    """
+    errors: list[SemanticError] = []
+    if not success_criteria:
+        return errors
+
+    criteria_prefix = f"{path_prefix}.success_criteria" if path_prefix else "success_criteria"
+    for i, criterion in enumerate(success_criteria):
+        if isinstance(criterion, dict):
+            output_ref = criterion.get("output")
+            condition = criterion.get("condition")
+
+            # condition requires output
+            if condition is not None and output_ref is None:
+                errors.append(
+                    SemanticError(
+                        "CRITERION_CONDITION_NO_OUTPUT",
+                        "Success criterion has 'condition' but no 'output'",
+                        f"{criteria_prefix}[{i}]",
+                    )
+                )
+
+            # output must reference a declared output
+            if output_ref is not None and output_ref not in output_ids:
+                errors.append(
+                    SemanticError(
+                        "INVALID_CRITERION_OUTPUT",
+                        f"Success criterion references non-existent output '{output_ref}'",
+                        f"{criteria_prefix}[{i}]",
+                    )
+                )
     return errors
 
 

--- a/tests/fixtures/invalid/success_criteria_bad_output.yaml
+++ b/tests/fixtures/invalid/success_criteria_bad_output.yaml
@@ -1,0 +1,17 @@
+version: "0.1"
+name: "Invalid output reference"
+description: "Success criterion references non-existent output"
+success_criteria:
+  - claim: "References missing output"
+    output: nonexistent_output
+    condition: "value > 0.5"
+outputs:
+  - id: accuracy
+    type: metric
+decisions:
+  method:
+    label: "Method"
+    default: a
+    options:
+      a:
+        label: "A"

--- a/tests/fixtures/invalid/success_criteria_condition_no_output.yaml
+++ b/tests/fixtures/invalid/success_criteria_condition_no_output.yaml
@@ -1,0 +1,19 @@
+version: "0.1"
+name: "Invalid"
+description: "Condition without output"
+success_criteria:
+  - claim: "Should fail"
+    condition: "value > 0.95"
+inputs:
+  - id: raw_data
+    type: data
+outputs:
+  - id: result
+    type: metric
+decisions:
+  method:
+    label: "Method"
+    default: a
+    options:
+      a:
+        label: "A"

--- a/tests/fixtures/valid/nested.yaml
+++ b/tests/fixtures/valid/nested.yaml
@@ -27,7 +27,7 @@ analyses:
   build_mocks:
     parent_decisions: [cosmology_model]
     success_criteria:
-      - "Mock catalog matches observed magnitude distribution"
+      - claim: "Mock catalog matches observed magnitude distribution"
     inputs:
       - id: survey_data
         type: data

--- a/tests/fixtures/valid/success_criteria.yaml
+++ b/tests/fixtures/valid/success_criteria.yaml
@@ -1,0 +1,22 @@
+version: "0.1"
+name: "Success criteria test"
+description: "Test structured success criteria"
+success_criteria:
+  - claim: "Simple string criterion"
+  - claim: "Classification accuracy exceeds 95%"
+    output: accuracy
+    condition: "value > 0.95"
+  - claim: "Posterior contours are clean"
+inputs:
+  - id: raw_data
+    type: data
+outputs:
+  - id: accuracy
+    type: metric
+decisions:
+  method:
+    label: "Method"
+    default: a
+    options:
+      a:
+        label: "A"

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -381,9 +381,7 @@ class TestSuccessCriteriaValidation:
 
     def test_bad_output_reference(self, invalid_dir: Path):
         """Criterion referencing non-existent output should fail semantic validation."""
-        errors = validate_analysis_file(
-            invalid_dir / "success_criteria_bad_output.yaml"
-        )
+        errors = validate_analysis_file(invalid_dir / "success_criteria_bad_output.yaml")
         assert any(e.code == "INVALID_CRITERION_OUTPUT" for e in errors)
 
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -374,9 +374,7 @@ class TestSuccessCriteriaValidation:
 
     def test_condition_without_output(self, invalid_dir: Path):
         """Condition set without output should fail semantic validation."""
-        errors = validate_analysis_file(
-            invalid_dir / "success_criteria_condition_no_output.yaml"
-        )
+        errors = validate_analysis_file(invalid_dir / "success_criteria_condition_no_output.yaml")
         assert any(e.code == "CRITERION_CONDITION_NO_OUTPUT" for e in errors)
 
     def test_bad_output_reference(self, invalid_dir: Path):

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -359,6 +359,34 @@ class TestUniverseNewFeaturesValidation:
         assert any(e.code == "INACTIVE_DECISION" for e in errors)
 
 
+class TestSuccessCriteriaValidation:
+    """Tests for structured success criteria."""
+
+    def test_valid_success_criteria(self, valid_dir: Path):
+        """Structured criteria with valid output refs should pass."""
+        errors = validate_analysis_file(valid_dir / "success_criteria.yaml")
+        assert errors == []
+
+    def test_valid_success_criteria_schema(self, valid_dir: Path):
+        """Structured success criteria should pass schema validation."""
+        errors = validate_analysis_schema(valid_dir / "success_criteria.yaml")
+        assert errors == []
+
+    def test_condition_without_output(self, invalid_dir: Path):
+        """Condition set without output should fail semantic validation."""
+        errors = validate_analysis_file(
+            invalid_dir / "success_criteria_condition_no_output.yaml"
+        )
+        assert any(e.code == "CRITERION_CONDITION_NO_OUTPUT" for e in errors)
+
+    def test_bad_output_reference(self, invalid_dir: Path):
+        """Criterion referencing non-existent output should fail semantic validation."""
+        errors = validate_analysis_file(
+            invalid_dir / "success_criteria_bad_output.yaml"
+        )
+        assert any(e.code == "INVALID_CRITERION_OUTPUT" for e in errors)
+
+
 class TestSemanticError:
     """Tests for SemanticError class."""
 


### PR DESCRIPTION
## Summary

**Breaking change:** Replaces plain-string `success_criteria` with structured `SuccessCriterion` objects. Existing YAML files using string criteria will fail validation and must be updated.

**Before:**
```yaml
success_criteria:
  - "Accuracy > 95%"
```

**After:**
```yaml
success_criteria:
  - claim: "Accuracy > 95%"
    output: accuracy
    condition: "value > 0.95"
```

### Why

Prism's execution loop needs to programmatically verify whether analysis outputs satisfy success criteria. With plain strings, this required fragile pattern-matching against freeform text. Structured criteria let the build loop match a criterion to a specific declared output and evaluate a concrete condition against the result file — making automated verification reliable.

Each `SuccessCriterion` has:
- **`claim`** (required): Human-readable statement
- **`output`** (optional): ID of a declared output to check against
- **`condition`** (optional, requires `output`): Expression to evaluate against the output value

Criteria with only a `claim` still work for qualitative judgments that can't be automated (e.g., "Posterior contours are clean").

### Migration

Any existing YAML with string success criteria must be updated. At minimum, wrap each string in a `claim` field:
```yaml
# Old
success_criteria:
  - "Some criterion"

# New (minimal migration)
success_criteria:
  - claim: "Some criterion"
```

## Changes

- **`models/analysis.py`**: New `SuccessCriterion` model; `success_criteria` type changed from `list[str] | None` to `list[SuccessCriterion] | None`
- **`src/asp/validation/semantic.py`**: Validates that `output` references exist in declared outputs, and that `condition` requires `output`
- **`spec/draft/analysis.schema.json`**: Regenerated from model
- **`tests/`**: Fixtures and tests for valid/invalid structured criteria (120 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)