### PR TITLE
Add when conditions on outputs with negation and list support

### DIFF
--- a/models/analysis.py
+++ b/models/analysis.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import re
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+# Pattern for when condition strings: optional ~ prefix, then decision_id.option_id
+WHEN_PATTERN = re.compile(r"^~?[a-z][a-z0-9_]*\.[a-z][a-z0-9_]*$")
 
 
 class Checksum(BaseModel):
@@ -141,11 +145,32 @@ class Output(BaseModel):
         "(e.g., 'sub_analysis.output_id')",
     )
 
+    # Conditional: when this output is active
+    when: str | list[str] | None = Field(
+        default=None,
+        description="Condition(s): 'decision_id.option_id' or '~decision_id.option_id' — "
+        "this output only exists when all conditions are met. "
+        "Prefix with ~ for negation. Lists are AND'd together.",
+    )
+
     # Execution: how to produce this output
     recipe: Recipe | None = Field(
         default=None,
         description="Inline recipe describing how to produce this output",
     )
+
+    @model_validator(mode="after")
+    def validate_when_format(self) -> Output:
+        """Validate that each when condition matches the expected pattern."""
+        if self.when is not None:
+            conditions = [self.when] if isinstance(self.when, str) else self.when
+            for cond in conditions:
+                if not WHEN_PATTERN.match(cond):
+                    raise ValueError(
+                        f"Invalid 'when' condition '{cond}': must match "
+                        "'[~]decision_id.option_id'"
+                    )
+        return self
 
 
 class Option(BaseModel):
@@ -182,10 +207,11 @@ class Decision(BaseModel):
     tags: list[str] | None = Field(
         default=None, description="Tags for grouping and categorizing this decision"
     )
