### PR TITLE
Suggest tree-path form when narrative anchor uses 'analyses.<sub>.<cat>' anti-pattern

### DIFF
--- a/src/astra/validation/narrative.py
+++ b/src/astra/validation/narrative.py
@@ -59,6 +59,13 @@ _CATEGORIES = frozenset(
     {"inputs", "outputs", "decisions", "findings", "prior_insights", "analyses"}
 )
 
+# Non-canonical "analyses.<sub>.<category>..." drill-in — the spec-canonical
+# form drops the "analyses." collection prefix when descending into a
+# sub-analysis (e.g. #pure_eb.decisions.foo, not #analyses.pure_eb.decisions.foo).
+_ANALYSES_PREFIX_FORM_RE = re.compile(
+    r"^analyses\.[^.]+\.(?:" + "|".join(sorted(_CATEGORIES)) + r")(?:\.|$)"
+)
+
 # Categories whose elements are coverage-checked, with the human-readable
 # label used in warnings. Options, inputs, and prior_insights are
 # intentionally excluded: options are typically numerous, inputs are
@@ -278,6 +285,22 @@ def _walk_anchors(
                 continue
             parsed = _parse_anchor(raw)
             if parsed is None:
+                stripped = raw
+                while stripped.startswith("../"):
+                    stripped = stripped[3:]
+                if _ANALYSES_PREFIX_FORM_RE.match(stripped):
+                    errors.append(
+                        SemanticError(
+                            "INVALID_NARRATIVE_ANCHOR",
+                            f"Anchor '{href}' starts with 'analyses.<sub>' but "
+                            f"drilling below the sub-analysis node uses the "
+                            f"tree-path form: write '#<sub>.<category>.<id>' "
+                            f"(or '#../<sib>.<category>.<id>' from a sibling) "
+                            f"instead.",
+                            narrative_path,
+                        )
+                    )
+                    continue
                 errors.append(
                     SemanticError(
                         "INVALID_NARRATIVE_ANCHOR",

--- a/tests/test_narrative.py
+++ b/tests/test_narrative.py
@@ -145,6 +145,72 @@ class TestAnchorResolution:
         assert len(errs) == 1
         assert errs[0].code == "INVALID_NARRATIVE_ANCHOR"
 
+    def test_analyses_prefix_drill_in_emits_tailored_hint(self) -> None:
+        # `#analyses.<sub>.<cat>.<id>` is the natural-but-wrong form authors
+        # write when drilling into a sub-analysis. The correct form drops
+        # the `analyses.` collection prefix: `#<sub>.<cat>.<id>`.
+        data = _minimal_with_narrative("[bad](#analyses.sub.decisions.d)")
+        data["analyses"] = {
+            "sub": {
+                "inputs": [{"id": "x", "type": "data"}],
+                "outputs": [{"id": "y", "type": "metric"}],
+                "decisions": {
+                    "d": {
+                        "label": "D",
+                        "rationale": "r",
+                        "default": "a",
+                        "options": {"a": {"label": "A"}},
+                    }
+                },
+            }
+        }
+        errs = validate_narrative_anchors(data)
+        assert len(errs) == 1
+        assert errs[0].code == "INVALID_NARRATIVE_ANCHOR"
+        assert "starts with 'analyses.<sub>'" in errs[0].message
+        assert "#<sub>.<category>.<id>" in errs[0].message
+
+    def test_analyses_prefix_drill_in_with_parent_escape_emits_tailored_hint(self) -> None:
+        # Sibling reference written with the analyses-prefix anti-pattern:
+        # `#../analyses.<sib>.<cat>.<id>`. The correct form is
+        # `#../<sib>.<cat>.<id>`.
+        data = _minimal_with_narrative("(placeholder)")
+        data["analyses"] = {
+            "sub": {
+                "narrative": {"summary": "[bad](#../analyses.other.decisions.d)"},
+                "inputs": [{"id": "x", "type": "data"}],
+                "outputs": [{"id": "y", "type": "metric"}],
+            },
+            "other": {
+                "inputs": [{"id": "x", "type": "data"}],
+                "outputs": [{"id": "y", "type": "metric"}],
+                "decisions": {
+                    "d": {
+                        "label": "D",
+                        "rationale": "r",
+                        "default": "a",
+                        "options": {"a": {"label": "A"}},
+                    }
+                },
+            },
+        }
+        errs = validate_narrative_anchors(data)
+        assert len(errs) == 1
+        assert errs[0].code == "INVALID_NARRATIVE_ANCHOR"
+        assert "starts with 'analyses.<sub>'" in errs[0].message
+
+    def test_analyses_node_reference_still_valid(self) -> None:
+        # `#analyses.<sub>` (whole sub-analysis node, no further drill-in)
+        # remains the canonical form and must not trigger the new hint.
+        data = _minimal_with_narrative("[s](#analyses.sub)")
+        data["analyses"] = {
+            "sub": {
+                "inputs": [{"id": "x", "type": "data"}],
+                "outputs": [{"id": "y", "type": "metric"}],
+            }
+        }
+        assert validate_narrative_anchors(data) == []
+
     def test_external_links_ignored(self) -> None:
         # URLs and other non-anchor hrefs are not ASTRA references.
         data = _minimal_with_narrative(


### PR DESCRIPTION
Closes #72

## Problem

`[INVALID_NARRATIVE_ANCHOR]` returns a generic "does not match the narrative anchor grammar" message when authors write `#analyses.<sub>.<cat>.<id>` to drill into a sub-analysis. The actually-correct form is `#<sub>.<cat>.<id>` (the sub-analysis ID becomes the path segment), but the message gives no hint.

## Fix

Add a pre-check in `_walk_anchors`, symmetric with the existing `_PARENT_PATH_FORM_RE` diagnostic, that detects the `analyses.<sub>.<cat>` prefix (after stripping `../`) and emits a tailored hint pointing to the tree-path form.

## Test plan

- [x] Existing valid forms continue to validate: `#analyses.pure_eb`, `#pure_eb.decisions.hartlap_application`, `#../cosebis.decisions.mode_subsets`
- [x] Anti-pattern emits tailored message: `#analyses.pure_eb.decisions.hartlap_application`
- [x] Parent-escape + anti-pattern combo emits tailored message: `#../analyses.cosebis.decisions.mode_subsets`
- [x] `pytest` clean
- [x] `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- dco-signed-off-by -->
Signed-off-by: Cail Daley <cail.daley@cea.fr>