### PR TITLE
Validate PDF magic bytes before caching downloaded papers

### DIFF
--- a/src/astra/papers/__init__.py
+++ b/src/astra/papers/__init__.py
@@ -4,11 +4,12 @@ Provides DOI-based paper acquisition and caching for evidence verification.
 """
 
 from astra.papers.cache import PaperCache, PaperMetadata
-from astra.papers.download import download_paper, resolve_doi
+from astra.papers.download import download_paper, is_valid_pdf, resolve_doi
 
 __all__ = [
     "PaperCache",
     "PaperMetadata",
     "download_paper",
+    "is_valid_pdf",
     "resolve_doi",
 ]

--- a/src/astra/papers/cache.py
+++ b/src/astra/papers/cache.py
@@ -182,6 +182,14 @@ class PaperCache:
         Returns:
             CachedPaper with paths and metadata.
         """
+        from astra.papers.download import is_valid_pdf
+
+        if not is_valid_pdf(pdf_content):
+            raise ValueError(
+                "Content is not a valid PDF (magic bytes mismatch). "
+                "Refusing to cache non-PDF content."
+            )
+
         paper_dir = self._paper_dir(doi, version)
         paper_dir.mkdir(parents=True, exist_ok=True)
 

--- a/src/astra/papers/download.py
+++ b/src/astra/papers/download.py
@@ -137,6 +137,18 @@ class PaperDownloadResult:
     error: str | None = None
 
 
+def is_valid_pdf(content: bytes) -> bool:
+    """Check if content is a valid PDF by inspecting magic bytes.
+
+    Args:
+        content: Raw bytes of the downloaded file.
+
+    Returns:
+        True if the content starts with the PDF magic bytes ``%PDF``.
+    """
+    return content[:4] == b"%PDF"
+
+
 def _is_arxiv_doi(doi: str) -> bool:
     """Check if DOI is an arXiv DOI."""
     return doi.startswith("10.48550/arXiv.")
@@ -174,10 +186,19 @@ def _download_arxiv_pdf(arxiv_id: str, doi: str, version: int | None = None) -> 
 
         # Check if we got a PDF (arXiv returns application/pdf or application/octet-stream)
         content_type = response.headers.get("content-type", "")
-        is_pdf = "application/pdf" in content_type or content_type.startswith("application/octet")
-        if not is_pdf:
+        is_pdf_content_type = "application/pdf" in content_type or content_type.startswith(
+            "application/octet"
+        )
+        if not is_pdf_content_type:
             return PaperDownloadResult(
                 success=False, error=f"Unexpected content type: {content_type}"
+            )
+
+        # Validate magic bytes — guard against content-type lies
+        if not is_valid_pdf(response.content):
+            return PaperDownloadResult(
+                success=False,
+                error="Downloaded content is not a valid PDF (magic bytes mismatch)",
             )
 
         # Fetch metadata using DOI content negotiation
@@ -252,6 +273,17 @@ def _try_unpaywall(doi: str) -> PaperDownloadResult:
         # Download the PDF
         pdf_response = httpx.get(pdf_url, follow_redirects=True, timeout=60.0)
         pdf_response.raise_for_status()
+
+        # Validate that we actually got a PDF and not an HTML redirect/paywall page
+        if not is_valid_pdf(pdf_response.content):
+            content_type = pdf_response.headers.get("content-type", "unknown")
+            return PaperDownloadResult(
+                success=False,
+                error=(
+                    f"Downloaded content is not a valid PDF (got content-type: {content_type}). "
+                    "The URL may have redirected to a paywall or CAPTCHA page."
+                ),
+            )
 
         # Extract metadata
         title = data.get("title")