-    when: str | None = Field(
+    when: str | list[str] | None = Field(
         default=None,
-        pattern=r"^[a-z][a-z0-9_]*\.[a-z][a-z0-9_]*$",
-        description="Condition: 'decision_id.option_id' — this decision only exists when that option is selected",
+        description="Condition(s): 'decision_id.option_id' or '~decision_id.option_id' — "
+        "this decision only exists when all conditions are met. "
+        "Prefix with ~ for negation. Lists are AND'd together.",
     )
     default: str | None = Field(
         default=None, description="Default option ID for baseline universes"
@@ -193,10 +219,18 @@ class Decision(BaseModel):
     options: dict[str, Option] = Field(description="Map of option IDs to option specifications")
 
     @model_validator(mode="after")
-    def validate_default_exists(self) -> Decision:
-        """Ensure default option exists in options."""
+    def validate_decision(self) -> Decision:
+        """Validate default option exists and when conditions have valid format."""
         if self.default is not None and self.default not in self.options:
             raise ValueError(f"Default option '{self.default}' not found in options")
+        if self.when is not None:
+            conditions = [self.when] if isinstance(self.when, str) else self.when
+            for cond in conditions:
+                if not WHEN_PATTERN.match(cond):
+                    raise ValueError(
+                        f"Invalid 'when' condition '{cond}': must match "
+                        "'[~]decision_id.option_id'"
+                    )
         return self
 
 

--- a/spec/draft/analysis.schema.json
+++ b/spec/draft/analysis.schema.json
@@ -493,15 +493,20 @@
         "when": {
           "anyOf": [
             {
-              "pattern": "^[a-z][a-z0-9_]*\\.[a-z][a-z0-9_]*$",
               "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
             },
             {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Condition: 'decision_id.option_id' \u2014 this decision only exists when that option is selected",
+          "description": "Condition(s): 'decision_id.option_id' or '~decision_id.option_id' \u2014 this decision only exists when all conditions are met. Prefix with ~ for negation. Lists are AND'd together.",
           "title": "When"
         },
         "default": {
@@ -1126,6 +1131,25 @@
           "default": null,
           "description": "Sub-analysis output that produces this (e.g., 'sub_analysis.output_id')",
           "title": "From"
+        },
+        "when": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Condition(s): 'decision_id.option_id' or '~decision_id.option_id' \u2014 this output only exists when all conditions are met. Prefix with ~ for negation. Lists are AND'd together.",
+          "title": "When"
         },
         "recipe": {
           "anyOf": [

--- a/src/astra/helpers.py
+++ b/src/astra/helpers.py
@@ -15,6 +15,37 @@ import yaml
 logger = logging.getLogger(__name__)
 
 
+def is_condition_met(
+    when: str | list[str] | None,
+    universe_decisions: dict[str, str],
+) -> bool:
+    """Check if a when condition is met given universe decisions.
+
+    Args:
+        when: A string, list of strings, or None. Each string is
+            ``decision_id.option_id`` or ``~decision_id.option_id`` (negation).
+            Multiple items are AND'd together.
+        universe_decisions: Dict mapping decision_id to selected option_id.
+
+    Returns:
+        True if the condition is met (or when is None), False otherwise.
+    """
+    if when is None:
+        return True
+    conditions = [when] if isinstance(when, str) else when
+    for cond in conditions:
+        negate = cond.startswith("~")
+        ref = cond.lstrip("~")
+        decision_id, option_id = ref.split(".")
+        selected = universe_decisions.get(decision_id)
+        match = selected == option_id
+        if negate:
+            match = not match
+        if not match:
+            return False  # AND logic: all must be true
+    return True
+
+
 def _collect_node_decisions(node: dict[str, Any]) -> dict[str, Any]:
     """Collect decisions from a node."""
     decisions: dict[str, Any] = dict(node.get("decisions") or {})
@@ -185,13 +216,10 @@ def _get_node_defaults(node: dict[str, Any]) -> dict[str, Any]:
         when = decision.get("when")
         if not when:
             continue
-        when_parts = when.split(".")
-        if len(when_parts) == 2:
-            when_decision_id, when_option_id = when_parts
-            if decisions.get(when_decision_id) == when_option_id:
-                default = decision.get("default")
-                if default is not None:
-                    decisions[decision_id] = default
+        if is_condition_met(when, decisions):
+            default = decision.get("default")
+            if default is not None:
+                decisions[decision_id] = default
 
     if decisions:
         result["decisions"] = decisions

--- a/src/astra/validation/semantic.py
+++ b/src/astra/validation/semantic.py
@@ -323,9 +323,7 @@ def _validate_decisions(
                         ref_decision = decisions.get(when_decision_id) or (
                             constraint_scope or {}
                         ).get(when_decision_id)
-                        if ref_decision and when_option_id not in ref_decision.get(
-                            "options", {}
-                        ):
+                        if ref_decision and when_option_id not in ref_decision.get("options", {}):
                             errors.append(
                                 SemanticError(
                                     "INVALID_WHEN_REF",

--- a/src/astra/validation/semantic.py
+++ b/src/astra/validation/semantic.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from astra.helpers import _collect_node_decisions, load_yaml
+from astra.helpers import _collect_node_decisions, is_condition_met, load_yaml
 
 
 class SemanticError:
@@ -99,6 +99,9 @@ def validate_analysis(data: dict[str, Any]) -> list[SemanticError]:
 
     # Validate output recipes
     errors.extend(_validate_output_recipes(outputs, ""))
+
+    # Validate output when conditions
+    errors.extend(_validate_output_when(outputs, root_decisions, ""))
 
     # Validate sub-analyses recursively
     sub_analyses = data.get("analyses") or {}
@@ -204,6 +207,9 @@ def _validate_analysis_node(
     node_outputs = node.get("outputs") or []
     errors.extend(_validate_output_recipes(node_outputs, node_path))
 
+    # Validate output when conditions
+    errors.extend(_validate_output_when(node_outputs, constraint_scope, node_path))
+
     # Recurse into sub-analyses
     sub_analyses = node.get("analyses") or {}
     for sub_id, sub_node in sub_analyses.items():
@@ -298,40 +304,45 @@ def _validate_decisions(
         # Check `when` condition references a valid decision.option
         when = decision.get("when")
         if when:
-            when_parts = when.split(".")
-            if len(when_parts) == 2:
-                when_decision_id, when_option_id = when_parts
-                scope = constraint_scope or {}
-                if when_decision_id not in decisions and when_decision_id not in scope:
-                    errors.append(
-                        SemanticError(
-                            "INVALID_WHEN_REF",
-                            f"'when' references non-existent decision '{when_decision_id}'",
-                            decision_path,
-                        )
-                    )
-                else:
-                    ref_decision = decisions.get(when_decision_id) or (constraint_scope or {}).get(
-                        when_decision_id
-                    )
-                    if ref_decision and when_option_id not in ref_decision.get("options", {}):
+            conditions = [when] if isinstance(when, str) else when
+            for cond in conditions:
+                ref = cond.lstrip("~")
+                when_parts = ref.split(".")
+                if len(when_parts) == 2:
+                    when_decision_id, when_option_id = when_parts
+                    scope = constraint_scope or {}
+                    if when_decision_id not in decisions and when_decision_id not in scope:
                         errors.append(
                             SemanticError(
                                 "INVALID_WHEN_REF",
-                                f"'when' references non-existent option '{when_option_id}' "
-                                f"in decision '{when_decision_id}'",
+                                f"'when' references non-existent decision '{when_decision_id}'",
                                 decision_path,
                             )
                         )
-                # Check no self-reference
-                if when_decision_id == decision_id:
-                    errors.append(
-                        SemanticError(
-                            "INVALID_WHEN_REF",
-                            "'when' cannot reference own decision",
-                            decision_path,
+                    else:
+                        ref_decision = decisions.get(when_decision_id) or (
+                            constraint_scope or {}
+                        ).get(when_decision_id)
+                        if ref_decision and when_option_id not in ref_decision.get(
+                            "options", {}
+                        ):
+                            errors.append(
+                                SemanticError(
+                                    "INVALID_WHEN_REF",
+                                    f"'when' references non-existent option '{when_option_id}' "
+                                    f"in decision '{when_decision_id}'",
+                                    decision_path,
+                                )
+                            )
+                    # Check no self-reference
+                    if when_decision_id == decision_id:
+                        errors.append(
+                            SemanticError(
+                                "INVALID_WHEN_REF",
+                                "'when' cannot reference own decision",
+                                decision_path,
+                            )
                         )
-                    )
 
         # Validate options
         for option_id, option in options.items():
@@ -390,6 +401,65 @@ def _validate_decisions(
                         decision_path,
                     )
                 )
+
+    return errors
+
+
+def _validate_output_when(
+    outputs: list[dict[str, Any]],
+    decisions: dict[str, Any],
+    path_prefix: str,
+) -> list[SemanticError]:
+    """Validate ``when`` conditions on outputs.
+
+    Checks that each referenced decision.option exists in the available decisions.
+    """
+    errors: list[SemanticError] = []
+    outputs_prefix = f"{path_prefix}.outputs" if path_prefix else "outputs"
+
+    for out in outputs:
+        out_id = out.get("id")
+        if not out_id:
+            continue
+        when = out.get("when")
+        if not when:
+            continue
+
+        conditions = [when] if isinstance(when, str) else when
+        output_path = f"{outputs_prefix}.{out_id}"
+
+        for cond in conditions:
+            ref = cond.lstrip("~")
+            parts = ref.split(".")
+            if len(parts) != 2:
+                errors.append(
+                    SemanticError(
+                        "INVALID_WHEN_REF",
+                        f"Output 'when' condition '{cond}' has invalid format",
+                        output_path,
+                    )
+                )
+                continue
+            decision_id, option_id = parts
+            if decision_id not in decisions:
+                errors.append(
+                    SemanticError(
+                        "INVALID_WHEN_REF",
+                        f"Output 'when' references non-existent decision '{decision_id}'",
+                        output_path,
+                    )
+                )
+            else:
+                ref_decision = decisions[decision_id]
+                if option_id not in ref_decision.get("options", {}):
+                    errors.append(
+                        SemanticError(
+                            "INVALID_WHEN_REF",
+                            f"Output 'when' references non-existent option '{option_id}' "
+                            f"in decision '{decision_id}'",
+                            output_path,
+                        )
+                    )
 
     return errors
 
@@ -642,6 +712,10 @@ def _validate_universe_node(
                     )
                 )
 
+    # Merge current and parent universe decisions for condition evaluation
+    all_universe_decisions = dict(parent_universe_decisions)
+    all_universe_decisions.update(universe_decisions)
+
     # Check all analysis decisions are covered (respecting conditional decisions)
     for decision_id in analysis_decisions:
         decision = analysis_decisions[decision_id]
@@ -649,25 +723,18 @@ def _validate_universe_node(
 
         # If conditional, check if the condition is met
         if when:
-            when_parts = when.split(".")
-            if len(when_parts) == 2:
-                when_decision_id, when_option_id = when_parts
-                # Look in current universe decisions and parent decisions
-                selected = universe_decisions.get(when_decision_id)
-                if selected is None:
-                    selected = parent_universe_decisions.get(when_decision_id)
-                if selected != when_option_id:
-                    # Condition not met — this decision should NOT be in the universe
-                    if decision_id in universe_decisions:
-                        errors.append(
-                            SemanticError(
-                                "INACTIVE_DECISION",
-                                f"Universe specifies decision '{decision_id}' but its condition "
-                                f"'{when}' is not met ('{when_decision_id}' = '{selected}')",
-                                f"{decisions_path}.{decision_id}",
-                            )
+            if not is_condition_met(when, all_universe_decisions):
+                # Condition not met -- this decision should NOT be in the universe
+                if decision_id in universe_decisions:
+                    errors.append(
+                        SemanticError(
+                            "INACTIVE_DECISION",
+                            f"Universe specifies decision '{decision_id}' but its condition "
+                            f"'{when}' is not met",
+                            f"{decisions_path}.{decision_id}",
                         )
-                    continue  # Skip the missing check
+                    )
+                continue  # Skip the missing check
 
         if decision_id not in universe_decisions:
             errors.append(

--- a/tests/fixtures/invalid/invalid_output_when_ref.yaml
+++ b/tests/fixtures/invalid/invalid_output_when_ref.yaml
@@ -1,0 +1,17 @@
+# Output with when referencing a non-existent decision
+version: "1.0"
+name: "Invalid Output When"
+inputs:
+  - id: data
+    type: data
+outputs:
+  - id: result
+    type: metric
+    when: nonexistent_decision.option_a
+decisions:
+  model:
+    label: "Model"
+    default: a
+    options:
+      a:
+        label: "A"

--- a/tests/fixtures/valid/conditional_outputs.yaml
+++ b/tests/fixtures/valid/conditional_outputs.yaml
@@ -1,0 +1,58 @@
+# Analysis with conditional outputs using when conditions
+version: "1.0"
+name: "Conditional Outputs Analysis"
+description: "Tests when conditions on outputs with negation and lists"
+inputs:
+  - id: training_data
+    type: data
+    source: "data/train.csv"
+outputs:
+  - id: trained_model
+    type: data
+    recipe:
+      command: python scripts/train.py
+
+  # Only produced when training_sample is not bright_only
+  - id: faint_metrics
+    type: metric
+    when: "~training_sample.bright_only"
+    recipe:
+      command: python scripts/evaluate.py
+      inputs: [trained_model]
+
+  # Only produced when model is svm
+  - id: svm_report
+    type: report
+    when: model.svm
+    recipe:
+      command: python scripts/svm_report.py
+      inputs: [trained_model]
+
+  # Only produced when multiple conditions met (AND)
+  - id: combined_report
+    type: report
+    when:
+      - "~training_sample.bright_only"
+      - model.svm
+    recipe:
+      command: python scripts/combined.py
+      inputs: [trained_model]
+
+decisions:
+  training_sample:
+    label: "Training Sample"
+    default: combined
+    options:
+      combined:
+        label: "Combined"
+      bright_only:
+        label: "Bright Only"
+
+  model:
+    label: "Model Type"
+    default: rf
+    options:
+      svm:
+        label: "SVM"
+      rf:
+        label: "Random Forest"

--- a/tests/fixtures/valid/conditional_outputs_universe.yaml
+++ b/tests/fixtures/valid/conditional_outputs_universe.yaml
@@ -1,0 +1,6 @@
+# Universe for conditional outputs analysis
+id: baseline
+description: "Baseline universe with combined sample and RF"
+decisions:
+  training_sample: combined
+  model: rf

--- a/tests/fixtures/valid/decision_list_when.yaml
+++ b/tests/fixtures/valid/decision_list_when.yaml
@@ -1,0 +1,40 @@
+# Analysis with a decision that has a list-valued when condition
+version: "1.0"
+name: "Decision List When"
+description: "Tests list-valued when on decisions"
+inputs:
+  - id: data
+    type: data
+outputs:
+  - id: result
+    type: metric
+decisions:
+  mode:
+    label: "Mode"
+    default: advanced
+    options:
+      basic:
+        label: "Basic"
+      advanced:
+        label: "Advanced"
+
+  backend:
+    label: "Backend"
+    default: gpu
+    options:
+      cpu:
+        label: "CPU"
+      gpu:
+        label: "GPU"
+
+  gpu_optimization:
+    label: "GPU Optimization"
+    when:
+      - mode.advanced
+      - backend.gpu
+    default: tensor_cores
+    options:
+      tensor_cores:
+        label: "Tensor Cores"
+      standard:
+        label: "Standard"

--- a/tests/fixtures/valid/decision_list_when_universe.yaml
+++ b/tests/fixtures/valid/decision_list_when_universe.yaml
@@ -1,0 +1,7 @@
+# Universe where list when condition is met
+id: gpu_advanced
+description: "Advanced mode with GPU"
+decisions:
+  mode: advanced
+  backend: gpu
+  gpu_optimization: tensor_cores

--- a/tests/fixtures/valid/decision_list_when_universe_inactive.yaml
+++ b/tests/fixtures/valid/decision_list_when_universe_inactive.yaml
@@ -1,0 +1,7 @@
+# Universe where list when condition is NOT met (basic mode)
+# gpu_optimization should not be present
+id: cpu_basic
+description: "Basic mode with CPU - gpu_optimization is inactive"
+decisions:
+  mode: basic
+  backend: cpu

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -497,9 +497,7 @@ class TestConditionalOutputs:
             },
         }
         errors = validate_analysis(data)
-        assert any(
-            e.code == "INVALID_WHEN_REF" and "nonexistent" in e.message for e in errors
-        )
+        assert any(e.code == "INVALID_WHEN_REF" and "nonexistent" in e.message for e in errors)
 
     def test_decision_when_list(self, valid_dir: Path):
         """Decision with list-valued when should pass validation."""
@@ -557,9 +555,7 @@ class TestConditionalOutputsUniverse:
     def test_decision_list_when_inactive(self, valid_dir: Path):
         """Universe where list when condition is NOT met should skip the decision."""
         analysis_data = load_yaml(valid_dir / "decision_list_when.yaml")
-        universe_data = load_yaml(
-            valid_dir / "decision_list_when_universe_inactive.yaml"
-        )
+        universe_data = load_yaml(valid_dir / "decision_list_when_universe_inactive.yaml")
         errors = validate_universe(universe_data, analysis_data)
         assert errors == []
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -396,3 +396,282 @@ class TestSemanticError:
         error = SemanticError("TEST_CODE", "Test message")
         assert "[TEST_CODE]" in str(error)
         assert "Test message" in str(error)
+
+
+class TestConditionalOutputs:
+    """Tests for conditional outputs with when conditions."""
+
+    def test_valid_output_with_when(self, valid_dir: Path):
+        """Output with a valid when condition should pass validation."""
+        errors = validate_analysis_file(valid_dir / "conditional_outputs.yaml")
+        assert errors == []
+
+    def test_output_when_negation(self):
+        """Output with ~decision.option negation should pass validation."""
+        data = {
+            "version": "1.0",
+            "name": "test",
+            "inputs": [],
+            "outputs": [
+                {"id": "base", "type": "data"},
+                {
+                    "id": "faint_only",
+                    "type": "metric",
+                    "when": "~sample.bright_only",
+                },
+            ],
+            "decisions": {
+                "sample": {
+                    "label": "Sample",
+                    "default": "combined",
+                    "options": {
+                        "combined": {"label": "Combined"},
+                        "bright_only": {"label": "Bright Only"},
+                    },
+                }
+            },
+        }
+        errors = validate_analysis(data)
+        assert errors == []
+
+    def test_output_when_list(self):
+        """Output with when as list (AND logic) should pass validation."""
+        data = {
+            "version": "1.0",
+            "name": "test",
+            "inputs": [],
+            "outputs": [
+                {"id": "base", "type": "data"},
+                {
+                    "id": "combined_report",
+                    "type": "report",
+                    "when": ["~sample.bright_only", "model.svm"],
+                },
+            ],
+            "decisions": {
+                "sample": {
+                    "label": "Sample",
+                    "default": "combined",
+                    "options": {
+                        "combined": {"label": "Combined"},
+                        "bright_only": {"label": "Bright Only"},
+                    },
+                },
+                "model": {
+                    "label": "Model",
+                    "default": "svm",
+                    "options": {
+                        "svm": {"label": "SVM"},
+                        "rf": {"label": "RF"},
+                    },
+                },
+            },
+        }
+        errors = validate_analysis(data)
+        assert errors == []
+
+    def test_invalid_output_when_ref(self, invalid_dir: Path):
+        """Output when referencing non-existent decision should fail."""
+        errors = validate_analysis_file(invalid_dir / "invalid_output_when_ref.yaml")
+        assert any(e.code == "INVALID_WHEN_REF" for e in errors)
+
+    def test_invalid_output_when_bad_option(self):
+        """Output when referencing non-existent option should fail."""
+        data = {
+            "version": "1.0",
+            "name": "test",
+            "inputs": [],
+            "outputs": [
+                {
+                    "id": "result",
+                    "type": "metric",
+                    "when": "model.nonexistent",
+                },
+            ],
+            "decisions": {
+                "model": {
+                    "label": "Model",
+                    "default": "a",
+                    "options": {"a": {"label": "A"}},
+                }
+            },
+        }
+        errors = validate_analysis(data)
+        assert any(
+            e.code == "INVALID_WHEN_REF" and "nonexistent" in e.message for e in errors
+        )
+
+    def test_decision_when_list(self, valid_dir: Path):
+        """Decision with list-valued when should pass validation."""
+        errors = validate_analysis_file(valid_dir / "decision_list_when.yaml")
+        assert errors == []
+
+    def test_decision_when_negation(self):
+        """Decision with ~decision.option negation should pass validation."""
+        data = {
+            "version": "1.0",
+            "name": "test",
+            "inputs": [],
+            "outputs": [{"id": "result", "type": "metric"}],
+            "decisions": {
+                "mode": {
+                    "label": "Mode",
+                    "default": "full",
+                    "options": {
+                        "full": {"label": "Full"},
+                        "lite": {"label": "Lite"},
+                    },
+                },
+                "advanced_setting": {
+                    "label": "Advanced",
+                    "when": "~mode.lite",
+                    "default": "on",
+                    "options": {
+                        "on": {"label": "On"},
+                        "off": {"label": "Off"},
+                    },
+                },
+            },
+        }
+        errors = validate_analysis(data)
+        assert errors == []
+
+
+class TestConditionalOutputsUniverse:
+    """Tests for universe validation with conditional outputs."""
+
+    def test_valid_universe_with_conditional_outputs(self, valid_dir: Path):
+        """Universe should validate against analysis with conditional outputs."""
+        analysis_data = load_yaml(valid_dir / "conditional_outputs.yaml")
+        universe_data = load_yaml(valid_dir / "conditional_outputs_universe.yaml")
+        errors = validate_universe(universe_data, analysis_data)
+        assert errors == []
+
+    def test_decision_list_when_active(self, valid_dir: Path):
+        """Universe where list when condition IS met should include the decision."""
+        analysis_data = load_yaml(valid_dir / "decision_list_when.yaml")
+        universe_data = load_yaml(valid_dir / "decision_list_when_universe.yaml")
+        errors = validate_universe(universe_data, analysis_data)
+        assert errors == []
+
+    def test_decision_list_when_inactive(self, valid_dir: Path):
+        """Universe where list when condition is NOT met should skip the decision."""
+        analysis_data = load_yaml(valid_dir / "decision_list_when.yaml")
+        universe_data = load_yaml(
+            valid_dir / "decision_list_when_universe_inactive.yaml"
+        )
+        errors = validate_universe(universe_data, analysis_data)
+        assert errors == []
+
+    def test_decision_list_when_inactive_with_selection_is_error(self, valid_dir: Path):
+        """Selecting an inactive decision (list when not met) should be an error."""
+        analysis_data = load_yaml(valid_dir / "decision_list_when.yaml")
+        universe_data = {
+            "id": "bad",
+            "decisions": {
+                "mode": "basic",
+                "backend": "cpu",
+                "gpu_optimization": "tensor_cores",  # inactive: mode != advanced
+            },
+        }
+        errors = validate_universe(universe_data, analysis_data)
+        assert any(e.code == "INACTIVE_DECISION" for e in errors)
+
+
+class TestIsConditionMet:
+    """Tests for the is_condition_met helper function."""
+
+    def test_none_always_met(self):
+        from astra.helpers import is_condition_met
+
+        assert is_condition_met(None, {}) is True
+
+    def test_simple_positive_match(self):
+        from astra.helpers import is_condition_met
+
+        assert is_condition_met("model.svm", {"model": "svm"}) is True
+
+    def test_simple_positive_no_match(self):
+        from astra.helpers import is_condition_met
+
+        assert is_condition_met("model.svm", {"model": "rf"}) is False
+
+    def test_negation_match(self):
+        from astra.helpers import is_condition_met
+
+        assert is_condition_met("~model.svm", {"model": "rf"}) is True
+
+    def test_negation_no_match(self):
+        from astra.helpers import is_condition_met
+
+        assert is_condition_met("~model.svm", {"model": "svm"}) is False
+
+    def test_list_and_all_met(self):
+        from astra.helpers import is_condition_met
+
+        decisions = {"model": "svm", "sample": "combined"}
+        assert is_condition_met(["model.svm", "~sample.bright"], decisions) is True
+
+    def test_list_and_one_not_met(self):
+        from astra.helpers import is_condition_met
+
+        decisions = {"model": "rf", "sample": "combined"}
+        assert is_condition_met(["model.svm", "~sample.bright"], decisions) is False
+
+    def test_missing_decision_is_no_match(self):
+        from astra.helpers import is_condition_met
+
+        assert is_condition_met("model.svm", {}) is False
+
+    def test_missing_decision_negated_is_match(self):
+        from astra.helpers import is_condition_met
+
+        # ~model.svm with model not set: selected is None, match=(None==svm)=False, negated=True
+        assert is_condition_met("~model.svm", {}) is True
+
+
+class TestDefaultUniverseConditional:
+    """Tests for get_default_universe with conditional decisions."""
+
+    def test_defaults_with_list_when(self, valid_dir: Path):
+        """Conditional decision with list when should be included when conditions are met."""
+        from astra.helpers import get_default_universe
+
+        data = load_yaml(valid_dir / "decision_list_when.yaml")
+        defaults = get_default_universe(data)
+        # mode=advanced, backend=gpu -> gpu_optimization should be included
+        assert defaults["decisions"]["gpu_optimization"] == "tensor_cores"
+
+    def test_defaults_skip_unmet_list_when(self):
+        """Conditional decision with unmet list when should be skipped."""
+        from astra.helpers import get_default_universe
+
+        data = {
+            "decisions": {
+                "mode": {
+                    "label": "Mode",
+                    "default": "basic",
+                    "options": {
+                        "basic": {"label": "Basic"},
+                        "advanced": {"label": "Advanced"},
+                    },
+                },
+                "backend": {
+                    "label": "Backend",
+                    "default": "gpu",
+                    "options": {
+                        "cpu": {"label": "CPU"},
+                        "gpu": {"label": "GPU"},
+                    },
+                },
+                "gpu_opt": {
+                    "label": "GPU Opt",
+                    "when": ["mode.advanced", "backend.gpu"],
+                    "default": "on",
+                    "options": {"on": {"label": "On"}, "off": {"label": "Off"}},
+                },
+            }
+        }
+        defaults = get_default_universe(data)
+        # mode=basic -> condition not met, gpu_opt should NOT be included
+        assert "gpu_opt" not in defaults["decisions"]


### PR DESCRIPTION
## Summary

- Add `when:` field to `Output` model, matching the existing `Decision.when` behavior
- Extend `when:` syntax for both decisions and outputs to support negation (`~` prefix) and list values (AND logic)
- Add `is_condition_met()` helper function for evaluating when conditions against universe decisions
- Update semantic validation to validate output `when:` references and handle list/negation in decision `when:` validation
- Update universe validation to use the new helper for conditional decision skipping
- Regenerate JSON schemas to include the new `when` field on outputs

## Examples

```yaml
# Single condition (existing behavior, still works)
when: model.svm

# Negation -- active when model is NOT svm
when: ~model.svm

# List (AND) -- active when both conditions are met
when:
  - ~training_sample.bright_only
  - model.svm
```

## Test plan

- [x] 22 new test cases covering:
  - Output with `when:` (positive, negation, list)
  - Decision with `when:` as list and negation
  - Invalid output `when:` references
  - Universe validation with conditional outputs/decisions
  - `is_condition_met()` helper edge cases
  - `get_default_universe()` with list when conditions
- [x] All 142 tests pass (120 existing + 22 new)
- [x] Ruff linter passes on all changed files
- [x] JSON schemas regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)