### PR TITLE
Walk findings.evidence in --verify-evidence; SKIP artifact-backed evidence

### DIFF
--- a/src/astra/cli.py
+++ b/src/astra/cli.py
@@ -249,12 +249,15 @@ def _init_git_repo(directory: Path, no_git: bool) -> None:
     "--verify-evidence",
     "-e",
     is_flag=True,
-    help="Verify evidence quotes exist in source papers (requires papers to be cached)",
+    help=(
+        "Verify evidence quotes (in prior_insights and findings) "
+        "exist in source papers (requires papers to be cached)"
+    ),
 )
 @click.option(
     "--skip-evidence",
     is_flag=True,
-    help="Skip evidence verification even if prior insights are present",
+    help="Skip evidence verification even if prior insights or findings are present",
 )
 def validate(file: Path, analysis: Path | None, verify_evidence: bool, skip_evidence: bool) -> None:
     """Validate an ASTRA specification file.
@@ -262,9 +265,10 @@ def validate(file: Path, analysis: Path | None, verify_evidence: bool, skip_evid
     FILE can be an analysis (astra.yaml) or universe file.
     For universe files, use --analysis to specify the analysis file.
 
-    Evidence verification (--verify-evidence) checks that quotes in prior insights
-    actually exist in the source papers. Papers must be cached first using
-    'astra paper add'.
+    Evidence verification (--verify-evidence) checks that quotes in prior_insights
+    and findings actually exist in the source papers. Papers must be cached first
+    using 'astra paper add'. Artifact-backed evidence (typical for findings whose
+    artifacts are not yet materialized) is reported as SKIPPED.
     """
     # Determine file type
     is_universe = "universe" in file.stem.lower() or file.parent.name == "universes"
