### PR TITLE
Streamline init template: drop outputs/ dir, add container field

### DIFF
--- a/examples/iris/astra.yaml
+++ b/examples/iris/astra.yaml
@@ -1,6 +1,7 @@
 id: iris_classification
 version: "0.1.0"
 name: Iris Classification Study
+container: python:3.12-slim
 narrative:
   summary: |
     A demonstration analysis that builds a classifier for the classic

--- a/examples/iris_pipeline/astra.yaml
+++ b/examples/iris_pipeline/astra.yaml
@@ -1,6 +1,7 @@
 id: iris_pipeline
 version: "0.1.0"
 name: Iris Two-Stage Classification
+container: python:3.12-slim
 narrative:
   summary: |
     A two-stage pipeline for Iris classification that demonstrates

--- a/src/astra/cli.py
+++ b/src/astra/cli.py
@@ -111,12 +111,10 @@ def init(directory: Path, no_git: bool) -> None:
 
     # Create directory structure
     (directory / "universes").mkdir(parents=True, exist_ok=True)
-    (directory / "outputs").mkdir(parents=True, exist_ok=True)
     (directory / "src").mkdir(parents=True, exist_ok=True)
 
     # Create .gitignore
     gitignore = """# ASTRA Analysis
-outputs/
 __pycache__/
 *.py[cod]
 .venv/
@@ -144,6 +142,7 @@ def _create_boilerplate_astra_yaml(directory: Path) -> None:
 
 version: "1.0"
 name: "{name}"
+container: python:3.12-slim
 narrative:
   summary: |
     TODO: One-paragraph overview of the analysis — its question,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -256,7 +256,6 @@ class TestInitCommand:
         assert (project_dir / ".gitignore").exists()
         assert (project_dir / "universes").is_dir()
         assert (project_dir / "universes" / "baseline.yaml").exists()
-        assert (project_dir / "outputs").is_dir()
         assert (project_dir / "src").is_dir()
 
         # Agentic scaffolding NOT created (handled by prism init)
@@ -282,6 +281,7 @@ class TestInitCommand:
         assert "version:" in content
         assert "decisions:" in content
         assert "recipe:" in content
+        assert "container:" in content
 
     def test_init_gitignore_content(self, runner: CliRunner, tmp_path: Path):
         """Test gitignore content."""
@@ -293,8 +293,8 @@ class TestInitCommand:
         assert result.exit_code == 0
 
         gitignore = (project_dir / ".gitignore").read_text()
-        assert "outputs/" in gitignore
         assert "__pycache__/" in gitignore
+        assert ".venv/" in gitignore
 
     def test_init_existing_nonempty_dir_fails(self, runner: CliRunner, tmp_path: Path):
         """Test that init fails on existing non-empty directory."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -295,6 +295,7 @@ class TestInitCommand:
         gitignore = (project_dir / ".gitignore").read_text()
         assert "__pycache__/" in gitignore
         assert ".venv/" in gitignore
+        assert "outputs/" not in gitignore
 
     def test_init_existing_nonempty_dir_fails(self, runner: CliRunner, tmp_path: Path):
         """Test that init fails on existing non-empty directory."""


### PR DESCRIPTION
## Summary

- Remove the vestigial `outputs/` directory that `astra init` was creating. ASTRA does not prescribe a materialized-output directory layout — that is an executor concern.
- Drop the matching `outputs/` line from the generated `.gitignore`.
- Add `container: python:3.12-slim` to the boilerplate `astra.yaml` so the scaffold is runnable end-to-end as soon as an executor is wired up.

Downstream tools that bring their own container build (e.g. lightcone-cli) can amend this `container:` line to point at a project-local `Containerfile`. This removes a chunk of duplicated init logic in `lightcone-cli`, which was previously emitting its own `astra.yaml` boilerplate to inject the `container:` field.

## Test plan

- [x] `pytest tests/test_cli.py::TestInitCommand` (11 tests pass)
- [x] Full suite: `pytest` (196 pass, 21 skipped — same as main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)