### PR TITLE
Fix evidence verification taking 10+ minutes on large papers

### DIFF
--- a/src/astra/verification/core.py
+++ b/src/astra/verification/core.py
@@ -338,8 +338,90 @@ def verify_all_insights(
     if verification_cache is None:
         verification_cache = VerificationCache()
 
+    # Pre-extract PDFs once per unique (DOI, version) to avoid redundant parsing.
+    # This is critical for performance: a single 23MB PDF can take seconds to parse,
+    # and without caching it would be re-parsed for every evidence item that references it.
+    pdf_cache: dict[tuple[str, int | None], PDFDocument | None] = {}
+
+    # Collect all unique (DOI, version) pairs across all insights
+    for insight in insights.values():
+        for ev in _get_attr(insight, "evidence", []):
+            doi = _get_attr(ev, "doi", "")
+            version = _get_attr(ev, "version")
+            key = (doi, version)
+            if key not in pdf_cache:
+                cached_paper = paper_cache.get(doi, version)
+                if cached_paper is None:
+                    pdf_cache[key] = None
+                else:
+                    try:
+                        pdf_cache[key] = extract_text_from_pdf(cached_paper.pdf_path)
+                    except Exception:
+                        pdf_cache[key] = None
+
     results = {}
     for insight_id, insight in insights.items():
-        results[insight_id] = verify_insight(insight, paper_cache, verification_cache)
+        results[insight_id] = _verify_insight_with_pdf_cache(
+            insight, paper_cache, verification_cache, pdf_cache
+        )
 
     return results
+
+
+def _verify_insight_with_pdf_cache(
+    insight: Any,
+    paper_cache: PaperCache,
+    verification_cache: VerificationCache,
+    pdf_cache: dict[tuple[str, int | None], PDFDocument | None],
+) -> InsightVerification:
+    """Verify all evidence for an insight using pre-extracted PDFs.
+
+    Args:
+        insight: The insight to verify (dict or Insight object).
+        paper_cache: Cache for downloaded papers.
+        verification_cache: Cache for verification results.
+        pdf_cache: Pre-extracted PDF documents keyed by (DOI, version).
+
+    Returns:
+        InsightVerification with results for all evidence.
+    """
+    insight_id = _get_attr(insight, "id", "unknown")
+    evidence_list = _get_attr(insight, "evidence", [])
+
+    evidence_results: list[EvidenceVerification] = []
+
+    for ev in evidence_list:
+        evidence_id = _get_attr(ev, "id", "unknown")
+        doi = _get_attr(ev, "doi", "")
+        version = _get_attr(ev, "version")
+        key = (doi, version)
+
+        pdf = pdf_cache.get(key)
+        if pdf is None:
+            # Check if paper exists but failed to parse vs not in cache
+            cached_paper = paper_cache.get(doi, version)
+            if not cached_paper:
+                msg = f"Paper not in cache: {doi} (use 'astra paper add' first)"
+            else:
+                msg = f"Failed to extract text from PDF: {doi}"
+            evidence_results.append(
+                EvidenceVerification(
+                    evidence_id=evidence_id,
+                    doi=doi,
+                    version=version,
+                    status=VerificationStatus.ERROR,
+                    message=msg,
+                )
+            )
+            continue
+
+        result = verify_evidence(ev, pdf, verification_cache)
+        evidence_results.append(result)
+
+    overall = _determine_overall_status(evidence_results)
+
+    return InsightVerification(
+        insight_id=insight_id,
+        evidence_results=evidence_results,
+        overall_status=overall,
+    )

--- a/src/astra/verification/pdf.py
+++ b/src/astra/verification/pdf.py
@@ -6,6 +6,7 @@ Extracts text from PDFs for quote verification using RapidFuzz for robust matchi
 from __future__ import annotations
 
 import hashlib
+import json
 import re
 import unicodedata
 from dataclasses import dataclass, field
@@ -237,6 +238,12 @@ class PDFDocument:
     pages: list[str] = field(default_factory=list)
     num_pages: int = 0
     sha256: str = ""
+    _normalized_pages: list[str] = field(default_factory=list, repr=False)
+
+    def __post_init__(self) -> None:
+        """Pre-normalize all page texts for efficient fuzzy matching."""
+        if self.pages and not self._normalized_pages:
+            self._normalized_pages = [_normalize_processor(p) for p in self.pages]
 
     def get_page_text(self, page: int) -> str | None:
         """Get text for a specific page (1-indexed as per FragmentSelector).
@@ -281,6 +288,18 @@ class PDFDocument:
             List of 1-indexed page numbers where quote was found.
         """
         found_pages = []
+        norm_quote = _normalize_processor(quote)
+
+        # Pre-normalize context if prefix/suffix provided
+        norm_context = None
+        if prefix or suffix:
+            context_parts = []
+            if prefix:
+                context_parts.append(prefix.strip())
+            context_parts.append(quote.strip())
+            if suffix:
+                context_parts.append(suffix.strip())
+            norm_context = _normalize_processor(" ".join(context_parts))
 
         # Search pages (prioritize hint page if provided)
         pages_to_search = list(range(self.num_pages))
@@ -290,53 +309,31 @@ class PDFDocument:
             pages_to_search.insert(0, page - 1)
 
         for page_idx in pages_to_search:
-            page_text = self.pages[page_idx]
+            norm_page = self._normalized_pages[page_idx]
 
-            # Use partial_ratio which finds the best matching substring
-            # _normalize_processor handles Greek letters, math symbols, and lowercasing
-            score = fuzz.partial_ratio(quote, page_text, processor=_normalize_processor)
+            # Use partial_ratio with processor=None since texts are pre-normalized
+            score = fuzz.partial_ratio(norm_quote, norm_page, processor=None)
 
             if score >= min_score:
                 # If prefix/suffix provided, verify context matches too
-                if prefix or suffix:
-                    if not self._verify_context(page_text, quote, prefix, suffix):
+                if norm_context is not None:
+                    ctx_score = fuzz.partial_ratio(norm_context, norm_page, processor=None)
+                    if ctx_score < 80.0:
                         continue
                 found_pages.append(page_idx + 1)
+                # Early return: for verification we only need to confirm the quote exists
+                # on at least one page. Searching all remaining pages is unnecessary.
+                return found_pages
 
         return found_pages
-
-    def _verify_context(
-        self,
-        page_text: str,
-        quote: str,
-        prefix: str | None,
-        suffix: str | None,
-    ) -> bool:
-        """Verify that prefix/suffix context matches around the quote.
-
-        Uses fuzzy matching to find if the context appears in the expected order.
-        The full context (prefix + quote + suffix) must appear as a sequence.
-        """
-        # Build a context pattern: prefix + quote + suffix
-        context_parts = []
-        if prefix:
-            context_parts.append(prefix.strip())
-        context_parts.append(quote.strip())
-        if suffix:
-            context_parts.append(suffix.strip())
-
-        # Join with flexible whitespace matching
-        context = " ".join(context_parts)
-
-        # Check if this context appears in the page with high confidence
-        # Use a higher threshold since we want the full context to match
-        # _normalize_processor handles Greek letters, math symbols, and lowercasing
-        score = fuzz.partial_ratio(context, page_text, processor=_normalize_processor)
-        return score >= 80.0
 
 
 def extract_text_from_pdf(pdf_path: Path) -> PDFDocument:
     """Extract text from a PDF file.
+
+    Uses a disk cache (_text_cache.json) alongside the PDF to avoid re-extracting
+    text on subsequent runs. pypdf text extraction can be very slow on large PDFs
+    (e.g., 2+ minutes for a 23MB paper), so caching is critical for performance.
 
     Args:
         pdf_path: Path to the PDF file.
@@ -353,9 +350,36 @@ def extract_text_from_pdf(pdf_path: Path) -> PDFDocument:
     pdf_bytes = pdf_path.read_bytes()
     sha256 = hashlib.sha256(pdf_bytes).hexdigest()
 
+    # Check for cached extracted text (stored in user's cache dir to avoid
+    # permission issues when papers are in another user's directory)
+    text_cache_dir = Path.home() / ".cache" / "astra" / "text_cache"
+    cache_path = text_cache_dir / f"{sha256}.json"
+    if cache_path.exists():
+        try:
+            with open(cache_path) as f:
+                cached = json.load(f)
+            if cached.get("pdf_sha256") == sha256:
+                pages = cached["pages"]
+                return PDFDocument(
+                    path=pdf_path,
+                    pages=pages,
+                    num_pages=len(pages),
+                    sha256=sha256,
+                )
+        except (json.JSONDecodeError, KeyError):
+            pass
+
     # Extract text by page using pypdf
     reader = PdfReader(pdf_path)
     pages = [page.extract_text() or "" for page in reader.pages]
+
+    # Cache extracted text for future runs
+    try:
+        text_cache_dir.mkdir(parents=True, exist_ok=True)
+        with open(cache_path, "w") as f:
+            json.dump({"pdf_sha256": sha256, "pages": pages}, f)
+    except OSError:
+        pass  # Non-fatal: caching is an optimization
 
     return PDFDocument(
         path=pdf_path,


### PR DESCRIPTION
## Summary

- **Fix redundant PDF parsing**: Pre-extract each unique PDF once per `verify_all_insights` call instead of re-parsing for every evidence item. A 23MB ExoMiner paper was being parsed 5 separate times (~125s each).
- **Add disk-based text extraction cache**: Cache pypdf's extracted page text to `~/.cache/astra/text_cache/<sha256>.json` so the expensive extraction only happens once per PDF, ever. Stored in the user's home dir to handle cross-user paper caches.
- **Optimize fuzzy matching**: Pre-normalize page texts once in `PDFDocument.__post_init__`, use `processor=None` for rapidfuzz calls (enables C-optimized paths), and early-return from `find_quote` after the first matching page.

### Why the old system was slow

The old pipeline had three compounding bottlenecks:

1. `verify_all_insights` → `verify_insight` → `extract_text_from_pdf` was called **per evidence item**, not per unique paper. With 23 evidence items referencing 5 papers, the same PDFs were extracted up to 5x each.
2. `pypdf.extract_text()` is inherently slow on large/complex PDFs (125s for the 47-page ExoMiner paper). This cost was paid from scratch on every validation run.
3. `fuzz.partial_ratio` was called with a Python `processor=` callable, which prevented rapidfuzz's C-optimized code path. Combined with searching all 47 pages (even after finding a match) and re-normalizing text on every call, a single quote search took 121s across the ExoMiner paper.

### Benchmarks

On an `astra.yaml` with 23 evidence items across 5 papers (including a 23MB/47-page PDF):

| Scenario | Time |
|----------|------|
| Before (every run) | **~11 min** |
| After — cold (first run, must extract PDFs) | **~2 min 14s** |
| After — warm (text cache populated) | **~0.56s** |

Also tested on `spherex-redshift` (20 evidence items, 4.0s) and `spherex-z-sbi` (12 evidence items, 1.3s).

## Test plan

- [x] All 120 existing tests pass (21 skipped as before)
- [x] Verified 23/23 evidence items on original astra.yaml
- [x] Verified spherex-redshift: 8/8 available papers verified (12 correctly report missing papers)
- [x] Verified spherex-z-sbi: 12/12 verified
- [x] Text cache files correctly created in `~/.cache/astra/text_cache/`
- [x] Cache invalidation works (keyed by PDF SHA-256)

🤖 Generated with [Claude Code](https://claude.com/claude-code)