@@ -339,33 +343,46 @@ def validate(file: Path, analysis: Path | None, verify_evidence: bool, skip_evid
         else:
             console.print("[green]✓[/green] Narrative coverage complete")
 
-    # Evidence verification (for analysis files with prior insights)
+    # Evidence verification (for analysis files with prior insights and/or findings)
     if not is_universe and not skip_evidence:
         prior_insights = data.get("prior_insights", {})
+        findings = data.get("findings", {})
 
-        if prior_insights:
+        if prior_insights or findings:
             if not verify_evidence:
                 # Show hint about evidence verification
-                evidence_count = sum(
+                prior_ev_count = sum(
                     len(insight.get("evidence", [])) for insight in prior_insights.values()
                 )
-                if evidence_count > 0:
+                finding_ev_count = sum(
+                    len(finding.get("evidence", [])) for finding in findings.values()
+                )
+                total_ev = prior_ev_count + finding_ev_count
+                if total_ev > 0:
                     console.print(
-                        f"\n[dim]Note: {len(prior_insights)} prior insight(s) with "
-                        f"{evidence_count} evidence item(s) found.[/dim]"
+                        f"\n[dim]Note: {len(prior_insights)} prior insight(s) "
+                        f"({prior_ev_count} evidence) and {len(findings)} finding(s) "
+                        f"({finding_ev_count} evidence) found.[/dim]"
                     )
                     console.print(
                         "[dim]Run with --verify-evidence to verify quotes exist in papers.[/dim]"
                     )
             else:
                 console.print("\n[bold]Verifying evidence...[/bold]")
-                _verify_insights_evidence(prior_insights)
+                if prior_insights:
+                    _verify_insights_evidence(prior_insights, label="prior_insights")
+                if findings:
+                    _verify_insights_evidence(findings, label="findings")
 
     console.print("\n[green]Validation successful![/green]")
 
 
-def _verify_insights_evidence(prior_insights: dict[str, Any]) -> None:
-    """Verify evidence for all prior insights."""
+def _verify_insights_evidence(insights: dict[str, Any], label: str = "prior_insights") -> None:
+    """Verify evidence for all insight-shaped entries (prior_insights or findings).
+
+    The verification machinery is generic over insight-shaped dicts
+    ({<id>: {claim, evidence: [...]}}); the label is used only for the summary line.
+    """
     from astra.papers.cache import PaperCache
     from astra.verification.cache import VerificationCache
     from astra.verification.core import VerificationStatus, verify_all_insights
@@ -373,12 +390,12 @@ def _verify_insights_evidence(prior_insights: dict[str, Any]) -> None:
     paper_cache = PaperCache()
     verification_cache = VerificationCache()
 
-    results = verify_all_insights(prior_insights, paper_cache, verification_cache)
+    results = verify_all_insights(insights, paper_cache, verification_cache)
 
-    has_errors = False
     verified_count = 0
     cached_count = 0
     skipped_count = 0
+    artifact_skipped_count = 0
     failed_count = 0
 
     for insight_id, result in results.items():
@@ -390,9 +407,12 @@ def _verify_insights_evidence(prior_insights: dict[str, Any]) -> None:
                     cached_count += 1
             elif status == VerificationStatus.SKIPPED:
                 skipped_count += 1
+                # Artifact-backed evidence carries its own diagnostic message;
+                # surface it as a separate count so the gap is visible.
+                if "Artifact quote verification" in ev_result.message:
+                    artifact_skipped_count += 1
             else:
                 failed_count += 1
-                has_errors = True
                 if status == VerificationStatus.ERROR:
                     icon = "[yellow]![/yellow]"
                 else:
@@ -403,17 +423,19 @@ def _verify_insights_evidence(prior_insights: dict[str, Any]) -> None:
 
     # Summary
     total = verified_count + skipped_count + failed_count
+    parts = [f"{verified_count}/{total} verified"]
     if cached_count > 0:
-        console.print(
-            f"[green]✓[/green] Evidence: {verified_count}/{total} verified "
-            f"({cached_count} from cache), {skipped_count} skipped"
-        )
-    else:
-        console.print(
-            f"[green]✓[/green] Evidence: {verified_count}/{total} verified, {skipped_count} skipped"
-        )
+        parts.append(f"{cached_count} from cache")
+    if artifact_skipped_count > 0:
+        parts.append(f"{artifact_skipped_count} SKIPPED (artifact)")
+        other_skipped = skipped_count - artifact_skipped_count
+        if other_skipped > 0:
+            parts.append(f"{other_skipped} skipped")
+    elif skipped_count > 0:
+        parts.append(f"{skipped_count} skipped")
+    console.print(f"[green]✓[/green] Evidence ({label}): " + ", ".join(parts))
 
-    if has_errors:
+    if failed_count > 0:
         console.print(f"\n[red]Error:[/red] {failed_count} evidence item(s) failed verification")
         console.print("\nTo fix:")
         console.print("  1. Check that quotes are exact copies from the paper")

--- a/src/astra/verification/core.py
+++ b/src/astra/verification/core.py
@@ -107,6 +107,31 @@ def _get_attr(obj: Any, key: str, default: Any = None) -> Any:
     return getattr(obj, key, default)
 
 
+def _skip_if_no_paper(evidence: Any) -> EvidenceVerification | None:
+    """Return a SKIPPED EvidenceVerification for evidence that has no paper backing.
+
+    Some evidence (typically findings.evidence) references an `artifact:` (output ID)
+    rather than a paper DOI — there is no document to search, so paper-cache lookup
+    would spuriously return ERROR ("Paper not in cache"). Mark these SKIPPED so the
+    gap is visible in the summary instead of being reported as a failure.
+
+    Returns None if the evidence has a DOI (normal paper-backed verification path).
+    """
+    doi = _get_attr(evidence, "doi", "")
+    if doi:
+        return None
+    if _get_attr(evidence, "artifact"):
+        artifact_id = _get_attr(evidence, "artifact", "unknown")
+        return EvidenceVerification(
+            evidence_id=_get_attr(evidence, "id", "unknown"),
+            doi="",
+            version=_get_attr(evidence, "version"),
+            status=VerificationStatus.SKIPPED,
+            message=f"Artifact quote verification not yet implemented: {artifact_id}",
+        )
+    return None
+
+
 def _determine_overall_status(results: list[EvidenceVerification]) -> VerificationStatus:
     """Determine overall verification status from individual results.
 
@@ -239,6 +264,15 @@ def verify_evidence(
         result.status = VerificationStatus.SKIPPED
         result.message = f"Table verification not yet implemented: {label}"
 
+    elif _get_attr(evidence, "artifact"):
+        # Artifact-backed evidence (typical for findings.evidence): the evidence
+        # references an output ID rather than a paper DOI. At SPECIFY phase the
+        # artifact is not materialized, so there is no document to search.
+        # Mark SKIPPED so the gap is visible in the summary rather than silent.
+        artifact_id = _get_attr(evidence, "artifact", "unknown")
+        result.status = VerificationStatus.SKIPPED
+        result.message = f"Artifact quote verification not yet implemented: {artifact_id}"
+
     return result
 
 
@@ -271,6 +305,13 @@ def verify_insight(
 
     # Group evidence by DOI/version for efficiency
     for ev in evidence_list:
+        # Artifact-backed evidence (no paper DOI) cannot be verified against a PDF;
+        # emit SKIPPED so the gap is visible instead of a spurious "paper not cached" error.
+        skipped = _skip_if_no_paper(ev)
+        if skipped is not None:
+            evidence_results.append(skipped)
+            continue
+
         evidence_id = _get_attr(ev, "id", "unknown")
         doi = _get_attr(ev, "doi", "")
         version = _get_attr(ev, "version")
@@ -346,6 +387,9 @@ def verify_all_insights(
     # Collect all unique (DOI, version) pairs across all insights
     for insight in insights.values():
         for ev in _get_attr(insight, "evidence", []):
+            # Skip artifact-backed evidence (no DOI) — handled per-evidence below.
+            if _skip_if_no_paper(ev) is not None:
+                continue
             doi = _get_attr(ev, "doi", "")
             version = _get_attr(ev, "version")
             key = (doi, version)
@@ -391,6 +435,13 @@ def _verify_insight_with_pdf_cache(
     evidence_results: list[EvidenceVerification] = []
 
     for ev in evidence_list:
+        # Artifact-backed evidence (no paper DOI) cannot be verified against a PDF;
+        # emit SKIPPED so the gap is visible instead of a spurious "paper not cached" error.
+        skipped = _skip_if_no_paper(ev)
+        if skipped is not None:
+            evidence_results.append(skipped)
+            continue
+
         evidence_id = _get_attr(ev, "id", "unknown")
         doi = _get_attr(ev, "doi", "")
         version = _get_attr(ev, "version")

--- a/tests/test_findings_verification.py
+++ b/tests/test_findings_verification.py
@@ -1,0 +1,228 @@
+"""Unit tests for findings.evidence verification and artifact-backed evidence skipping.
+
+Covers the fix from PR ":astra validate --verify-evidence" walking findings.evidence
+in addition to prior_insights.evidence, and the symmetric SKIPPED handling for
+artifact-backed evidence (which has no paper to verify against).
+
+These tests do not need network access — they construct in-memory PDFDocument
+objects and dispatch through the verification machinery directly.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from click.testing import CliRunner
+
+from astra.cli import main
+from astra.verification.core import (
+    VerificationStatus,
+    verify_all_insights,
+    verify_evidence,
+)
+from astra.verification.pdf import PDFDocument
+
+# ---------------------------------------------------------------------------
+# Stub paper cache: returns a pre-built PDFDocument by DOI/version
+# ---------------------------------------------------------------------------
+
+
+class _StubCachedPaper:
+    def __init__(self, pdf_path: Path) -> None:
+        self.pdf_path = pdf_path
+
+
+class _StubPaperCache:
+    """Minimal paper cache stand-in with optional pre-canned PDFs by (doi, version)."""
+
+    def __init__(self, pdfs: dict[tuple[str, int | None], PDFDocument] | None = None) -> None:
+        self._pdfs = pdfs or {}
+
+    def get(self, doi: str, version: int | None = None) -> _StubCachedPaper | None:
+        if (doi, version) in self._pdfs:
+            # Path is unused by our stub extract_text monkeypatch; placeholder fine.
+            return _StubCachedPaper(Path(f"/tmp/{doi.replace('/', '_')}.pdf"))
+        return None
+
+
+@pytest.fixture
+def patch_extract(monkeypatch: pytest.MonkeyPatch):
+    """Patch extract_text_from_pdf to return our pre-built PDFDocument."""
+
+    def _install(pdfs: dict[tuple[str, int | None], PDFDocument]) -> _StubPaperCache:
+        def fake_extract(_path: Path) -> PDFDocument:
+            # Single-PDF fixtures: return the only one we have.
+            return next(iter(pdfs.values()))
+
+        monkeypatch.setattr(
+            "astra.verification.core.extract_text_from_pdf", fake_extract
+        )
+        return _StubPaperCache(pdfs)
+
+    return _install
+
+
+# ---------------------------------------------------------------------------
+# Direct unit tests on verify_evidence + verify_all_insights
+# ---------------------------------------------------------------------------
+
+
+def test_artifact_evidence_returns_skipped_directly() -> None:
+    """verify_evidence on artifact-backed evidence (no quote/figure/table) → SKIPPED."""
+    pdf = PDFDocument(path=None, pages=[""], num_pages=1, sha256="x")  # type: ignore[arg-type]
+    evidence = {"id": "ev1", "artifact": "trained_model"}
+    result = verify_evidence(evidence, pdf)
+    assert result.status == VerificationStatus.SKIPPED
+    assert "Artifact quote verification not yet implemented" in result.message
+    assert "trained_model" in result.message
+
+
+def test_findings_with_artifact_evidence_skipped(patch_extract: Any) -> None:
+    """verify_all_insights walks findings-shaped dict and skips artifact-only evidence."""
+    paper_cache = patch_extract({})
+    findings = {
+        "result_a": {
+            "id": "result_a",
+            "claim": "Some result",
+            "evidence": [
+                {"id": "ev_a", "artifact": "accuracy_table"},
+                {"id": "ev_b", "artifact": "f1_table"},
+            ],
+        }
+    }
+    results = verify_all_insights(findings, paper_cache=paper_cache)  # type: ignore[arg-type]
+
+    assert "result_a" in results
+    ev_results = results["result_a"].evidence_results
+    assert len(ev_results) == 2
+    assert all(ev.status == VerificationStatus.SKIPPED for ev in ev_results)
+    assert all("Artifact quote verification" in ev.message for ev in ev_results)
+
+
+def test_findings_with_paper_evidence_verified(patch_extract: Any) -> None:
+    """findings.evidence backed by a paper DOI flows through normal verification."""
+    pdf = PDFDocument(
+        path=None,  # type: ignore[arg-type]
+        pages=["The pipeline reproduces the canonical result within 1 percent."],
+        num_pages=1,
+        sha256="abc",
+    )
+    paper_cache = patch_extract({("10.9999/findings_paper", 1): pdf})
+
+    findings = {
+        "reproduction": {
+            "id": "reproduction",
+            "claim": "Pipeline reproduces the canonical result.",
+            "evidence": [
+                {
+                    "id": "ev_paper",
+                    "doi": "10.9999/findings_paper",
+                    "version": 1,
+                    "quote": {
+                        "type": "TextQuoteSelector",
+                        "exact": "The pipeline reproduces the canonical result within 1 percent.",
+                    },
+                }
+            ],
+        }
+    }
+    results = verify_all_insights(findings, paper_cache=paper_cache)  # type: ignore[arg-type]
+
+    ev = results["reproduction"].evidence_results[0]
+    assert ev.status in (VerificationStatus.VERIFIED, VerificationStatus.CACHED)
+
+
+def test_prior_insights_still_walked(patch_extract: Any) -> None:
+    """Regression guard: prior_insights verification is unchanged by the findings extension."""
+    pdf = PDFDocument(
+        path=None,  # type: ignore[arg-type]
+        pages=["Prior result that was already verified."],
+        num_pages=1,
+        sha256="xyz",
+    )
+    paper_cache = patch_extract({("10.1234/prior", 2): pdf})
+
+    prior = {
+        "p1": {
+            "id": "p1",
+            "claim": "Prior result.",
+            "evidence": [
+                {
+                    "id": "ev_p1",
+                    "doi": "10.1234/prior",
+                    "version": 2,
+                    "quote": {
+                        "type": "TextQuoteSelector",
+                        "exact": "Prior result that was already verified.",
+                    },
+                }
+            ],
+        }
+    }
+    results = verify_all_insights(prior, paper_cache=paper_cache)  # type: ignore[arg-type]
+    ev = results["p1"].evidence_results[0]
+    assert ev.status in (VerificationStatus.VERIFIED, VerificationStatus.CACHED)
+
+
+# ---------------------------------------------------------------------------
+# CLI-level: validate --verify-evidence reports findings + artifact SKIPPED
+# ---------------------------------------------------------------------------
+
+
+def test_cli_validate_reports_findings_artifact_skipped(
+    tmp_path: Path, patch_extract: Any
+) -> None:
+    """`astra validate --verify-evidence` walks findings and reports SKIPPED (artifact)."""
+    # No paper-backed PDFs needed: all evidence is artifact-backed.
+    patch_extract({})
+
+    yaml_text = """\
+version: "1.0"
+name: "Findings walk smoke test"
+narrative:
+  summary: |
+    Smoke-test fixture for findings.evidence walk. The [result](#findings.result)
+    is supported by an artifact-backed evidence item.
+  methods: |
+    A single [method decision](#decisions.method) governs the run.
+  inputs: |
+    Consumes the [data](#inputs.data) input.
+  outputs: |
+    Produces the [accuracy_table](#outputs.accuracy_table).
+  findings: |
+    Reports the [result](#findings.result).
+inputs:
+  - id: data
+    type: data
+outputs:
+  - id: accuracy_table
+    type: table
+decisions:
+  method:
+    label: Method
+    default: a
+    options:
+      a: {label: A}
+      b: {label: B}
+findings:
+  result:
+    id: result
+    claim: "Method A is best."
+    created_at: "2026-01-01T00:00:00Z"
+    evidence:
+      - id: ev_acc
+        artifact: accuracy_table
+"""
+    analysis_path = tmp_path / "astra.yaml"
+    analysis_path.write_text(yaml_text)
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["validate", str(analysis_path), "--verify-evidence"])
+
+    assert result.exit_code == 0, result.output
+    assert "Verifying evidence" in result.output
+    assert "findings" in result.output
+    assert "SKIPPED (artifact)" in result.output
+    assert "Validation successful" in result.output

--- a/tests/test_findings_verification.py
+++ b/tests/test_findings_verification.py
@@ -56,9 +56,7 @@ def patch_extract(monkeypatch: pytest.MonkeyPatch):
             # Single-PDF fixtures: return the only one we have.
             return next(iter(pdfs.values()))
 
-        monkeypatch.setattr(
-            "astra.verification.core.extract_text_from_pdf", fake_extract
-        )
+        monkeypatch.setattr("astra.verification.core.extract_text_from_pdf", fake_extract)
         return _StubPaperCache(pdfs)
 
     return _install
@@ -171,9 +169,7 @@ def test_prior_insights_still_walked(patch_extract: Any) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_cli_validate_reports_findings_artifact_skipped(
-    tmp_path: Path, patch_extract: Any
-) -> None:
+def test_cli_validate_reports_findings_artifact_skipped(tmp_path: Path, patch_extract: Any) -> None:
     """`astra validate --verify-evidence` walks findings and reports SKIPPED (artifact)."""
     # No paper-backed PDFs needed: all evidence is artifact-backed.
     patch_extract({})


### PR DESCRIPTION
Closes #74

## Problem

`astra validate --verify-evidence` only walked `prior_insights.evidence`. `findings.evidence` was silently unverified — fabricated quotes would survive the check clean. Verification-side mirror of #70's citation-side asymmetry; both faces of the same findings-second-class pattern.

## Fix

- `cli.py`: extend the verify-evidence section to walk both `prior_insights` and `findings`, reusing the existing verification machinery (insight-shape-agnostic). Generalized `_verify_insights_evidence` to take any insight-shaped dict + a label for the summary line.
- `verification/core.py`: add `SKIPPED` handling for `artifact:` evidence, parallel to the existing handling for `figure:` / `table:` evidence. New `_skip_if_no_paper` helper short-circuits the per-evidence loop in `verify_insight` and `_verify_insight_with_pdf_cache` so artifact-only evidence does not spuriously surface as "Paper not in cache". Makes the artifact-quote-verification gap *visible* without solving it (deeper design question).
- Help text updated to mention findings.
- Summary surfaces artifact skips distinctly: `Evidence (findings): 0/1 verified, 1 SKIPPED (artifact)`.

## Test plan

- [x] Existing `prior_insights` verification continues to work (regression guard test)
- [x] `findings.evidence` with paper-backed evidence is verified through the normal path
- [x] `findings.evidence` with artifact-backed evidence reports SKIPPED with "Artifact quote verification not yet implemented"
- [x] CLI smoke test: `astra validate --verify-evidence` on a findings-only artifact-backed analysis exits 0 and prints `SKIPPED (artifact)` in the summary
- [x] `pytest` clean (186 passed, 21 skipped — network tests unaffected)
- [x] `ruff check src/ tests/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- dco-signed-off-by -->
Signed-off-by: Cail Daley <cail.daley@cea.fr>
Signed-off-by: EiffL <fr.eiffel@gmail.com>