### PR TITLE
Align validator with output-centric Recipe schema (tracks astra-spec #19)

### DIFF
--- a/examples/iris/astra.yaml
+++ b/examples/iris/astra.yaml
@@ -45,43 +45,70 @@ outputs:
   - id: trained_output
     type: data
     description: Best performing classifier
+    decisions: [scaling, model, test_size, random_seed]
     recipe:
-      command: python src/train.py
+      command: >-
+        python src/train.py
+        --scaling {decisions.scaling}
+        --model {decisions.model}
+        --test-size {decisions.test_size}
+        --seed {decisions.random_seed}
+        --out {output}
 
   - id: accuracy
     type: metric
     description: Classification accuracy on held-out test set
+    inputs: [trained_output]
     recipe:
-      command: python src/evaluate.py
-      inputs: [trained_output]
+      command: >-
+        python src/evaluate.py
+        --classifier {inputs.trained_output}
+        --metric accuracy
+        --out {output}
 
   - id: f1_score
     type: metric
     description: Macro-averaged F1 score
+    inputs: [trained_output]
     recipe:
-      command: python src/evaluate.py
-      inputs: [trained_output]
+      command: >-
+        python src/evaluate.py
+        --classifier {inputs.trained_output}
+        --metric f1_macro
+        --out {output}
 
   - id: confusion_matrix
     type: figure
     description: Confusion matrix heatmap
+    inputs: [trained_output]
     recipe:
-      command: python src/evaluate.py
-      inputs: [trained_output]
+      command: >-
+        python src/evaluate.py
+        --classifier {inputs.trained_output}
+        --metric confusion
+        --out {output}
 
   - id: model_comparison
     type: table
     description: Accuracy by model and preprocessing combination
+    inputs: [trained_output]
     recipe:
-      command: python src/evaluate.py
-      inputs: [trained_output]
+      command: >-
+        python src/evaluate.py
+        --classifier {inputs.trained_output}
+        --metric comparison
+        --out {output}
 
   - id: conclusion
     type: report
     description: Summary of classifier performance and suitability for the application
+    inputs: [trained_output]
     recipe:
-      command: python src/evaluate.py
-      inputs: [trained_output]
+      command: >-
+        python src/evaluate.py
+        --classifier {inputs.trained_output}
+        --metric summary
+        --out {output}
 
 decisions:
   scaling:

--- a/examples/iris_pipeline/astra.yaml
+++ b/examples/iris_pipeline/astra.yaml
@@ -51,7 +51,7 @@ outputs:
     type: report
     description: End-to-end comparison of feature extraction methods
     recipe:
-      command: python src/summarize.py
+      command: python src/summarize.py --out {output}
 
 decisions:
   test_split:
@@ -107,15 +107,29 @@ analyses:
       - id: features
         type: data
         description: Transformed feature matrix (n_samples x n_components)
+        inputs: [raw_features]
+        decisions: [method, n_components, seed]
         recipe:
-          command: python src/extract_features.py
+          command: >-
+            python src/extract_features.py
+            --features {inputs.raw_features}
+            --method {decisions.method}
+            --n-components {decisions.n_components}
+            --seed {decisions.seed}
+            --out {output}
 
       - id: feature_plot
         type: figure
         description: Scatter plot of extracted features
+        inputs: [features]
+        decisions: [method, n_components]
         recipe:
-          command: python src/plot_features.py
-          inputs: [features]
+          command: >-
+            python src/plot_features.py
+            --features {inputs.features}
+            --method {decisions.method}
+            --n-components {decisions.n_components}
+            --out {output}
 
     decisions:
       seed:
@@ -174,15 +188,28 @@ analyses:
       - id: predictions
         type: data
         description: Predicted class labels for the test set
+        inputs: [features]
+        decisions: [classifier, split]
         recipe:
-          command: python src/classify.py
+          command: >-
+            python src/classify.py
+            --features {inputs.features}
+            --classifier {decisions.classifier}
+            --split {decisions.split}
+            --out {output}
 
       - id: accuracy
         type: metric
         description: Classification accuracy on held-out test set
+        inputs: [predictions]
+        decisions: [classifier, split]
         recipe:
-          command: python src/evaluate.py
-          inputs: [predictions]
+          command: >-
+            python src/evaluate.py
+            --predictions {inputs.predictions}
+            --classifier {decisions.classifier}
+            --split {decisions.split}
+            --out {output}
 
     decisions:
       split:

--- a/examples/iris_pipeline/astra.yaml
+++ b/examples/iris_pipeline/astra.yaml
@@ -38,13 +38,9 @@ inputs:
 
 outputs:
   - id: accuracy
-    type: metric
-    description: Classification accuracy on held-out test set
     from: classification.accuracy
 
   - id: feature_plot
-    type: figure
-    description: Scatter plot of extracted features colored by class
     from: feature_extraction.feature_plot
 
   - id: pipeline_summary
@@ -99,9 +95,7 @@ analyses:
 
     inputs:
       - id: raw_features
-        type: data
-        from: iris_data
-        description: Raw 4-dimensional Iris features from parent
+        from: ../iris_data
 
     outputs:
       - id: features
@@ -180,9 +174,7 @@ analyses:
 
     inputs:
       - id: features
-        type: data
-        from: feature_extraction.features
-        description: Transformed features from the extraction stage
+        from: ../feature_extraction.features
 
     outputs:
       - id: predictions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 
 dependencies = [
-    "astra-spec>=0.0.6",
+    "astra-spec>=0.0.7",
     "click>=8.0",
     "pydantic>=2.0",
     "pyyaml>=6.0",

--- a/src/astra/cli.py
+++ b/src/astra/cli.py
@@ -171,15 +171,16 @@ outputs:
   - id: main_result
     type: metric
     description: "TODO: Describe your primary output metric"
+    decisions: [example_method]
     recipe:
-      command: python src/main.py
+      command: python src/main.py --method {{decisions.example_method}} --out {{output}}
 
   - id: conclusion
     type: report
     description: "Summary of analysis findings"
+    inputs: [main_result]
     recipe:
-      command: python src/main.py
-      inputs: [main_result]
+      command: python src/main.py --result {{inputs.main_result}} --out {{output}}
 
 decisions:
   example_method:

--- a/src/astra/helpers.py
+++ b/src/astra/helpers.py
@@ -547,25 +547,21 @@ def get_option_value(decision: dict[str, Any], option_id: str) -> str:
 
 
 def get_output_dependencies(data: dict[str, Any]) -> dict[str, list[str]]:
-    """Build the output-to-output dependency graph from inline recipes.
+    """Build the output-to-output dependency graph from output declarations.
 
     Args:
         data: Analysis data as a dict.
 
     Returns:
-        Dict mapping output_id to list of input output_ids (from recipe.inputs).
-        Outputs without recipes have an empty dependency list.
+        Dict mapping output_id to list of input IDs (from Output.inputs).
+        Outputs without declared inputs have an empty dependency list.
     """
     result: dict[str, list[str]] = {}
     for out in data.get("outputs") or []:
         out_id = out.get("id")
         if not out_id:
             continue
-        recipe = out.get("recipe")
-        if recipe:
-            result[out_id] = recipe.get("inputs") or []
-        else:
-            result[out_id] = []
+        result[out_id] = out.get("inputs") or []
     return result
 
 

--- a/src/astra/validation/semantic.py
+++ b/src/astra/validation/semantic.py
@@ -163,8 +163,16 @@ def validate_analysis(data: dict[str, Any], base_path: Path | None = None) -> li
             if out_id:
                 sub_output_ids.add(f"{analysis_id}.{out_id}")
 
-    # Validate output recipes
-    errors.extend(_validate_output_recipes(outputs, "", extra_valid_ids=sub_output_ids))
+    # Validate output declarations and recipes
+    errors.extend(
+        _validate_output_dependencies(
+            outputs,
+            analysis_input_ids=input_ids,
+            decisions_in_scope=root_decisions,
+            path_prefix="",
+            extra_valid_ids=sub_output_ids,
+        )
+    )
 
     # Validate output when conditions
     errors.extend(_validate_output_when(outputs, root_decisions, ""))
@@ -285,9 +293,16 @@ def _validate_analysis_node(
         )
     )
 
-    # Validate output recipes
+    # Validate output declarations and recipes
     node_outputs = node.get("outputs") or []
-    errors.extend(_validate_output_recipes(node_outputs, node_path))
+    errors.extend(
+        _validate_output_dependencies(
+            node_outputs,
+            analysis_input_ids=node_input_ids,
+            decisions_in_scope=constraint_scope,
+            path_prefix=node_path,
+        )
+    )
 
     # Validate output when conditions
     errors.extend(_validate_output_when(node_outputs, constraint_scope, node_path))
@@ -542,61 +557,255 @@ def _validate_output_when(
     return errors
 
 
-def _validate_output_recipes(
+def _validate_output_dependencies(
     outputs: list[dict[str, Any]],
+    analysis_input_ids: set[str],
+    decisions_in_scope: dict[str, Any],
     path_prefix: str,
     extra_valid_ids: set[str] | None = None,
 ) -> list[SemanticError]:
-    """Validate inline recipes on outputs.
+    """Validate Output.inputs/decisions declarations and Recipe.command templates.
 
     Checks:
-    - Recipe inputs reference declared output IDs (or *extra_valid_ids*
-      such as qualified sub-analysis outputs like ``hod_fitting.galaxy_mesh``)
-    - No cycles in the output dependency graph
+    - Each ``Output.inputs`` ID resolves to an analysis-level input,
+      a sibling output, or a qualified sub-analysis output
+      (``sub.output_id``, supplied via ``extra_valid_ids``).
+    - Each ``Output.decisions`` ID resolves to a decision in scope.
+    - Recipe.command template placeholders only reference items declared
+      in ``Output.inputs`` / ``Output.decisions``.
+    - No cycles in the output-to-output dependency graph.
     """
     errors: list[SemanticError] = []
     outputs_prefix = f"{path_prefix}.outputs" if path_prefix else "outputs"
 
-    # Collect all output IDs at this level
     output_ids = {out.get("id") for out in outputs if out.get("id")}
+    sibling_or_extra = output_ids | (extra_valid_ids or set())
+    valid_input_ids = analysis_input_ids | sibling_or_extra
 
-    # Combine with extra valid IDs (e.g. sub-analysis outputs)
-    valid_ids = output_ids | (extra_valid_ids or set())
-
-    # Build dependency graph and validate inputs
     dep_graph: dict[str, list[str]] = {}
     for out in outputs:
         out_id = out.get("id")
         if not out_id:
             continue
-        recipe = out.get("recipe")
-        if not recipe:
-            dep_graph[out_id] = []
-            continue
-        inputs = recipe.get("inputs") or []
-        dep_graph[out_id] = inputs
-        for inp_id in inputs:
-            if inp_id not in valid_ids:
+        out_path = f"{outputs_prefix}.{out_id}"
+
+        declared_inputs = out.get("inputs") or []
+        # Cycle graph only edges to sibling outputs (analysis-level inputs
+        # are leaves and can't participate in a cycle).
+        dep_graph[out_id] = [i for i in declared_inputs if i in sibling_or_extra]
+
+        for inp_id in declared_inputs:
+            if inp_id not in valid_input_ids:
                 errors.append(
                     SemanticError(
-                        "INVALID_RECIPE_INPUT",
-                        f"Recipe input '{inp_id}' is not a declared output",
-                        f"{outputs_prefix}.{out_id}.recipe",
+                        "INVALID_OUTPUT_INPUT",
+                        f"Output input '{inp_id}' is not a declared analysis input "
+                        f"or sibling output",
+                        f"{out_path}.inputs",
                     )
                 )
 
-    # Check for cycles
+        declared_decisions = out.get("decisions") or []
+        for dec_id in declared_decisions:
+            if dec_id not in decisions_in_scope:
+                errors.append(
+                    SemanticError(
+                        "INVALID_OUTPUT_DECISION",
+                        f"Output decision '{dec_id}' is not a decision in scope",
+                        f"{out_path}.decisions",
+                    )
+                )
+
+        recipe = out.get("recipe")
+        if recipe and recipe.get("command"):
+            errors.extend(
+                _validate_command_template(
+                    recipe["command"],
+                    set(declared_inputs),
+                    set(declared_decisions),
+                    f"{out_path}.recipe.command",
+                )
+            )
+
     cycle = _detect_output_cycle(dep_graph)
     if cycle:
         errors.append(
             SemanticError(
-                "RECIPE_CYCLE",
+                "OUTPUT_CYCLE",
                 f"Dependency cycle detected: {' -> '.join(cycle)}",
                 outputs_prefix,
             )
         )
 
     return errors
+
+
+def _validate_command_template(
+    command: str,
+    declared_inputs: set[str],
+    declared_decisions: set[str],
+    path: str,
+) -> list[SemanticError]:
+    """Validate ``{...}`` placeholders in a Recipe.command template.
+
+    Recognized placeholders: ``{inputs}``, ``{inputs.<id>}``,
+    ``{decisions.<id>}``, ``{output}``. ``{{`` and ``}}`` are literal braces.
+    Each ``{inputs.<id>}`` / ``{decisions.<id>}`` must reference an item
+    declared on the surrounding Output. Declared-but-unreferenced inputs
+    or decisions produce a staleness lint.
+    """
+    errors: list[SemanticError] = []
+
+    referenced_inputs: set[str] = set()
+    referenced_decisions: set[str] = set()
+    uses_inputs_glob = False
+
+    i = 0
+    n = len(command)
+    while i < n:
+        ch = command[i]
+        if ch == "{":
+            if i + 1 < n and command[i + 1] == "{":
+                i += 2
+                continue
+            end = command.find("}", i + 1)
+            if end == -1:
+                errors.append(
+                    SemanticError(
+                        "INVALID_COMMAND_TEMPLATE",
+                        f"Unterminated '{{' in command template at offset {i}",
+                        path,
+                    )
+                )
+                break
+            placeholder = command[i + 1 : end]
+            ref_err = _classify_command_placeholder(
+                placeholder,
+                declared_inputs,
+                declared_decisions,
+                path,
+            )
+            if ref_err.error is not None:
+                errors.append(ref_err.error)
+            if ref_err.input_ref is not None:
+                referenced_inputs.add(ref_err.input_ref)
+            if ref_err.decision_ref is not None:
+                referenced_decisions.add(ref_err.decision_ref)
+            if ref_err.uses_inputs_glob:
+                uses_inputs_glob = True
+            i = end + 1
+            continue
+        if ch == "}":
+            if i + 1 < n and command[i + 1] == "}":
+                i += 2
+                continue
+            errors.append(
+                SemanticError(
+                    "INVALID_COMMAND_TEMPLATE",
+                    f"Unmatched '}}' in command template at offset {i}",
+                    path,
+                )
+            )
+            i += 1
+            continue
+        i += 1
+
+    # Staleness lint: declared but unreferenced. {inputs} satisfies all inputs.
+    if not uses_inputs_glob:
+        for inp in sorted(declared_inputs - referenced_inputs):
+            errors.append(
+                SemanticError(
+                    "UNREFERENCED_INPUT",
+                    f"Output input '{inp}' is declared but not referenced "
+                    f"in command template (use {{inputs.{inp}}} or {{inputs}})",
+                    path,
+                )
+            )
+    for dec in sorted(declared_decisions - referenced_decisions):
+        errors.append(
+            SemanticError(
+                "UNREFERENCED_DECISION",
+                f"Output decision '{dec}' is declared but not referenced "
+                f"in command template (use {{decisions.{dec}}})",
+                path,
+            )
+        )
+
+    return errors
+
+
+class _PlaceholderResult:
+    """Result from classifying a single ``{...}`` placeholder."""
+
+    __slots__ = ("error", "input_ref", "decision_ref", "uses_inputs_glob")
+
+    def __init__(
+        self,
+        error: SemanticError | None = None,
+        input_ref: str | None = None,
+        decision_ref: str | None = None,
+        uses_inputs_glob: bool = False,
+    ):
+        self.error = error
+        self.input_ref = input_ref
+        self.decision_ref = decision_ref
+        self.uses_inputs_glob = uses_inputs_glob
+
+
+def _classify_command_placeholder(
+    placeholder: str,
+    declared_inputs: set[str],
+    declared_decisions: set[str],
+    path: str,
+) -> _PlaceholderResult:
+    """Classify a single placeholder body (the text between ``{`` and ``}``)."""
+    if placeholder == "":
+        return _PlaceholderResult(
+            error=SemanticError(
+                "INVALID_COMMAND_TEMPLATE", "Empty '{}' placeholder", path
+            )
+        )
+    if placeholder == "output":
+        return _PlaceholderResult()
+    if placeholder == "inputs":
+        return _PlaceholderResult(uses_inputs_glob=True)
+
+    parts = placeholder.split(".")
+    if len(parts) == 2 and parts[0] == "inputs":
+        ref = parts[1]
+        if ref not in declared_inputs:
+            return _PlaceholderResult(
+                error=SemanticError(
+                    "UNDECLARED_TEMPLATE_REF",
+                    f"Command placeholder '{{inputs.{ref}}}' references undeclared "
+                    f"input '{ref}' (add it to Output.inputs)",
+                    path,
+                ),
+                input_ref=ref,
+            )
+        return _PlaceholderResult(input_ref=ref)
+    if len(parts) == 2 and parts[0] == "decisions":
+        ref = parts[1]
+        if ref not in declared_decisions:
+            return _PlaceholderResult(
+                error=SemanticError(
+                    "UNDECLARED_TEMPLATE_REF",
+                    f"Command placeholder '{{decisions.{ref}}}' references undeclared "
+                    f"decision '{ref}' (add it to Output.decisions)",
+                    path,
+                ),
+                decision_ref=ref,
+            )
+        return _PlaceholderResult(decision_ref=ref)
+
+    return _PlaceholderResult(
+        error=SemanticError(
+            "INVALID_COMMAND_TEMPLATE",
+            f"Unknown command placeholder '{{{placeholder}}}' (use "
+            "{inputs}, {inputs.<id>}, {decisions.<id>}, or {output})",
+            path,
+        )
+    )
 
 
 def _detect_output_cycle(dep_graph: dict[str, list[str]]) -> list[str] | None:

--- a/src/astra/validation/semantic.py
+++ b/src/astra/validation/semantic.py
@@ -1008,7 +1008,8 @@ def _validate_input_from(
     if up == 0:
         return _error(
             f"Input.from '{ref}' must start with '../' to escape upward "
-            "(downward references aren't allowed on Inputs; consume sub outputs via Output re-export)"
+            "(downward references aren't allowed on Inputs; "
+            "consume sub outputs via Output re-export)"
         )
 
     target_scope = _resolve_ancestor_scope(ancestor_chain, up)

--- a/src/astra/validation/semantic.py
+++ b/src/astra/validation/semantic.py
@@ -1032,8 +1032,7 @@ def _validate_input_from(
         sub_analyses = current.get("analyses") or {}
         if seg not in sub_analyses:
             return _error(
-                f"Input.from '{ref}': sub-analysis '{seg}' not found "
-                f"at depth {i} in target scope"
+                f"Input.from '{ref}': sub-analysis '{seg}' not found at depth {i} in target scope"
             )
         # Block self-reference: `../<self>.out_id` would point at our own scope's outputs.
         if up == 1 and i == 0 and seg == current_node_id:
@@ -1081,9 +1080,7 @@ def _validate_output_from(
     for i, seg in enumerate(segments[:-1]):
         sub_analyses = current.get("analyses") or {}
         if seg not in sub_analyses:
-            return _error(
-                f"Output.from '{ref}': sub-analysis '{seg}' not found at depth {i}"
-            )
+            return _error(f"Output.from '{ref}': sub-analysis '{seg}' not found at depth {i}")
         current = sub_analyses[seg]
 
     if segments[-1] not in _output_ids_in_scope(current):

--- a/src/astra/validation/semantic.py
+++ b/src/astra/validation/semantic.py
@@ -6,6 +6,7 @@ using dict-based data structures loaded from YAML files.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import Any
 
@@ -29,6 +30,55 @@ class SemanticError:
         if self.path:
             return f"[{self.code}] {self.path}: {self.message}"
         return f"[{self.code}] {self.message}"
+
+
+# ---------------------------------------------------------------------------
+# `from:` path grammar
+# ---------------------------------------------------------------------------
+#
+# A unified path expression that any `from:` slot can take:
+#
+#   ../id              -- escape one scope upward, then `id`
+#   ../../id           -- escape two scopes upward, then `id`
+#   ../scope.id        -- escape upward, then descend into a named child
+#   scope.id           -- descend from current scope into a named child
+#   scope.sub.id       -- descend through nested children
+#
+# Direction restrictions are applied per-slot by the caller:
+#   Input.from    : up, or up-then-into-sibling
+#   Output.from   : down (re-export)
+#   Decision.from : up only
+#
+# The Pydantic schema validator already enforces the regex grammar at load
+# time; the helper here is for resolution against the actual analysis tree.
+
+_ID_PATTERN = re.compile(r"^[a-z][a-z0-9_]*$")
+
+
+def _parse_from_path(ref: str) -> tuple[int, list[str]] | None:
+    """Parse a `from:` path into ``(up_levels, descent_segments)``.
+
+    Returns ``None`` if the path is malformed (empty segments, invalid
+    identifier characters, etc.). Examples:
+
+        "../id"               -> (1, ["id"])
+        "../../id"            -> (2, ["id"])
+        "../scope.id"         -> (1, ["scope", "id"])
+        "scope.id"            -> (0, ["scope", "id"])
+        "scope.sub.id"        -> (0, ["scope", "sub", "id"])
+    """
+    up = 0
+    rest = ref
+    while rest.startswith("../"):
+        up += 1
+        rest = rest[3:]
+    if not rest or rest.startswith(".") or rest.endswith("."):
+        return None
+    segments = rest.split(".")
+    for seg in segments:
+        if not _ID_PATTERN.match(seg):
+            return None
+    return (up, segments)
 
 
 def _check_path_exclusivity(
@@ -163,6 +213,11 @@ def validate_analysis(data: dict[str, Any], base_path: Path | None = None) -> li
             if out_id:
                 sub_output_ids.add(f"{analysis_id}.{out_id}")
 
+    # Validate Output.from re-exports at the root (one boundary deep into
+    # any direct child sub-analysis) before output dependencies, since those
+    # rely on knowing which output ids are real.
+    errors.extend(_validate_outputs_from(outputs, data, ""))
+
     # Validate output declarations and recipes
     errors.extend(
         _validate_output_dependencies(
@@ -182,9 +237,7 @@ def validate_analysis(data: dict[str, Any], base_path: Path | None = None) -> li
                 analysis_id,
                 analysis_node,
                 prior_insights,
-                parent_input_ids=input_ids,
-                parent_decisions=root_decisions,
-                sibling_analyses=sub_analyses,
+                ancestor_chain=[data],
                 path_prefix="analyses",
             )
         )
@@ -196,12 +249,14 @@ def _validate_analysis_node(
     node_id: str,
     node: dict[str, Any],
     prior_insights: dict[str, Any],
-    parent_input_ids: set[str],
-    parent_decisions: dict[str, Any],
-    sibling_analyses: dict[str, Any],
+    ancestor_chain: list[dict[str, Any]],
     path_prefix: str,
 ) -> list[SemanticError]:
-    """Validate a single analysis node's decisions, inputs, and sub-analyses."""
+    """Validate a single analysis node's decisions, inputs, and sub-analyses.
+
+    ``ancestor_chain`` is ordered root-first; ``ancestor_chain[-1]`` is the
+    immediate parent of this node.
+    """
     errors: list[SemanticError] = []
     node_path = f"{path_prefix}.{node_id}"
 
@@ -220,7 +275,7 @@ def _validate_analysis_node(
                 )
             )
 
-    # Validate decision `from` references against parent decisions
+    # Validate decision `from` references against ancestor decisions
     node_all_decisions = node.get("decisions") or {}
     for decision_id, decision in node_all_decisions.items():
         ref = decision.get("from")
@@ -229,7 +284,7 @@ def _validate_analysis_node(
                 _validate_decision_from(
                     decision_id,
                     ref,
-                    parent_decisions,
+                    ancestor_chain,
                     f"{node_path}.decisions.{decision_id}",
                 )
             )
@@ -244,10 +299,9 @@ def _validate_analysis_node(
         ref = inp.get("from")
         if ref:
             errors.extend(
-                _validate_from(
+                _validate_input_from(
                     ref,
-                    parent_input_ids,
-                    sibling_analyses,
+                    ancestor_chain,
                     node_id,
                     node_path,
                 )
@@ -268,17 +322,32 @@ def _validate_analysis_node(
         if out_id:
             node_output_ids.add(out_id)
 
+    # Validate Output.from re-exports (downward into own children)
+    node_outputs = node.get("outputs") or []
+    errors.extend(_validate_outputs_from(node_outputs, node, node_path))
+
     # Validate decisions
     # Collect only locally-defined decisions (not `from` references)
     node_decisions = _collect_node_decisions(node)
-    # Build constraint scope: local decisions + resolved `from` references from parent
+    # Build constraint scope: local decisions + resolved ancestor decisions
+    # (multi-level via ancestor_chain).
     constraint_scope = dict(node_decisions)
     for decision_id, decision in node_all_decisions.items():
         ref = decision.get("from")
-        if ref and ref.startswith("../"):
-            parent_decision_id = ref[3:]
-            if parent_decision_id in parent_decisions:
-                constraint_scope[decision_id] = parent_decisions[parent_decision_id]
+        if not ref:
+            continue
+        parsed = _parse_from_path(ref)
+        if parsed is None:
+            continue
+        up, segments = parsed
+        if up <= 0 or len(segments) != 1:
+            continue
+        target_scope = _resolve_ancestor_scope(ancestor_chain, up)
+        if target_scope is None:
+            continue
+        target_decisions = target_scope.get("decisions") or {}
+        if segments[0] in target_decisions:
+            constraint_scope[decision_id] = target_decisions[segments[0]]
     errors.extend(_validate_decisions(node_decisions, prior_insights, node_path, constraint_scope))
 
     # Validate evidence artifact references in prior_insights and findings
@@ -293,14 +362,24 @@ def _validate_analysis_node(
         )
     )
 
+    # Sub-analysis output IDs are exposed as qualified ids so this node's
+    # outputs can declare them as inputs (e.g. ``inputs: [child.out]``).
+    sub_analyses = node.get("analyses") or {}
+    sub_output_ids: set[str] = set()
+    for sub_id, sub_node in sub_analyses.items():
+        for out in sub_node.get("outputs") or []:
+            out_id = out.get("id")
+            if out_id:
+                sub_output_ids.add(f"{sub_id}.{out_id}")
+
     # Validate output declarations and recipes
-    node_outputs = node.get("outputs") or []
     errors.extend(
         _validate_output_dependencies(
             node_outputs,
             analysis_input_ids=node_input_ids,
             decisions_in_scope=constraint_scope,
             path_prefix=node_path,
+            extra_valid_ids=sub_output_ids,
         )
     )
 
@@ -308,20 +387,40 @@ def _validate_analysis_node(
     errors.extend(_validate_output_when(node_outputs, constraint_scope, node_path))
 
     # Recurse into sub-analyses
-    sub_analyses = node.get("analyses") or {}
     for sub_id, sub_node in sub_analyses.items():
         errors.extend(
             _validate_analysis_node(
                 sub_id,
                 sub_node,
                 prior_insights,
-                parent_input_ids=node_input_ids,
-                parent_decisions=node_decisions,
-                sibling_analyses=sub_analyses,
+                ancestor_chain=ancestor_chain + [node],
                 path_prefix=f"{node_path}.analyses",
             )
         )
 
+    return errors
+
+
+def _validate_outputs_from(
+    outputs: list[dict[str, Any]],
+    current_scope: dict[str, Any],
+    path_prefix: str,
+) -> list[SemanticError]:
+    """Validate ``from:`` paths on a list of Outputs (re-exports)."""
+    errors: list[SemanticError] = []
+    outputs_prefix = f"{path_prefix}.outputs" if path_prefix else "outputs"
+    for out in outputs:
+        ref = out.get("from")
+        out_id = out.get("id")
+        if not ref or not out_id:
+            continue
+        errors.extend(
+            _validate_output_from(
+                ref,
+                current_scope,
+                f"{outputs_prefix}.{out_id}",
+            )
+        )
     return errors
 
 
@@ -589,6 +688,13 @@ def _validate_output_dependencies(
             continue
         out_path = f"{outputs_prefix}.{out_id}"
 
+        # Aliased Outputs (re-exports) are pure pointers — they don't have
+        # their own inputs/decisions/recipe to validate. The `from:` path
+        # itself is checked by `_validate_outputs_from`.
+        if out.get("from"):
+            dep_graph[out_id] = []
+            continue
+
         declared_inputs = out.get("inputs") or []
         # Cycle graph only edges to sibling outputs (analysis-level inputs
         # are leaves and can't participate in a cycle).
@@ -651,14 +757,15 @@ def _validate_command_template(
     Recognized placeholders: ``{inputs}``, ``{inputs.<id>}``,
     ``{decisions.<id>}``, ``{output}``. ``{{`` and ``}}`` are literal braces.
     Each ``{inputs.<id>}`` / ``{decisions.<id>}`` must reference an item
-    declared on the surrounding Output. Declared-but-unreferenced inputs
-    or decisions produce a staleness lint.
+    declared on the surrounding Output.
+
+    Note: we deliberately don't lint "declared but unreferenced" — the spec
+    grants the runner free choice of delivery mechanism for declared inputs
+    and decisions ("via flags, env vars, or a sidecar — runner's choice"),
+    so a recipe with `python script.py` and decisions delivered by sidecar
+    is just as valid as one using `{decisions.x}` template substitution.
     """
     errors: list[SemanticError] = []
-
-    referenced_inputs: set[str] = set()
-    referenced_decisions: set[str] = set()
-    uses_inputs_glob = False
 
     i = 0
     n = len(command)
@@ -687,12 +794,6 @@ def _validate_command_template(
             )
             if ref_err.error is not None:
                 errors.append(ref_err.error)
-            if ref_err.input_ref is not None:
-                referenced_inputs.add(ref_err.input_ref)
-            if ref_err.decision_ref is not None:
-                referenced_decisions.add(ref_err.decision_ref)
-            if ref_err.uses_inputs_glob:
-                uses_inputs_glob = True
             i = end + 1
             continue
         if ch == "}":
@@ -710,46 +811,16 @@ def _validate_command_template(
             continue
         i += 1
 
-    # Staleness lint: declared but unreferenced. {inputs} satisfies all inputs.
-    if not uses_inputs_glob:
-        for inp in sorted(declared_inputs - referenced_inputs):
-            errors.append(
-                SemanticError(
-                    "UNREFERENCED_INPUT",
-                    f"Output input '{inp}' is declared but not referenced "
-                    f"in command template (use {{inputs.{inp}}} or {{inputs}})",
-                    path,
-                )
-            )
-    for dec in sorted(declared_decisions - referenced_decisions):
-        errors.append(
-            SemanticError(
-                "UNREFERENCED_DECISION",
-                f"Output decision '{dec}' is declared but not referenced "
-                f"in command template (use {{decisions.{dec}}})",
-                path,
-            )
-        )
-
     return errors
 
 
 class _PlaceholderResult:
     """Result from classifying a single ``{...}`` placeholder."""
 
-    __slots__ = ("error", "input_ref", "decision_ref", "uses_inputs_glob")
+    __slots__ = ("error",)
 
-    def __init__(
-        self,
-        error: SemanticError | None = None,
-        input_ref: str | None = None,
-        decision_ref: str | None = None,
-        uses_inputs_glob: bool = False,
-    ):
+    def __init__(self, error: SemanticError | None = None):
         self.error = error
-        self.input_ref = input_ref
-        self.decision_ref = decision_ref
-        self.uses_inputs_glob = uses_inputs_glob
 
 
 def _classify_command_placeholder(
@@ -758,48 +829,49 @@ def _classify_command_placeholder(
     declared_decisions: set[str],
     path: str,
 ) -> _PlaceholderResult:
-    """Classify a single placeholder body (the text between ``{`` and ``}``)."""
+    """Classify a single placeholder body (the text between ``{`` and ``}``).
+
+    Returns an error if the placeholder references something not declared
+    on the Output, or if its grammar is malformed. The caller doesn't track
+    *which* declared item was referenced — declared-but-unreferenced is a
+    legitimate pattern (decisions can flow via env/sidecar, not just the
+    template), so there's nothing to lint.
+    """
     if placeholder == "":
         return _PlaceholderResult(
-            error=SemanticError(
-                "INVALID_COMMAND_TEMPLATE", "Empty '{}' placeholder", path
-            )
+            SemanticError("INVALID_COMMAND_TEMPLATE", "Empty '{}' placeholder", path)
         )
-    if placeholder == "output":
+    if placeholder == "output" or placeholder == "inputs":
         return _PlaceholderResult()
-    if placeholder == "inputs":
-        return _PlaceholderResult(uses_inputs_glob=True)
 
     parts = placeholder.split(".")
     if len(parts) == 2 and parts[0] == "inputs":
         ref = parts[1]
         if ref not in declared_inputs:
             return _PlaceholderResult(
-                error=SemanticError(
+                SemanticError(
                     "UNDECLARED_TEMPLATE_REF",
                     f"Command placeholder '{{inputs.{ref}}}' references undeclared "
                     f"input '{ref}' (add it to Output.inputs)",
                     path,
-                ),
-                input_ref=ref,
+                )
             )
-        return _PlaceholderResult(input_ref=ref)
+        return _PlaceholderResult()
     if len(parts) == 2 and parts[0] == "decisions":
         ref = parts[1]
         if ref not in declared_decisions:
             return _PlaceholderResult(
-                error=SemanticError(
+                SemanticError(
                     "UNDECLARED_TEMPLATE_REF",
                     f"Command placeholder '{{decisions.{ref}}}' references undeclared "
                     f"decision '{ref}' (add it to Output.decisions)",
                     path,
-                ),
-                decision_ref=ref,
+                )
             )
-        return _PlaceholderResult(decision_ref=ref)
+        return _PlaceholderResult()
 
     return _PlaceholderResult(
-        error=SemanticError(
+        SemanticError(
             "INVALID_COMMAND_TEMPLATE",
             f"Unknown command placeholder '{{{placeholder}}}' (use "
             "{inputs}, {inputs.<id>}, {decisions.<id>}, or {output})",
@@ -839,90 +911,185 @@ def _detect_output_cycle(dep_graph: dict[str, list[str]]) -> list[str] | None:
     return None
 
 
+def _resolve_ancestor_scope(
+    ancestor_chain: list[dict[str, Any]],
+    up_levels: int,
+) -> dict[str, Any] | None:
+    """Walk ``up_levels`` scopes up from the current node.
+
+    ``ancestor_chain`` is ordered root-first: ``ancestor_chain[-1]`` is the
+    immediate parent. Returns the target scope, or ``None`` if the chain is
+    not deep enough.
+    """
+    if up_levels <= 0 or up_levels > len(ancestor_chain):
+        return None
+    return ancestor_chain[len(ancestor_chain) - up_levels]
+
+
+def _output_ids_in_scope(scope: dict[str, Any]) -> set[str]:
+    return {o.get("id") for o in (scope.get("outputs") or []) if o.get("id")}
+
+
+def _input_ids_in_scope(scope: dict[str, Any]) -> set[str]:
+    return {i.get("id") for i in (scope.get("inputs") or []) if i.get("id")}
+
+
 def _validate_decision_from(
     decision_id: str,
     ref: str,
-    parent_decisions: dict[str, Any],
+    ancestor_chain: list[dict[str, Any]],
     decision_path: str,
 ) -> list[SemanticError]:
-    """Validate a `from` reference on a decision.
+    """Validate a `from:` reference on a Decision.
 
-    ``from: ../parent_decision_id`` references a parent decision.
-    The ``../`` prefix is required.
+    Decisions only flow downward through scopes — the only legal form is
+    ``../id``, ``../../id``, etc. (an ancestor decision). Sibling-sub or
+    child references are rejected.
     """
 
     def _error(message: str) -> list[SemanticError]:
         return [SemanticError("INVALID_DECISION_FROM", message, decision_path)]
 
-    if not ref.startswith("../"):
+    parsed = _parse_from_path(ref)
+    if parsed is None:
+        return _error(f"Decision.from '{ref}' has invalid path syntax")
+    up, segments = parsed
+    if up == 0:
         return _error(
-            f"Decision from reference '{ref}' must use '../' prefix to reference parent scope"
+            f"Decision.from '{ref}' must start with '../' to reference an ancestor decision"
+        )
+    if len(segments) != 1:
+        return _error(
+            f"Decision.from '{ref}' must reference a single decision id "
+            "(no descent into sibling/child scopes allowed; "
+            "lift the decision to a common ancestor instead)"
         )
 
-    parent_decision_id = ref[3:]
-    if not parent_decision_id:
-        return _error(f"Decision from reference '{ref}' is empty after '../'")
-
-    if parent_decision_id not in parent_decisions:
+    target_scope = _resolve_ancestor_scope(ancestor_chain, up)
+    if target_scope is None:
         return _error(
-            f"Decision from reference '{ref}' points to non-existent "
-            f"parent decision '{parent_decision_id}'"
+            f"Decision.from '{ref}' escapes {up} level(s) but only "
+            f"{len(ancestor_chain)} ancestor scope(s) available"
         )
 
+    target_decisions = target_scope.get("decisions") or {}
+    if segments[0] not in target_decisions:
+        return _error(
+            f"Decision.from '{ref}' points to non-existent ancestor decision '{segments[0]}'"
+        )
     return []
 
 
-def _validate_from(
+def _validate_input_from(
     ref: str,
-    parent_input_ids: set[str],
-    sibling_analyses: dict[str, Any],
+    ancestor_chain: list[dict[str, Any]],
     current_node_id: str,
     node_path: str,
 ) -> list[SemanticError]:
-    """Validate a `from` reference on a sub-analysis input.
+    """Validate a `from:` reference on an Input.
 
-    Supports two syntaxes:
-    - ``../`` prefix (new): ``../input_id`` (parent input),
-      ``../sibling.output_id`` (sibling output)
-    - Legacy (no prefix): ``input_id`` (parent input),
-      ``sibling.output_id`` (sibling output)
+    Legal forms:
+
+      ``../id``                       -- a parent (or further-ancestor) Input
+      ``../scope.out_id``             -- a sibling sub-analysis's Output
+      ``../../uncle.out_id``          -- a cousin sub's Output (further up)
+
+    Reaching downward from an Input (``child.out_id``) is not allowed — those
+    are consumed via Output re-export at the parent.
     """
 
     def _error(message: str) -> list[SemanticError]:
         return [SemanticError("INVALID_FROM", message, node_path)]
 
-    # Strip ../ prefix if present
-    tail = ref
-    if tail.startswith("../"):
-        tail = tail[3:]
+    parsed = _parse_from_path(ref)
+    if parsed is None:
+        return _error(f"Input.from '{ref}' has invalid path syntax")
+    up, segments = parsed
+    if up == 0:
+        return _error(
+            f"Input.from '{ref}' must start with '../' to escape upward "
+            "(downward references aren't allowed on Inputs; consume sub outputs via Output re-export)"
+        )
 
-    parts = tail.split(".")
-    if len(parts) == 1:
-        if tail not in parent_input_ids:
-            return _error(f"from reference '{ref}' not found in parent inputs")
-        return []
+    target_scope = _resolve_ancestor_scope(ancestor_chain, up)
+    if target_scope is None:
+        return _error(
+            f"Input.from '{ref}' escapes {up} level(s) but only "
+            f"{len(ancestor_chain)} ancestor scope(s) available"
+        )
 
-    if len(parts) == 2:
-        sibling_id, output_id = parts
-        if sibling_id == current_node_id:
-            return _error(f"from reference '{ref}' cannot reference own outputs")
-        if sibling_id not in sibling_analyses:
+    if len(segments) == 1:
+        if segments[0] not in _input_ids_in_scope(target_scope):
             return _error(
-                f"from reference '{ref}' points to non-existent sibling '{sibling_id}'",
-            )
-        sibling_outputs = sibling_analyses[sibling_id].get("outputs") or []
-        sibling_output_ids = {o.get("id") for o in sibling_outputs if o.get("id")}
-        if output_id not in sibling_output_ids:
-            return _error(
-                f"from reference '{ref}' points to non-existent output "
-                f"'{output_id}' in sibling '{sibling_id}'"
+                f"Input.from '{ref}' points to non-existent ancestor input '{segments[0]}'"
             )
         return []
 
-    return _error(
-        f"from reference '{ref}' has invalid format "
-        "(expected '[../]input_id' or '[../]sibling.output_id')"
-    )
+    # len >= 2: descend through named sub-analyses to a final Output id.
+    current = target_scope
+    for i, seg in enumerate(segments[:-1]):
+        sub_analyses = current.get("analyses") or {}
+        if seg not in sub_analyses:
+            return _error(
+                f"Input.from '{ref}': sub-analysis '{seg}' not found "
+                f"at depth {i} in target scope"
+            )
+        # Block self-reference: `../<self>.out_id` would point at our own scope's outputs.
+        if up == 1 and i == 0 and seg == current_node_id:
+            return _error(f"Input.from '{ref}' cannot reference own outputs")
+        current = sub_analyses[seg]
+
+    if segments[-1] not in _output_ids_in_scope(current):
+        return _error(
+            f"Input.from '{ref}': output '{segments[-1]}' not found in target sub-analysis"
+        )
+    return []
+
+
+def _validate_output_from(
+    ref: str,
+    current_scope: dict[str, Any],
+    output_path: str,
+) -> list[SemanticError]:
+    """Validate a `from:` reference on an Output (re-export).
+
+    Outputs only flow upward through re-export: a parent Output points down
+    into a child sub-analysis's Output via ``child.out_id`` (or deeper,
+    ``child.grandchild.out_id``). Upward references aren't allowed.
+    """
+
+    def _error(message: str) -> list[SemanticError]:
+        return [SemanticError("INVALID_OUTPUT_FROM", message, output_path)]
+
+    parsed = _parse_from_path(ref)
+    if parsed is None:
+        return _error(f"Output.from '{ref}' has invalid path syntax")
+    up, segments = parsed
+    if up != 0:
+        return _error(
+            f"Output.from '{ref}' must descend into a sub-analysis "
+            "(upward references aren't allowed; outputs flow up via per-layer re-export)"
+        )
+    if len(segments) < 2:
+        return _error(
+            f"Output.from '{ref}' must take the form 'child.out_id' "
+            "(at least one descent step into a named sub-analysis)"
+        )
+
+    current = current_scope
+    for i, seg in enumerate(segments[:-1]):
+        sub_analyses = current.get("analyses") or {}
+        if seg not in sub_analyses:
+            return _error(
+                f"Output.from '{ref}': sub-analysis '{seg}' not found at depth {i}"
+            )
+        current = sub_analyses[seg]
+
+    if segments[-1] not in _output_ids_in_scope(current):
+        return _error(
+            f"Output.from '{ref}': output '{segments[-1]}' not found in target sub-analysis"
+        )
+    return []
 
 
 def _validate_constraint_ref(
@@ -988,7 +1155,7 @@ def validate_universe(
         universe_data,
         analysis_data,
         path_prefix="",
-        parent_universe_decisions={},
+        ancestor_universe_chain=[],
     )
 
 
@@ -996,7 +1163,7 @@ def _validate_universe_node(
     universe_node: dict[str, Any],
     analysis_node: dict[str, Any],
     path_prefix: str,
-    parent_universe_decisions: dict[str, str],
+    ancestor_universe_chain: list[dict[str, str]],
 ) -> list[SemanticError]:
     """Recursively validate a universe node against an analysis node.
 
@@ -1066,8 +1233,10 @@ def _validate_universe_node(
                     )
                 )
 
-    # Merge current and parent universe decisions for condition evaluation
-    all_universe_decisions = dict(parent_universe_decisions)
+    # Merge current and ancestor universe decisions for condition evaluation
+    all_universe_decisions: dict[str, str] = {}
+    for ancestor_universe in ancestor_universe_chain:
+        all_universe_decisions.update(ancestor_universe)
     all_universe_decisions.update(universe_decisions)
 
     # Check all locally-defined analysis decisions are covered
@@ -1104,23 +1273,27 @@ def _validate_universe_node(
             )
 
     # Check constraints
-    # Build effective decisions: local selections + `from` resolved from parent
+    # Build effective decisions: local selections + `from` resolved from
+    # the appropriate ancestor in the chain (multi-level via `../../`).
     effective_decisions = dict(universe_decisions)
     for decision_id in from_decision_ids:
         ref = all_analysis_decisions[decision_id].get("from", "")
-        if ref.startswith("../"):
-            parent_decision_id = ref[3:]
-            if parent_decision_id in parent_universe_decisions:
-                effective_decisions[decision_id] = parent_universe_decisions[parent_decision_id]
+        parsed = _parse_from_path(ref)
+        if parsed is None:
+            continue
+        up, segments = parsed
+        if up <= 0 or len(segments) != 1:
+            continue
+        # The ancestor universe is `up` levels above us in the universe chain.
+        if up > len(ancestor_universe_chain):
+            continue
+        target_universe = ancestor_universe_chain[len(ancestor_universe_chain) - up]
+        target_decision_id = segments[0]
+        if target_decision_id in target_universe:
+            effective_decisions[decision_id] = target_universe[target_decision_id]
 
     # Build effective analysis decisions for constraint checking (include resolved `from`)
     effective_analysis_decisions = dict(analysis_decisions)
-    for decision_id in from_decision_ids:
-        ref = all_analysis_decisions[decision_id].get("from", "")
-        if ref.startswith("../"):
-            parent_decision_id = ref[3:]
-            # The constraint scope uses the parent's decision definition
-            # (This is already in analysis_decisions if _collect_node_decisions handled it)
 
     errors.extend(
         _validate_node_universe_constraints(
@@ -1157,7 +1330,7 @@ def _validate_universe_node(
                 sub_universe,
                 sub_analysis_node,
                 path_prefix=f"{analyses_prefix}.{analysis_id}",
-                parent_universe_decisions=universe_decisions,
+                ancestor_universe_chain=ancestor_universe_chain + [universe_decisions],
             )
         )
 

--- a/src/astra/validation/semantic.py
+++ b/src/astra/validation/semantic.py
@@ -7,15 +7,20 @@ using dict-based data structures loaded from YAML files.
 from __future__ import annotations
 
 import re
+import string
 from pathlib import Path
 from typing import Any
 
 from astra.helpers import (
     _collect_node_decisions,
+    get_input_ids,
+    get_output_ids,
     is_condition_met,
     load_yaml,
     resolve_analysis_tree,
 )
+
+_FORMATTER = string.Formatter()
 
 
 class SemanticError:
@@ -213,12 +218,10 @@ def validate_analysis(data: dict[str, Any], base_path: Path | None = None) -> li
             if out_id:
                 sub_output_ids.add(f"{analysis_id}.{out_id}")
 
-    # Validate Output.from re-exports at the root (one boundary deep into
-    # any direct child sub-analysis) before output dependencies, since those
+    # `from:` re-exports must be checked before output dependencies, which
     # rely on knowing which output ids are real.
     errors.extend(_validate_outputs_from(outputs, data, ""))
 
-    # Validate output declarations and recipes
     errors.extend(
         _validate_output_dependencies(
             outputs,
@@ -322,15 +325,10 @@ def _validate_analysis_node(
         if out_id:
             node_output_ids.add(out_id)
 
-    # Validate Output.from re-exports (downward into own children)
     node_outputs = node.get("outputs") or []
     errors.extend(_validate_outputs_from(node_outputs, node, node_path))
 
-    # Validate decisions
-    # Collect only locally-defined decisions (not `from` references)
     node_decisions = _collect_node_decisions(node)
-    # Build constraint scope: local decisions + resolved ancestor decisions
-    # (multi-level via ancestor_chain).
     constraint_scope = dict(node_decisions)
     for decision_id, decision in node_all_decisions.items():
         ref = decision.get("from")
@@ -372,7 +370,6 @@ def _validate_analysis_node(
             if out_id:
                 sub_output_ids.add(f"{sub_id}.{out_id}")
 
-    # Validate output declarations and recipes
     errors.extend(
         _validate_output_dependencies(
             node_outputs,
@@ -382,11 +379,8 @@ def _validate_analysis_node(
             extra_valid_ids=sub_output_ids,
         )
     )
-
-    # Validate output when conditions
     errors.extend(_validate_output_when(node_outputs, constraint_scope, node_path))
 
-    # Recurse into sub-analyses
     for sub_id, sub_node in sub_analyses.items():
         errors.extend(
             _validate_analysis_node(
@@ -759,125 +753,53 @@ def _validate_command_template(
     Each ``{inputs.<id>}`` / ``{decisions.<id>}`` must reference an item
     declared on the surrounding Output.
 
-    Note: we deliberately don't lint "declared but unreferenced" — the spec
-    grants the runner free choice of delivery mechanism for declared inputs
-    and decisions ("via flags, env vars, or a sidecar — runner's choice"),
-    so a recipe with `python script.py` and decisions delivered by sidecar
-    is just as valid as one using `{decisions.x}` template substitution.
+    We deliberately don't lint "declared but unreferenced" — the spec
+    grants the runner free choice of delivery mechanism (flags, env vars,
+    sidecar JSON), so a recipe with `python script.py` and decisions
+    delivered by sidecar is just as valid as one using `{decisions.x}`.
     """
-    errors: list[SemanticError] = []
+    try:
+        parsed = list(_FORMATTER.parse(command))
+    except ValueError as e:
+        return [SemanticError("INVALID_COMMAND_TEMPLATE", str(e), path)]
 
-    i = 0
-    n = len(command)
-    while i < n:
-        ch = command[i]
-        if ch == "{":
-            if i + 1 < n and command[i + 1] == "{":
-                i += 2
-                continue
-            end = command.find("}", i + 1)
-            if end == -1:
-                errors.append(
-                    SemanticError(
-                        "INVALID_COMMAND_TEMPLATE",
-                        f"Unterminated '{{' in command template at offset {i}",
-                        path,
-                    )
-                )
-                break
-            placeholder = command[i + 1 : end]
-            ref_err = _classify_command_placeholder(
-                placeholder,
-                declared_inputs,
-                declared_decisions,
-                path,
-            )
-            if ref_err.error is not None:
-                errors.append(ref_err.error)
-            i = end + 1
+    errors: list[SemanticError] = []
+    declared = {"inputs": declared_inputs, "decisions": declared_decisions}
+    for _literal, field_name, format_spec, conversion in parsed:
+        if field_name is None:
             continue
-        if ch == "}":
-            if i + 1 < n and command[i + 1] == "}":
-                i += 2
-                continue
+        if field_name == "" or format_spec or conversion:
             errors.append(
                 SemanticError(
                     "INVALID_COMMAND_TEMPLATE",
-                    f"Unmatched '}}' in command template at offset {i}",
+                    f"Invalid command placeholder '{{{field_name}}}'",
                     path,
                 )
             )
-            i += 1
             continue
-        i += 1
-
+        if field_name in ("output", "inputs"):
+            continue
+        head, dot, tail = field_name.partition(".")
+        if dot and "." not in tail and head in declared:
+            if tail not in declared[head]:
+                errors.append(
+                    SemanticError(
+                        "UNDECLARED_TEMPLATE_REF",
+                        f"Command placeholder '{{{field_name}}}' references undeclared "
+                        f"{head[:-1]} '{tail}' (add it to Output.{head})",
+                        path,
+                    )
+                )
+            continue
+        errors.append(
+            SemanticError(
+                "INVALID_COMMAND_TEMPLATE",
+                f"Unknown command placeholder '{{{field_name}}}' (use "
+                "{inputs}, {inputs.<id>}, {decisions.<id>}, or {output})",
+                path,
+            )
+        )
     return errors
-
-
-class _PlaceholderResult:
-    """Result from classifying a single ``{...}`` placeholder."""
-
-    __slots__ = ("error",)
-
-    def __init__(self, error: SemanticError | None = None):
-        self.error = error
-
-
-def _classify_command_placeholder(
-    placeholder: str,
-    declared_inputs: set[str],
-    declared_decisions: set[str],
-    path: str,
-) -> _PlaceholderResult:
-    """Classify a single placeholder body (the text between ``{`` and ``}``).
-
-    Returns an error if the placeholder references something not declared
-    on the Output, or if its grammar is malformed. The caller doesn't track
-    *which* declared item was referenced — declared-but-unreferenced is a
-    legitimate pattern (decisions can flow via env/sidecar, not just the
-    template), so there's nothing to lint.
-    """
-    if placeholder == "":
-        return _PlaceholderResult(
-            SemanticError("INVALID_COMMAND_TEMPLATE", "Empty '{}' placeholder", path)
-        )
-    if placeholder == "output" or placeholder == "inputs":
-        return _PlaceholderResult()
-
-    parts = placeholder.split(".")
-    if len(parts) == 2 and parts[0] == "inputs":
-        ref = parts[1]
-        if ref not in declared_inputs:
-            return _PlaceholderResult(
-                SemanticError(
-                    "UNDECLARED_TEMPLATE_REF",
-                    f"Command placeholder '{{inputs.{ref}}}' references undeclared "
-                    f"input '{ref}' (add it to Output.inputs)",
-                    path,
-                )
-            )
-        return _PlaceholderResult()
-    if len(parts) == 2 and parts[0] == "decisions":
-        ref = parts[1]
-        if ref not in declared_decisions:
-            return _PlaceholderResult(
-                SemanticError(
-                    "UNDECLARED_TEMPLATE_REF",
-                    f"Command placeholder '{{decisions.{ref}}}' references undeclared "
-                    f"decision '{ref}' (add it to Output.decisions)",
-                    path,
-                )
-            )
-        return _PlaceholderResult()
-
-    return _PlaceholderResult(
-        SemanticError(
-            "INVALID_COMMAND_TEMPLATE",
-            f"Unknown command placeholder '{{{placeholder}}}' (use "
-            "{inputs}, {inputs.<id>}, {decisions.<id>}, or {output})",
-            path,
-        )
-    )
 
 
 def _detect_output_cycle(dep_graph: dict[str, list[str]]) -> list[str] | None:
@@ -924,14 +846,6 @@ def _resolve_ancestor_scope(
     if up_levels <= 0 or up_levels > len(ancestor_chain):
         return None
     return ancestor_chain[len(ancestor_chain) - up_levels]
-
-
-def _output_ids_in_scope(scope: dict[str, Any]) -> set[str]:
-    return {o.get("id") for o in (scope.get("outputs") or []) if o.get("id")}
-
-
-def _input_ids_in_scope(scope: dict[str, Any]) -> set[str]:
-    return {i.get("id") for i in (scope.get("inputs") or []) if i.get("id")}
 
 
 def _validate_decision_from(
@@ -1020,7 +934,7 @@ def _validate_input_from(
         )
 
     if len(segments) == 1:
-        if segments[0] not in _input_ids_in_scope(target_scope):
+        if segments[0] not in get_input_ids(target_scope):
             return _error(
                 f"Input.from '{ref}' points to non-existent ancestor input '{segments[0]}'"
             )
@@ -1039,7 +953,7 @@ def _validate_input_from(
             return _error(f"Input.from '{ref}' cannot reference own outputs")
         current = sub_analyses[seg]
 
-    if segments[-1] not in _output_ids_in_scope(current):
+    if segments[-1] not in get_output_ids(current):
         return _error(
             f"Input.from '{ref}': output '{segments[-1]}' not found in target sub-analysis"
         )
@@ -1083,7 +997,7 @@ def _validate_output_from(
             return _error(f"Output.from '{ref}': sub-analysis '{seg}' not found at depth {i}")
         current = sub_analyses[seg]
 
-    if segments[-1] not in _output_ids_in_scope(current):
+    if segments[-1] not in get_output_ids(current):
         return _error(
             f"Output.from '{ref}': output '{segments[-1]}' not found in target sub-analysis"
         )

--- a/tests/fixtures/invalid/input_from_downward.yaml
+++ b/tests/fixtures/invalid/input_from_downward.yaml
@@ -1,0 +1,20 @@
+version: "1.0"
+name: "Test Input.from with downward path"
+description: "Input.from must escape upward, not descend into own children."
+inputs:
+  - id: data
+    type: data
+    source: data.csv
+outputs:
+  - id: result
+    from: child.relayed
+analyses:
+  child:
+    inputs:
+      - id: child_data
+        from: child.relayed   # invalid: Input.from must start with ../
+    outputs:
+      - id: relayed
+        type: data
+        recipe:
+          command: python src/relay.py

--- a/tests/fixtures/invalid/invalid_parent_decision.yaml
+++ b/tests/fixtures/invalid/invalid_parent_decision.yaml
@@ -12,8 +12,7 @@ analyses:
   sub:
     inputs:
       - id: sub_data
-        type: data
-        from: data
+        from: ../data
     outputs:
       - id: sub_result
         type: metric

--- a/tests/fixtures/invalid/output_from_unknown_child.yaml
+++ b/tests/fixtures/invalid/output_from_unknown_child.yaml
@@ -1,0 +1,20 @@
+version: "1.0"
+name: "Test Output.from points at non-existent child"
+description: "Output.from references a sub-analysis that doesn't exist."
+inputs:
+  - id: data
+    type: data
+    source: data.csv
+outputs:
+  - id: relayed
+    from: nonexistent_child.metric
+analyses:
+  real_child:
+    inputs:
+      - id: child_data
+        from: ../data
+    outputs:
+      - id: metric
+        type: metric
+        recipe:
+          command: python src/run.py

--- a/tests/fixtures/invalid/output_from_upward.yaml
+++ b/tests/fixtures/invalid/output_from_upward.yaml
@@ -1,0 +1,21 @@
+version: "1.0"
+name: "Test Output.from with upward path"
+description: "Output.from must descend into a sub-analysis, not escape upward."
+inputs:
+  - id: data
+    type: data
+    source: data.csv
+outputs:
+  - id: result
+    type: metric
+    inputs: [data]
+    recipe:
+      command: python src/eval.py
+analyses:
+  child:
+    inputs:
+      - id: child_data
+        from: ../data
+    outputs:
+      - id: relayed
+        from: ../result   # invalid: Output.from cannot reach upward

--- a/tests/fixtures/invalid/recipe_invalid_input.yaml
+++ b/tests/fixtures/invalid/recipe_invalid_input.yaml
@@ -4,6 +4,6 @@ inputs: []
 outputs:
   - id: result
     type: metric
+    inputs: [nonexistent_output]
     recipe:
-      command: python run.py
-      inputs: [nonexistent_output]
+      command: python run.py {inputs.nonexistent_output}

--- a/tests/fixtures/invalid/recipe_output_cycle.yaml
+++ b/tests/fixtures/invalid/recipe_output_cycle.yaml
@@ -4,11 +4,11 @@ inputs: []
 outputs:
   - id: a
     type: data
+    inputs: [b]
     recipe:
-      command: python a.py
-      inputs: [b]
+      command: python a.py {inputs.b}
   - id: b
     type: data
+    inputs: [a]
     recipe:
-      command: python b.py
-      inputs: [a]
+      command: python b.py {inputs.a}

--- a/tests/fixtures/invalid/sub_missing_outputs.yaml
+++ b/tests/fixtures/invalid/sub_missing_outputs.yaml
@@ -12,6 +12,5 @@ analyses:
   sub:
     inputs:
       - id: sub_data
-        type: data
-        from: data
+        from: ../data
     # outputs is missing

--- a/tests/fixtures/valid/conditional_outputs.yaml
+++ b/tests/fixtures/valid/conditional_outputs.yaml
@@ -10,24 +10,25 @@ inputs:
 outputs:
   - id: trained_model
     type: data
+    inputs: [training_data]
     recipe:
-      command: python scripts/train.py
+      command: python scripts/train.py {inputs.training_data}
 
   # Only produced when training_sample is not bright_only
   - id: faint_metrics
     type: metric
     when: "~training_sample.bright_only"
+    inputs: [trained_model]
     recipe:
-      command: python scripts/evaluate.py
-      inputs: [trained_model]
+      command: python scripts/evaluate.py {inputs.trained_model}
 
   # Only produced when model is svm
   - id: svm_report
     type: report
     when: model.svm
+    inputs: [trained_model]
     recipe:
-      command: python scripts/svm_report.py
-      inputs: [trained_model]
+      command: python scripts/svm_report.py {inputs.trained_model}
 
   # Only produced when multiple conditions met (AND)
   - id: combined_report
@@ -35,9 +36,9 @@ outputs:
     when:
       - "~training_sample.bright_only"
       - model.svm
+    inputs: [trained_model]
     recipe:
-      command: python scripts/combined.py
-      inputs: [trained_model]
+      command: python scripts/combined.py {inputs.trained_model}
 
 decisions:
   training_sample:

--- a/tests/fixtures/valid/full.yaml
+++ b/tests/fixtures/valid/full.yaml
@@ -30,37 +30,37 @@ outputs:
   - id: accuracy
     type: metric
     description: "Model accuracy"
+    inputs: [trained_output]
     recipe:
-      command: python src/evaluate.py
-      inputs: [trained_output]
+      command: python src/evaluate.py {inputs.trained_output}
 
   - id: f1_score
     type: metric
     description: "F1 score"
+    inputs: [trained_output]
     recipe:
-      command: python src/evaluate.py
-      inputs: [trained_output]
+      command: python src/evaluate.py {inputs.trained_output}
 
   - id: plot
     type: figure
     description: "Results plot"
+    inputs: [trained_output]
     recipe:
-      command: python src/evaluate.py
-      inputs: [trained_output]
+      command: python src/evaluate.py {inputs.trained_output}
 
   - id: summary
     type: table
     description: "Results summary"
+    inputs: [trained_output]
     recipe:
-      command: python src/evaluate.py
-      inputs: [trained_output]
+      command: python src/evaluate.py {inputs.trained_output}
 
   - id: conclusion
     type: report
     description: "Analysis conclusion"
+    inputs: [trained_output]
     recipe:
-      command: python src/evaluate.py
-      inputs: [trained_output]
+      command: python src/evaluate.py {inputs.trained_output}
 
 decisions:
   preprocessing:

--- a/tests/fixtures/valid/full_v2.yaml
+++ b/tests/fixtures/valid/full_v2.yaml
@@ -30,37 +30,37 @@ outputs:
   - id: accuracy
     type: metric
     description: "Model accuracy"
+    inputs: [trained_output]
     recipe:
-      command: python src/evaluate.py
-      inputs: [trained_output]
+      command: python src/evaluate.py {inputs.trained_output}
 
   - id: f1_score
     type: metric
     description: "F1 score"
+    inputs: [trained_output]
     recipe:
-      command: python src/evaluate.py
-      inputs: [trained_output]
+      command: python src/evaluate.py {inputs.trained_output}
 
   - id: plot
     type: figure
     description: "Results plot"
+    inputs: [trained_output]
     recipe:
-      command: python src/evaluate.py
-      inputs: [trained_output]
+      command: python src/evaluate.py {inputs.trained_output}
 
   - id: summary
     type: table
     description: "Results summary"
+    inputs: [trained_output]
     recipe:
-      command: python src/evaluate.py
-      inputs: [trained_output]
+      command: python src/evaluate.py {inputs.trained_output}
 
   - id: conclusion
     type: report
     description: "Analysis conclusion"
+    inputs: [trained_output]
     recipe:
-      command: python src/evaluate.py
-      inputs: [trained_output]
+      command: python src/evaluate.py {inputs.trained_output}
 
 prior_insights:
   compute_scaling:

--- a/tests/fixtures/valid/multilevel_from.yaml
+++ b/tests/fixtures/valid/multilevel_from.yaml
@@ -1,0 +1,46 @@
+version: "1.0"
+name: "Test multi-level from: paths"
+
+inputs:
+  - id: root_data
+    type: data
+    source: data.csv
+
+outputs:
+  - id: root_metric
+    from: stage_a.stage_b.deep_metric
+
+decisions:
+  random_seed:
+    label: "Random Seed"
+    default: seed_42
+    options:
+      seed_42:
+        label: "42"
+
+analyses:
+  stage_a:
+    inputs:
+      - id: a_data
+        from: ../root_data
+    outputs:
+      - id: deep_metric
+        from: stage_b.deep_metric
+    decisions:
+      seed:
+        from: ../random_seed
+    analyses:
+      stage_b:
+        inputs:
+          - id: b_data
+            from: ../../root_data        # grandparent input
+        outputs:
+          - id: deep_metric
+            type: metric
+            inputs: [b_data]
+            decisions: [seed]
+            recipe:
+              command: python src/deep.py {inputs.b_data} --seed {decisions.seed}
+        decisions:
+          seed:
+            from: ../../random_seed      # grandparent decision

--- a/tests/fixtures/valid/narrative_full_coverage.yaml
+++ b/tests/fixtures/valid/narrative_full_coverage.yaml
@@ -59,8 +59,7 @@ analyses:
         Produces the [scaled output](#outputs.scaled).
     inputs:
       - id: raw
-        type: data
-        from: primary_data
+        from: ../primary_data
     outputs:
       - id: scaled
         type: data

--- a/tests/fixtures/valid/nested.yaml
+++ b/tests/fixtures/valid/nested.yaml
@@ -32,14 +32,15 @@ analyses:
     outputs:
       - id: mock_catalog
         type: data
+        inputs: [survey_data]
         recipe:
-          command: python src/generate_mocks.py
+          command: python src/generate_mocks.py {inputs.survey_data}
       - id: mock_sample_plot
         type: figure
         description: "Sample mock catalog visualization"
+        inputs: [mock_catalog]
         recipe:
-          command: python src/generate_mocks.py
-          inputs: [mock_catalog]
+          command: python src/generate_mocks.py {inputs.mock_catalog}
     decisions:
       cosmology_model:
         from: ../cosmology_model
@@ -61,8 +62,9 @@ analyses:
     outputs:
       - id: trained_model
         type: data
+        inputs: [training_data]
         recipe:
-          command: python src/train.py
+          command: python src/train.py {inputs.training_data}
           resources:
             gpus: 1
             memory: "32GB"

--- a/tests/fixtures/valid/nested.yaml
+++ b/tests/fixtures/valid/nested.yaml
@@ -27,8 +27,7 @@ analyses:
   build_mocks:
     inputs:
       - id: survey_data
-        type: data
-        from: survey_catalog
+        from: ../survey_catalog
     outputs:
       - id: mock_catalog
         type: data
@@ -57,8 +56,7 @@ analyses:
   train_network:
     inputs:
       - id: training_data
-        type: data
-        from: build_mocks.mock_catalog
+        from: ../build_mocks.mock_catalog
     outputs:
       - id: trained_model
         type: data
@@ -82,8 +80,7 @@ analyses:
     description: "Validate trained model against observed data."
     inputs:
       - id: model
-        type: data
-        from: train_network.trained_model
+        from: ../train_network.trained_model
     outputs:
       - id: validation_report
         type: report

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -175,11 +175,11 @@ class TestSubAnalysisRequirements:
         assert any(e.code == "INCOMPATIBLE_OPTIONS" for e in errors)
 
 
-class TestRecipeValidation:
-    """Tests for output-to-output recipe validation."""
+class TestOutputDependencyValidation:
+    """Tests for Output.inputs/decisions and dependency-graph validation."""
 
-    def test_recipe_inputs_must_reference_declared_outputs(self):
-        """Recipe inputs must reference outputs declared in the same analysis."""
+    def test_output_input_must_reference_declared_id(self):
+        """Output.inputs must reference an analysis input or sibling output."""
         data = {
             "version": "1.0",
             "name": "test",
@@ -188,34 +188,31 @@ class TestRecipeValidation:
                 {
                     "id": "result",
                     "type": "metric",
-                    "recipe": {
-                        "command": "python run.py",
-                        "inputs": ["nonexistent"],
-                    },
+                    "inputs": ["nonexistent"],
                 },
             ],
         }
         errors = validate_analysis(data)
         codes = [e.code for e in errors]
-        assert "INVALID_RECIPE_INPUT" in codes
+        assert "INVALID_OUTPUT_INPUT" in codes
 
-    def test_recipe_output_dependency_cycle(self):
+    def test_output_dependency_cycle(self):
         """Cycle in output dependencies should be caught."""
         data = {
             "version": "1.0",
             "name": "test",
             "inputs": [],
             "outputs": [
-                {"id": "a", "type": "data", "recipe": {"command": "run_a", "inputs": ["b"]}},
-                {"id": "b", "type": "data", "recipe": {"command": "run_b", "inputs": ["a"]}},
+                {"id": "a", "type": "data", "inputs": ["b"]},
+                {"id": "b", "type": "data", "inputs": ["a"]},
             ],
         }
         errors = validate_analysis(data)
         codes = [e.code for e in errors]
-        assert "RECIPE_CYCLE" in codes
+        assert "OUTPUT_CYCLE" in codes
 
-    def test_valid_recipe_on_output(self):
-        """Valid inline recipe should pass validation."""
+    def test_valid_output_chain(self):
+        """Output that references a sibling output should pass validation."""
         data = {
             "version": "1.0",
             "name": "test",
@@ -225,18 +222,34 @@ class TestRecipeValidation:
                 {
                     "id": "result",
                     "type": "metric",
-                    "recipe": {
-                        "command": "python analyze.py",
-                        "inputs": ["cleaned"],
-                    },
+                    "inputs": ["cleaned"],
+                    "recipe": {"command": "python analyze.py {inputs.cleaned}"},
                 },
             ],
         }
         errors = validate_analysis(data)
-        assert len(errors) == 0
+        assert errors == []
 
-    def test_valid_recipe_no_inputs(self):
-        """Recipe with no inputs should pass validation."""
+    def test_output_input_can_reference_analysis_input(self):
+        """Output.inputs can resolve to an analysis-level Input."""
+        data = {
+            "version": "1.0",
+            "name": "test",
+            "inputs": [{"id": "raw", "type": "data", "source": "x.csv"}],
+            "outputs": [
+                {
+                    "id": "cleaned",
+                    "type": "data",
+                    "inputs": ["raw"],
+                    "recipe": {"command": "python clean.py {inputs.raw}"},
+                },
+            ],
+        }
+        errors = validate_analysis(data)
+        assert errors == []
+
+    def test_valid_output_no_inputs(self):
+        """Output with no inputs/decisions should pass validation."""
         data = {
             "version": "1.0",
             "name": "test",
@@ -245,35 +258,167 @@ class TestRecipeValidation:
                 {
                     "id": "result",
                     "type": "metric",
-                    "recipe": {
-                        "command": "python run.py",
-                    },
+                    "recipe": {"command": "python run.py"},
                 },
             ],
         }
         errors = validate_analysis(data)
-        assert len(errors) == 0
+        assert errors == []
 
-    def test_self_referencing_recipe_input(self):
-        """Recipe input referencing its own output should create a cycle."""
+    def test_self_referencing_output_input(self):
+        """Output input referencing its own ID should create a cycle."""
         data = {
             "version": "1.0",
             "name": "test",
             "inputs": [],
             "outputs": [
-                {"id": "a", "type": "data", "recipe": {"command": "run_a", "inputs": ["a"]}},
+                {"id": "a", "type": "data", "inputs": ["a"]},
             ],
         }
         errors = validate_analysis(data)
         codes = [e.code for e in errors]
-        assert "RECIPE_CYCLE" in codes
+        assert "OUTPUT_CYCLE" in codes
+
+    def test_output_decision_must_be_in_scope(self):
+        """Output.decisions must reference a decision in scope."""
+        data = {
+            "version": "1.0",
+            "name": "test",
+            "inputs": [],
+            "outputs": [
+                {"id": "result", "type": "metric", "decisions": ["nonexistent"]},
+            ],
+            "decisions": {
+                "real_decision": {
+                    "label": "Real",
+                    "default": "a",
+                    "options": {"a": {"label": "A"}},
+                },
+            },
+        }
+        errors = validate_analysis(data)
+        codes = [e.code for e in errors]
+        assert "INVALID_OUTPUT_DECISION" in codes
+
+
+class TestCommandTemplateValidation:
+    """Tests for the Recipe.command ``{...}`` placeholder grammar."""
+
+    def _make(self, output: dict, decisions: dict | None = None) -> dict:
+        return {
+            "version": "1.0",
+            "name": "test",
+            "inputs": [{"id": "raw", "type": "data", "source": "x"}],
+            "outputs": [output],
+            "decisions": decisions or {},
+        }
+
+    def test_valid_template(self):
+        out = {
+            "id": "r",
+            "type": "metric",
+            "inputs": ["raw"],
+            "decisions": ["m"],
+            "recipe": {
+                "command": "python run.py --in {inputs.raw} --m {decisions.m} --out {output}"
+            },
+        }
+        decisions = {
+            "m": {"label": "M", "default": "a", "options": {"a": {"label": "A"}}},
+        }
+        errors = validate_analysis(self._make(out, decisions))
+        assert errors == []
+
+    def test_undeclared_input_reference(self):
+        out = {
+            "id": "r",
+            "type": "metric",
+            "recipe": {"command": "python run.py {inputs.missing}"},
+        }
+        errors = validate_analysis(self._make(out))
+        codes = [e.code for e in errors]
+        assert "UNDECLARED_TEMPLATE_REF" in codes
+
+    def test_undeclared_decision_reference(self):
+        out = {
+            "id": "r",
+            "type": "metric",
+            "recipe": {"command": "python run.py --m {decisions.missing}"},
+        }
+        errors = validate_analysis(self._make(out))
+        codes = [e.code for e in errors]
+        assert "UNDECLARED_TEMPLATE_REF" in codes
+
+    def test_unreferenced_input_warns(self):
+        out = {
+            "id": "r",
+            "type": "metric",
+            "inputs": ["raw"],
+            "recipe": {"command": "python run.py"},
+        }
+        errors = validate_analysis(self._make(out))
+        codes = [e.code for e in errors]
+        assert "UNREFERENCED_INPUT" in codes
+
+    def test_unreferenced_decision_warns(self):
+        out = {
+            "id": "r",
+            "type": "metric",
+            "decisions": ["m"],
+            "recipe": {"command": "python run.py"},
+        }
+        decisions = {
+            "m": {"label": "M", "default": "a", "options": {"a": {"label": "A"}}},
+        }
+        errors = validate_analysis(self._make(out, decisions))
+        codes = [e.code for e in errors]
+        assert "UNREFERENCED_DECISION" in codes
+
+    def test_inputs_glob_satisfies_input_references(self):
+        out = {
+            "id": "r",
+            "type": "metric",
+            "inputs": ["raw"],
+            "recipe": {"command": "python run.py {inputs}"},
+        }
+        errors = validate_analysis(self._make(out))
+        assert errors == []
+
+    def test_literal_braces_are_allowed(self):
+        out = {
+            "id": "r",
+            "type": "metric",
+            "recipe": {"command": "echo '{{not a placeholder}}'"},
+        }
+        errors = validate_analysis(self._make(out))
+        assert errors == []
+
+    def test_unknown_placeholder_form(self):
+        out = {
+            "id": "r",
+            "type": "metric",
+            "recipe": {"command": "python run.py {bogus}"},
+        }
+        errors = validate_analysis(self._make(out))
+        codes = [e.code for e in errors]
+        assert "INVALID_COMMAND_TEMPLATE" in codes
+
+    def test_unterminated_brace(self):
+        out = {
+            "id": "r",
+            "type": "metric",
+            "recipe": {"command": "python run.py {output"},
+        }
+        errors = validate_analysis(self._make(out))
+        codes = [e.code for e in errors]
+        assert "INVALID_COMMAND_TEMPLATE" in codes
 
 
 class TestRecipeHelpers:
     """Tests for recipe helper functions."""
 
     def test_get_output_dependencies(self):
-        """get_output_dependencies should return output-to-output DAG."""
+        """get_output_dependencies should mirror Output.inputs declarations."""
         from astra.helpers import get_output_dependencies
 
         data = {
@@ -282,20 +427,16 @@ class TestRecipeHelpers:
                 {
                     "id": "train",
                     "type": "data",
-                    "recipe": {
-                        "command": "train.py",
-                        "inputs": ["clean"],
-                    },
+                    "inputs": ["clean"],
+                    "recipe": {"command": "train.py {inputs.clean}"},
                 },
                 {
                     "id": "eval",
                     "type": "metric",
-                    "recipe": {
-                        "command": "eval.py",
-                        "inputs": ["train"],
-                    },
+                    "inputs": ["train"],
+                    "recipe": {"command": "eval.py {inputs.train}"},
                 },
-                {"id": "external", "type": "data"},  # no recipe
+                {"id": "external", "type": "data"},  # no inputs declared
             ],
         }
         deps = get_output_dependencies(data)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -175,6 +175,37 @@ class TestSubAnalysisRequirements:
         assert any(e.code == "INCOMPATIBLE_OPTIONS" for e in errors)
 
 
+class TestFromPathGrammar:
+    """Tests for the unified `from:` path grammar across Input/Output/Decision."""
+
+    def test_valid_multilevel_from(self, valid_dir: Path):
+        """Multi-level `../../id` and `child.sub.id` should resolve correctly."""
+        errors = validate_analysis_file(valid_dir / "multilevel_from.yaml")
+        assert errors == []
+
+    def test_input_from_downward_rejected(self, invalid_dir: Path):
+        """Input.from must escape upward — bare `child.out` form is rejected."""
+        errors = validate_analysis_file(invalid_dir / "input_from_downward.yaml")
+        # Pydantic rejects this at schema level; semantic just needs to not crash.
+        # The schema-level error surfaces via the schema validator, not semantic.
+        # We check semantic doesn't accept it — but since the YAML may not even
+        # parse through pydantic, we instead check semantic flags it too.
+        codes = [e.code for e in errors]
+        assert "INVALID_FROM" in codes or "INVALID_OUTPUT_FROM" in codes
+
+    def test_output_from_upward_rejected(self, invalid_dir: Path):
+        """Output.from must descend; upward references rejected."""
+        errors = validate_analysis_file(invalid_dir / "output_from_upward.yaml")
+        codes = [e.code for e in errors]
+        assert "INVALID_OUTPUT_FROM" in codes
+
+    def test_output_from_unknown_child(self, invalid_dir: Path):
+        """Output.from points at a sub-analysis that doesn't exist."""
+        errors = validate_analysis_file(invalid_dir / "output_from_unknown_child.yaml")
+        codes = [e.code for e in errors]
+        assert "INVALID_OUTPUT_FROM" in codes
+
+
 class TestOutputDependencyValidation:
     """Tests for Output.inputs/decisions and dependency-graph validation."""
 
@@ -349,7 +380,11 @@ class TestCommandTemplateValidation:
         codes = [e.code for e in errors]
         assert "UNDECLARED_TEMPLATE_REF" in codes
 
-    def test_unreferenced_input_warns(self):
+    def test_declared_but_unreferenced_input_is_fine(self):
+        # The spec grants the runner free choice of delivery mechanism for
+        # declared inputs ("via flags, env vars, or a sidecar"), so a recipe
+        # whose command doesn't substitute every declared input is valid —
+        # the runner may deliver them by sidecar instead of template.
         out = {
             "id": "r",
             "type": "metric",
@@ -357,10 +392,10 @@ class TestCommandTemplateValidation:
             "recipe": {"command": "python run.py"},
         }
         errors = validate_analysis(self._make(out))
-        codes = [e.code for e in errors]
-        assert "UNREFERENCED_INPUT" in codes
+        assert errors == []
 
-    def test_unreferenced_decision_warns(self):
+    def test_declared_but_unreferenced_decision_is_fine(self):
+        # Same as above for decisions.
         out = {
             "id": "r",
             "type": "metric",
@@ -371,10 +406,9 @@ class TestCommandTemplateValidation:
             "m": {"label": "M", "default": "a", "options": {"a": {"label": "A"}}},
         }
         errors = validate_analysis(self._make(out, decisions))
-        codes = [e.code for e in errors]
-        assert "UNREFERENCED_DECISION" in codes
+        assert errors == []
 
-    def test_inputs_glob_satisfies_input_references(self):
+    def test_inputs_glob_is_valid_template(self):
         out = {
             "id": "r",
             "type": "metric",


### PR DESCRIPTION
## Summary

- Migrates the validator and tooling to astra-spec [v0.0.7](https://github.com/LightconeResearch/astra-spec/releases/tag/v0.0.7) (covers PRs [#19](https://github.com/LightconeResearch/astra-spec/pull/19) and [#22](https://github.com/LightconeResearch/astra-spec/pull/22)): dependencies live on the Output (`Output.inputs`, `Output.decisions`), Recipe is `command` + `resources` + `container`, and `from:` aliasing is unified across Input/Output/Decision with multi-level path support.
- Adds a `{...}` template-grammar validator for `Recipe.command` that types its substitution surface against the surrounding Output's declarations — closing the "decision in scope but ignored by command" failure mode.
- Updates fixtures, both `examples/iris*/astra.yaml`, the `astra init` template, and the CLI `info`/`viz` commands to the new schema.
- Bumps `astra-spec>=0.0.7` in `pyproject.toml`.

## Validator surface

- `Output.inputs` resolve to an analysis Input, sibling Output, or qualified sub-analysis output. Cycles run on the Output→Output graph.
- `Output.decisions` resolve through `from:` chains.
- `Recipe.command` placeholders: `{inputs}`, `{inputs.<id>}`, `{decisions.<id>}`, `{output}`; `{{` / `}}` are literal braces. Every `{inputs.<id>}` / `{decisions.<id>}` must resolve to an item declared on the Output. Declared-but-unreferenced inputs/decisions are intentionally **not** flagged — the spec grants the runner free choice of delivery (flags, env vars, sidecar JSON), so a recipe with `python script.py` and decisions delivered by sidecar is just as valid as one using `{decisions.x}` substitution.
- Unified `from:` grammar (parsed once via `_parse_from_path`):
  - `Input.from`: must escape upward — `../id`, `../../id`, `../scope.out_id`.
  - `Output.from`: must descend — `child.out_id`, `child.sub.out_id`.
  - `Decision.from`: ancestor only — `../id`, `../../id`.
- New codes: `INVALID_OUTPUT_INPUT`, `INVALID_OUTPUT_DECISION`, `OUTPUT_CYCLE` (replaces `RECIPE_CYCLE`), `UNDECLARED_TEMPLATE_REF`, `INVALID_COMMAND_TEMPLATE`, `INVALID_OUTPUT_FROM`.

## Test plan

- [x] `pytest` — 192 passed, 21 skipped
- [x] `ruff check src/ tests/` clean
- [x] `astra validate examples/iris/astra.yaml` ✓
- [x] `astra validate examples/iris_pipeline/astra.yaml` ✓
- [x] astra-spec v0.0.7 released; dependency pin bumped

🤖 Generated with [Claude Code](https://claude.com/claude-code)