--- a/tests/test_paper_pdf_validation.py
+++ b/tests/test_paper_pdf_validation.py
@@ -4,8 +4,6 @@ Ensures that non-PDF content (HTML paywall pages, CAPTCHA redirects, etc.)
 is rejected before being written to the paper cache.
 """
 
-from __future__ import annotations
-
 import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch

--- a/tests/test_paper_pdf_validation.py
+++ b/tests/test_paper_pdf_validation.py
@@ -1,0 +1,203 @@
+"""Tests for PDF validation before caching (issue #48).
+
+Ensures that non-PDF content (HTML paywall pages, CAPTCHA redirects, etc.)
+is rejected before being written to the paper cache.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from astra.papers.cache import PaperCache
+from astra.papers.download import is_valid_pdf
+
+
+# ---------------------------------------------------------------------------
+# is_valid_pdf helper
+# ---------------------------------------------------------------------------
+
+PDF_MAGIC = b"%PDF-1.4\n%some content"
+HTML_CONTENT = b"<!DOCTYPE html><html><body>Please enable cookies</body></html>"
+EMPTY_CONTENT = b""
+
+
+class TestIsValidPdf:
+    def test_valid_pdf_magic_bytes(self) -> None:
+        assert is_valid_pdf(PDF_MAGIC) is True
+
+    def test_html_content_rejected(self) -> None:
+        assert is_valid_pdf(HTML_CONTENT) is False
+
+    def test_empty_content_rejected(self) -> None:
+        assert is_valid_pdf(EMPTY_CONTENT) is False
+
+    def test_short_content_rejected(self) -> None:
+        assert is_valid_pdf(b"%PD") is False
+
+    def test_exact_magic_bytes(self) -> None:
+        assert is_valid_pdf(b"%PDF") is True
+
+    def test_json_content_rejected(self) -> None:
+        assert is_valid_pdf(b'{"error": "not found"}') is False
+
+
+# ---------------------------------------------------------------------------
+# PaperCache.add() guard
+# ---------------------------------------------------------------------------
+
+class TestPaperCacheAddValidation:
+    def test_add_rejects_non_pdf(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            cache = PaperCache(Path(tmp))
+            with pytest.raises(ValueError, match="not a valid PDF"):
+                cache.add(
+                    doi="10.1234/test",
+                    pdf_content=HTML_CONTENT,
+                )
+
+    def test_add_rejects_empty_content(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            cache = PaperCache(Path(tmp))
+            with pytest.raises(ValueError, match="not a valid PDF"):
+                cache.add(
+                    doi="10.1234/test",
+                    pdf_content=EMPTY_CONTENT,
+                )
+
+    def test_add_accepts_valid_pdf(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            cache = PaperCache(Path(tmp))
+            cached = cache.add(
+                doi="10.1234/test",
+                pdf_content=PDF_MAGIC,
+                title="Test Paper",
+            )
+            assert cached.pdf_path.exists()
+            assert cached.pdf_path.read_bytes() == PDF_MAGIC
+
+    def test_add_from_file_rejects_non_pdf(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            html_file = tmp_path / "fake.pdf"
+            html_file.write_bytes(HTML_CONTENT)
+
+            cache = PaperCache(tmp_path / "cache")
+            with pytest.raises(ValueError, match="not a valid PDF"):
+                cache.add_from_file(doi="10.1234/test", pdf_path=html_file)
+
+    def test_add_from_file_accepts_valid_pdf(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            pdf_file = tmp_path / "paper.pdf"
+            pdf_file.write_bytes(PDF_MAGIC)
+
+            cache = PaperCache(tmp_path / "cache")
+            cached = cache.add_from_file(doi="10.1234/test", pdf_path=pdf_file)
+            assert cached.pdf_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# Download path validation (mocked HTTP)
+# ---------------------------------------------------------------------------
+
+class TestUnpaywallPdfValidation:
+    """Ensure _try_unpaywall rejects non-PDF download responses."""
+
+    def _make_response(self, content: bytes, content_type: str = "text/html") -> MagicMock:
+        resp = MagicMock()
+        resp.content = content
+        resp.headers = {"content-type": content_type}
+        resp.raise_for_status = MagicMock()
+        return resp
+
+    def _make_unpaywall_api_response(self, pdf_url: str) -> MagicMock:
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.raise_for_status = MagicMock()
+        resp.json.return_value = {
+            "title": "Test Paper",
+            "best_oa_location": {"url_for_pdf": pdf_url},
+            "z_authors": [],
+        }
+        return resp
+
+    def test_unpaywall_rejects_html_response(self) -> None:
+        from astra.papers.download import _try_unpaywall
+
+        api_resp = self._make_unpaywall_api_response("https://example.com/paper.pdf")
+        pdf_resp = self._make_response(HTML_CONTENT, "text/html")
+
+        with patch("astra.papers.download.httpx") as mock_httpx:
+            mock_httpx.get.side_effect = [api_resp, pdf_resp]
+            mock_httpx.HTTPStatusError = Exception
+            mock_httpx.RequestError = Exception
+
+            result = _try_unpaywall("10.1234/fake")
+
+        assert result.success is False
+        assert "not a valid PDF" in result.error  # type: ignore[operator]
+        assert "paywall" in result.error.lower()  # type: ignore[operator]
+
+    def test_unpaywall_accepts_pdf_response(self) -> None:
+        from astra.papers.download import _try_unpaywall
+
+        api_resp = self._make_unpaywall_api_response("https://example.com/paper.pdf")
+        pdf_resp = self._make_response(PDF_MAGIC, "application/pdf")
+
+        with patch("astra.papers.download.httpx") as mock_httpx:
+            mock_httpx.get.side_effect = [api_resp, pdf_resp]
+            mock_httpx.HTTPStatusError = Exception
+            mock_httpx.RequestError = Exception
+
+            result = _try_unpaywall("10.1234/fake")
+
+        assert result.success is True
+        assert result.content == PDF_MAGIC
+
+
+class TestArxivPdfValidation:
+    """Ensure _download_arxiv_pdf rejects non-PDF magic bytes even with correct content-type."""
+
+    def _make_arxiv_response(self, content: bytes, content_type: str) -> MagicMock:
+        resp = MagicMock()
+        resp.content = content
+        resp.headers = {"content-type": content_type}
+        resp.raise_for_status = MagicMock()
+        return resp
+
+    def test_arxiv_rejects_html_despite_pdf_content_type(self) -> None:
+        from astra.papers.download import _download_arxiv_pdf
+
+        resp = self._make_arxiv_response(HTML_CONTENT, "application/pdf")
+
+        with patch("astra.papers.download.httpx") as mock_httpx:
+            mock_httpx.get.return_value = resp
+            mock_httpx.HTTPStatusError = Exception
+            mock_httpx.RequestError = Exception
+
+            result = _download_arxiv_pdf("1706.03762", "10.48550/arXiv.1706.03762")
+
+        assert result.success is False
+        assert "magic bytes" in result.error  # type: ignore[operator]
+
+    def test_arxiv_accepts_valid_pdf(self) -> None:
+        from astra.papers.download import _download_arxiv_pdf
+
+        resp = self._make_arxiv_response(PDF_MAGIC, "application/pdf")
+
+        with patch("astra.papers.download.httpx") as mock_httpx, patch(
+            "astra.papers.download.fetch_doi_metadata"
+        ) as mock_meta:
+            mock_httpx.get.return_value = resp
+            mock_httpx.HTTPStatusError = Exception
+            mock_httpx.RequestError = Exception
+            mock_meta.return_value = MagicMock(title="Attention Is All You Need", authors=[])
+
+            result = _download_arxiv_pdf("1706.03762", "10.48550/arXiv.1706.03762")
+
+        assert result.success is True
+        assert result.content == PDF_MAGIC

--- a/tests/test_paper_pdf_validation.py
+++ b/tests/test_paper_pdf_validation.py
@@ -13,7 +13,6 @@ import pytest
 from astra.papers.cache import PaperCache
 from astra.papers.download import is_valid_pdf
 
-
 # ---------------------------------------------------------------------------
 # is_valid_pdf helper
 # ---------------------------------------------------------------------------
@@ -46,6 +45,7 @@ class TestIsValidPdf:
 # ---------------------------------------------------------------------------
 # PaperCache.add() guard
 # ---------------------------------------------------------------------------
+
 
 class TestPaperCacheAddValidation:
     def test_add_rejects_non_pdf(self) -> None:
@@ -101,6 +101,7 @@ class TestPaperCacheAddValidation:
 # ---------------------------------------------------------------------------
 # Download path validation (mocked HTTP)
 # ---------------------------------------------------------------------------
+
 
 class TestUnpaywallPdfValidation:
     """Ensure _try_unpaywall rejects non-PDF download responses."""
@@ -187,9 +188,10 @@ class TestArxivPdfValidation:
 
         resp = self._make_arxiv_response(PDF_MAGIC, "application/pdf")
 
-        with patch("astra.papers.download.httpx") as mock_httpx, patch(
-            "astra.papers.download.fetch_doi_metadata"
-        ) as mock_meta:
+        with (
+            patch("astra.papers.download.httpx") as mock_httpx,
+            patch("astra.papers.download.fetch_doi_metadata") as mock_meta,
+        ):
             mock_httpx.get.return_value = resp
             mock_httpx.HTTPStatusError = Exception
             mock_httpx.RequestError = Exception


### PR DESCRIPTION
Downloads from publishers can silently return HTML pages (CAPTCHA, paywall redirects) instead of the requested PDF. This caused downstream agents to cache and re-read garbage, leading to extraction loops.

**Changes:**
- Add `is_valid_pdf(content)` helper that checks for `%PDF` magic bytes
- Reject non-PDF responses in both the arXiv and Unpaywall download paths with a clear error message
- Guard `PaperCache.add()` so all call sites are protected
- Add `tests/test_paper_pdf_validation.py` with unit tests covering all changed paths (no network required)

Fixes #48

Generated with [Claude Code](https://claude.ai/code)