### PR TITLE
Align narrative validator with single-blob schema (tracks astra-spec)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,10 +10,7 @@ authors = [
 ]
 
 dependencies = [
-    # TEMPORARY: pinned to feature branch until astra-spec#23 (narrative-as-
-    # markdown) is merged + released. Revert to "astra-spec>=0.0.8" (or
-    # whatever the post-merge version is) once that lands.
-    "astra-spec @ git+https://github.com/LightconeResearch/astra-spec.git@feature/narrative-as-markdown",
+    "astra-spec>=0.0.7",
     "click>=8.0",
     "pydantic>=2.0",
     "pyyaml>=6.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,10 @@ authors = [
 ]
 
 dependencies = [
-    "astra-spec>=0.0.7",
+    # TEMPORARY: pinned to feature branch until astra-spec#23 (narrative-as-
+    # markdown) is merged + released. Revert to "astra-spec>=0.0.8" (or
+    # whatever the post-merge version is) once that lands.
+    "astra-spec @ git+https://github.com/LightconeResearch/astra-spec.git@feature/narrative-as-markdown",
     "click>=8.0",
     "pydantic>=2.0",
     "pyyaml>=6.0",

--- a/src/astra/cli.py
+++ b/src/astra/cli.py
@@ -26,7 +26,7 @@ from astra.helpers import (
 from astra.validation.narrative import (
     check_narrative_coverage,
     validate_narrative_anchors,
-    validate_narrative_sections,
+    validate_narrative_figure_embeds,
 )
 from astra.validation.schema import (
     validate_analysis_data,
@@ -143,23 +143,22 @@ def _create_boilerplate_astra_yaml(directory: Path) -> None:
 version: "1.0"
 name: "{name}"
 container: python:3.12-slim
-narrative:
-  summary: |
-    TODO: One-paragraph overview of the analysis — its question,
-    scope, and what the reader should take away.
-  findings: |
-    TODO: Prose that frames the analysis's findings. Reference
-    structured findings with `#findings.<id>` anchors once they
-    exist.
-  methods: |
-    TODO: Methodology write-up. Reference decisions and any
-    sub-analyses; this scaffold mentions the
-    [example method decision](#decisions.example_method).
-  inputs: |
-    TODO: Prose that frames the analysis's inputs.
-  outputs: |
-    TODO: Prose that frames the expected outputs; this scaffold
-    mentions the [main result output](#outputs.main_result).
+narrative: |
+  # Summary
+
+  TODO: One-paragraph overview of the analysis — its question,
+  scope, and what the reader should take away.
+
+  # Methods
+
+  TODO: Methodology write-up. Reference decisions and any
+  sub-analyses; this scaffold mentions the
+  [example method decision](#decisions.example_method).
+
+  # Outputs
+
+  TODO: Prose that frames the expected outputs; this scaffold
+  mentions the [main result output](#outputs.main_result).
 
 inputs:
   - id: primary_data
@@ -322,14 +321,14 @@ def validate(file: Path, analysis: Path | None, verify_evidence: bool, skip_evid
 
         console.print("[green]✓[/green] Narrative anchors resolved")
 
-        section_errors = validate_narrative_sections(data, base_path=file.parent)
-        if section_errors:
-            console.print("\n[red]Narrative section errors:[/red]")
-            for section_err in section_errors:
-                console.print(f"  • {section_err}")
+        embed_errors = validate_narrative_figure_embeds(data, base_path=file.parent)
+        if embed_errors:
+            console.print("\n[red]Narrative figure-embed errors:[/red]")
+            for embed_err in embed_errors:
+                console.print(f"  • {embed_err}")
             raise SystemExit(1)
 
-        console.print("[green]✓[/green] Narrative sections present")
+        console.print("[green]✓[/green] Narrative figure embeds valid")
 
         narrative_warnings = check_narrative_coverage(data, base_path=file.parent)
         if narrative_warnings:
@@ -445,13 +444,11 @@ def info(
     # Header
     console.print(f"\n[bold]{data.get('name', 'Unknown')}[/bold]")
     console.print(f"Version: {data.get('version', 'Unknown')}")
-    narrative = data.get("narrative") or {}
-    for section in ("summary", "findings", "methods", "inputs", "outputs"):
-        content = narrative.get(section)
-        if isinstance(content, str) and content.strip():
-            console.print()
-            console.print(f"[bold]{section.title()}[/bold]")
-            console.print(content)
+    narrative = data.get("narrative")
+    if isinstance(narrative, str) and narrative.strip():
+        console.print()
+        console.print("[bold]Narrative[/bold]")
+        console.print(narrative)
 
     # Summary stats
     input_list = get_inputs(data)

--- a/src/astra/cli.py
+++ b/src/astra/cli.py
@@ -158,7 +158,12 @@ narrative: |
   # Outputs
 
   TODO: Prose that frames the expected outputs; this scaffold
-  mentions the [main result output](#outputs.main_result).
+  mentions the [main result output](#outputs.main_result). On its
+  own line, Markdown image syntax pointing at a previewable output
+  (figure / table / metric) renders as an inline embed in the
+  reader UI:
+
+  ![Headline metric](#outputs.main_result)
 
 inputs:
   - id: primary_data

--- a/src/astra/validation/__init__.py
+++ b/src/astra/validation/__init__.py
@@ -6,8 +6,8 @@ from astra.validation.narrative import (
     check_narrative_coverage_file,
     validate_narrative_anchors,
     validate_narrative_anchors_file,
-    validate_narrative_sections,
-    validate_narrative_sections_file,
+    validate_narrative_figure_embeds,
+    validate_narrative_figure_embeds_file,
 )
 from astra.validation.schema import (
     is_valid_analysis,
@@ -38,8 +38,8 @@ __all__ = [
     "validate_analysis_schema",
     "validate_narrative_anchors",
     "validate_narrative_anchors_file",
-    "validate_narrative_sections",
-    "validate_narrative_sections_file",
+    "validate_narrative_figure_embeds",
+    "validate_narrative_figure_embeds_file",
     "validate_universe",
     "validate_universe_data",
     "validate_universe_file",

--- a/src/astra/validation/narrative.py
+++ b/src/astra/validation/narrative.py
@@ -1,25 +1,15 @@
 """Narrative validation for ASTRA specifications.
 
-Three checks layered on top of structural and semantic validation:
+Two checks layered on top of structural and semantic validation:
 
-1. **Anchor resolution** — Markdown links inside narrative section
-   prose of the form ``[text](#target)`` must resolve to a declared
-   element. Broken references are errors.
+1. **Anchor resolution** — Markdown links inside narrative prose of
+   the form ``[text](#target)`` must resolve to a declared element.
+   Broken references are errors.
 
 2. **Coverage** — each Analysis node's own decisions, findings,
    outputs, and sub-analyses should be mentioned somewhere in the
-   narrative tree. References may appear in any of the five narrative
-   sections — coverage is resolved across the whole narrative, not
-   per-section. Unmentioned elements emit warnings (not errors).
-
-3. **Sections** — a narrative section is required (non-empty prose)
-   when the corresponding structured data exists on the Analysis
-   node: ``findings`` when ``Analysis.findings`` has entries;
-   ``methods`` when ``Analysis.decisions`` or ``Analysis.analyses``
-   has entries; ``inputs`` when ``Analysis.inputs`` has entries;
-   ``outputs`` when ``Analysis.outputs`` has entries. ``summary`` is
-   always optional. Violations are errors — authors must narrate
-   what they declare.
+   narrative tree. References may appear anywhere across the tree;
+   unmentioned elements emit warnings (not errors).
 
 Anchor grammar is **tree-path-first**, matching the rest of ASTRA's
 reference syntax (``sibling.output_id`` in ``from``). Sub-analyses
@@ -51,9 +41,20 @@ from astra.helpers import load_yaml, resolve_analysis_tree
 from astra.validation.semantic import SemanticError
 
 _HREF_RE = re.compile(r"\[[^\]]*\]\(([^)\s]+)\)")
+# Image-syntax variant — `![alt](href)` — used for figure embeds in
+# rendered narrative. The renderer treats a standalone-line image
+# whose href is `#outputs.<id>` as an inline preview of that output;
+# the validator enforces shape regardless of position.
+_IMAGE_HREF_RE = re.compile(r"!\[[^\]]*\]\(([^)\s]+)\)")
 # Non-canonical "../" before "#" — the spec-canonical form puts the parent
 # escape inside the fragment (e.g. (#../decisions.foo), not (../#decisions.foo)).
 _PARENT_PATH_FORM_RE = re.compile(r"^(?:\.\./)+#")
+
+# Output types that have a visual preview in the renderer. Image syntax
+# pointing at an output of any other type would silently fall through to
+# a plain link — almost certainly an author mistake, so the validator
+# rejects it.
+_PREVIEWABLE_OUTPUT_TYPES = frozenset({"figure", "table", "metric"})
 
 _CATEGORIES = frozenset(
     {"inputs", "outputs", "decisions", "findings", "prior_insights", "analyses"}
@@ -70,9 +71,6 @@ _COVERAGE_CATEGORY_LABELS: dict[str, str] = {
     "outputs": "Output",
     "analyses": "Sub-analysis",
 }
-
-# The five narrative sections, in canonical render order.
-_NARRATIVE_SECTIONS = ("summary", "findings", "methods", "inputs", "outputs")
 
 
 @dataclass
@@ -204,24 +202,15 @@ def _resolve_anchor(
     return (target_path, anchor.category, anchor.element_id, anchor.option_id)
 
 
-def _iter_sections(narrative: Any) -> Iterator[tuple[str, str]]:
-    """Yield ``(section, content)`` pairs for each non-empty section,
-    in canonical render order. Non-dict narratives yield nothing —
-    the spec's ``Narrative`` is a dict of five optional section fields.
-    """
-    if not isinstance(narrative, dict):
-        return
-    for section in _NARRATIVE_SECTIONS:
-        content = narrative.get(section)
-        if isinstance(content, str) and content:
-            yield section, content
+def _narrative_text(node: dict[str, Any]) -> str:
+    """Return the narrative blob for a node, or empty string if missing/wrong type."""
+    n = node.get("narrative")
+    return n if isinstance(n, str) else ""
 
 
-def _extract_section_hrefs(narrative: Any) -> Iterator[tuple[str, str]]:
-    """Yield ``(section, href)`` for every Markdown link across sections."""
-    for section, content in _iter_sections(narrative):
-        for href in _HREF_RE.findall(content):
-            yield section, href
+def _extract_hrefs(text: str) -> Iterator[str]:
+    """Yield every Markdown link href in the prose."""
+    yield from _HREF_RE.findall(text)
 
 
 def _node_path_str(path: tuple[str, ...]) -> str:
@@ -229,9 +218,9 @@ def _node_path_str(path: tuple[str, ...]) -> str:
     return ".".join(f"analyses.{seg}" for seg in path)
 
 
-def _narrative_report_path(base: str, section: str) -> str:
+def _narrative_report_path(base: str) -> str:
     """Build the path string used in error/warning reports for a narrative location."""
-    return f"{base}.narrative.{section}" if base else f"narrative.{section}"
+    return f"{base}.narrative" if base else "narrative"
 
 
 def validate_narrative_anchors(
@@ -251,11 +240,10 @@ def _walk_anchors(
     root: dict[str, Any],
     errors: list[SemanticError],
 ) -> None:
-    narrative = node.get("narrative")
-    if narrative:
-        base = _node_path_str(path)
-        for section, href in _extract_section_hrefs(narrative):
-            narrative_path = _narrative_report_path(base, section)
+    text = _narrative_text(node)
+    if text:
+        narrative_path = _narrative_report_path(_node_path_str(path))
+        for href in _extract_hrefs(text):
             if _PARENT_PATH_FORM_RE.match(href):
                 errors.append(
                     SemanticError(
@@ -304,9 +292,9 @@ def check_narrative_coverage(
     """Warn about decisions, findings, outputs, and sub-analyses not
     mentioned in any narrative across the analysis tree.
 
-    A reference anywhere in the tree — and in any section of a node's
-    narrative — counts toward the target element's coverage. Mentioning
-    a descendant implicitly mentions each sub-analysis along the path.
+    A reference anywhere in the tree counts toward the target element's
+    coverage. Mentioning a descendant implicitly mentions each
+    sub-analysis along the path.
     """
     if base_path is not None:
         data = resolve_analysis_tree(data, base_path)
@@ -323,9 +311,9 @@ def _collect_mentioned(
     root: dict[str, Any],
     mentioned: set[tuple[tuple[str, ...], str, str]],
 ) -> None:
-    narrative = node.get("narrative")
-    if narrative:
-        for _section, href in _extract_section_hrefs(narrative):
+    text = _narrative_text(node)
+    if text:
+        for href in _extract_hrefs(text):
             if not href.startswith("#"):
                 continue
             raw = href[1:]
@@ -386,65 +374,124 @@ def _walk_coverage(
         _walk_coverage(sub_node, path + (sub_id,), mentioned, warnings)
 
 
-# Narrative sections triggered by the presence of structured data.
-# Each maps a section name to the Analysis keys that require it.
-_DATA_TRIGGERED_SECTIONS: dict[str, tuple[str, ...]] = {
-    "findings": ("findings",),
-    "methods": ("decisions", "analyses"),
-    "inputs": ("inputs",),
-    "outputs": ("outputs",),
-}
-
-
-def validate_narrative_sections(
+def validate_narrative_figure_embeds(
     data: dict[str, Any], base_path: Path | None = None
 ) -> list[SemanticError]:
-    """Require a narrative section when the corresponding structured
-    data exists on the Analysis node. Authors must narrate what they
-    declare.
+    """Enforce figure-embed shape on Markdown image syntax.
 
-    - ``narrative.findings`` required when ``Analysis.findings`` has entries.
-    - ``narrative.methods`` required when ``Analysis.decisions`` or
-      ``Analysis.analyses`` has entries.
-    - ``narrative.inputs`` required when ``Analysis.inputs`` has entries.
-    - ``narrative.outputs`` required when ``Analysis.outputs`` has entries.
-    - ``narrative.summary`` is always optional (no structured counterpart).
+    Image syntax (``![alt](href)``) in narrative prose means "embed
+    this artefact" to the renderer. Author mistakes show up as image
+    syntax pointing at the wrong kind of thing; this validator rejects
+    them so they don't degrade silently to a broken link.
 
-    A section counts as present only if it holds non-empty prose
-    (whitespace doesn't satisfy the rule).
+    Errors:
+
+    - **External URL**: image href that isn't an anchor (no leading
+      ``#``). Narrative figures should reference the analysis's own
+      outputs, not external pictures.
+    - **Wrong category**: image href that resolves to a decision /
+      finding / input / sub-analysis / option, not an output. Only
+      outputs are artefacts.
+    - **Non-previewable output**: image href that resolves to an
+      output whose type isn't ``figure``, ``table``, or ``metric``
+      (the previewable set). The renderer can't show a preview, so
+      the embed would degrade to a plain link.
+
+    Anchor-grammar errors and broken-anchor errors are already reported
+    by ``validate_narrative_anchors``; this validator skips unparseable
+    or unresolvable hrefs to avoid duplicate diagnostics.
     """
     if base_path is not None:
         data = resolve_analysis_tree(data, base_path)
     errors: list[SemanticError] = []
-    _walk_section_requirements(data, (), errors)
+    _walk_figure_embeds(data, (), data, errors)
     return errors
 
 
-def _walk_section_requirements(
+def _output_type(node: dict[str, Any], output_id: str) -> str | None:
+    """Return the declared ``type`` for ``output_id`` on ``node``, or None."""
+    for out in node.get("outputs") or []:
+        if out.get("id") == output_id:
+            t = out.get("type")
+            return t if isinstance(t, str) else None
+    return None
+
+
+def _walk_figure_embeds(
     node: dict[str, Any],
     path: tuple[str, ...],
+    root: dict[str, Any],
     errors: list[SemanticError],
 ) -> None:
-    raw_narrative = node.get("narrative")
-    narrative = raw_narrative if isinstance(raw_narrative, dict) else {}
-    base = _node_path_str(path)
-    for section, trigger_keys in _DATA_TRIGGERED_SECTIONS.items():
-        present_triggers = [key for key in trigger_keys if node.get(key)]
-        if not present_triggers:
-            continue
-        content = narrative.get(section)
-        if isinstance(content, str) and content.strip():
-            continue
-        triggers_str = " and ".join(f"'{k}'" for k in present_triggers)
-        errors.append(
-            SemanticError(
-                "NARRATIVE_SECTION_REQUIRED",
-                f"Narrative section '{section}' is required because {triggers_str} has entries",
-                _narrative_report_path(base, section),
-            )
-        )
+    text = _narrative_text(node)
+    if text:
+        narrative_path = _narrative_report_path(_node_path_str(path))
+        for href in _IMAGE_HREF_RE.findall(text):
+            if not href.startswith("#"):
+                errors.append(
+                    SemanticError(
+                        "INVALID_FIGURE_EMBED",
+                        f"Figure embed '{href}' must reference an analysis "
+                        f"output (e.g. '#outputs.<id>'), not an external URL",
+                        narrative_path,
+                    )
+                )
+                continue
+            raw = href[1:]
+            if "." not in raw:
+                # Dotless anchor — bare Markdown heading link, not an
+                # ASTRA reference. Image syntax pointing at one is
+                # still nonsense (no artefact to embed), so flag it.
+                errors.append(
+                    SemanticError(
+                        "INVALID_FIGURE_EMBED",
+                        f"Figure embed '#{raw}' must reference an output "
+                        f"(e.g. '#outputs.<id>')",
+                        narrative_path,
+                    )
+                )
+                continue
+            parsed = _parse_anchor(raw)
+            if parsed is None:
+                # Anchor-grammar errors are reported by
+                # validate_narrative_anchors — skip to avoid duplicate
+                # diagnostics on the same href.
+                continue
+            resolved = _resolve_anchor(parsed, path, root)
+            if resolved is None:
+                # Same — broken-anchor errors are reported elsewhere.
+                continue
+            target_path, category, element_id, option_id = resolved
+            if category != "outputs" or option_id is not None:
+                errors.append(
+                    SemanticError(
+                        "INVALID_FIGURE_EMBED",
+                        f"Figure embed '#{raw}' targets a {category} entry; "
+                        f"image syntax may only reference outputs",
+                        narrative_path,
+                    )
+                )
+                continue
+            target_node = _get_node_at(root, target_path)
+            out_type = _output_type(target_node or {}, element_id) or "data"
+            if out_type not in _PREVIEWABLE_OUTPUT_TYPES:
+                errors.append(
+                    SemanticError(
+                        "INVALID_FIGURE_EMBED",
+                        f"Figure embed '#{raw}' targets output '{element_id}' "
+                        f"of type '{out_type}', which has no preview; "
+                        f"figure embeds require type figure, table, or metric",
+                        narrative_path,
+                    )
+                )
     for sub_id, sub_node in (node.get("analyses") or {}).items():
-        _walk_section_requirements(sub_node, path + (sub_id,), errors)
+        _walk_figure_embeds(sub_node, path + (sub_id,), root, errors)
+
+
+def validate_narrative_figure_embeds_file(path: str | Path) -> list[SemanticError]:
+    """Load and run figure-embed validation on a YAML file."""
+    path = Path(path)
+    return validate_narrative_figure_embeds(load_yaml(path), base_path=path.parent)
 
 
 def validate_narrative_anchors_file(path: str | Path) -> list[SemanticError]:
@@ -457,9 +504,3 @@ def check_narrative_coverage_file(path: str | Path) -> list[NarrativeWarning]:
     """Load and run coverage check on a YAML file."""
     path = Path(path)
     return check_narrative_coverage(load_yaml(path), base_path=path.parent)
-
-
-def validate_narrative_sections_file(path: str | Path) -> list[SemanticError]:
-    """Load and run section-requirement check on a YAML file."""
-    path = Path(path)
-    return validate_narrative_sections(load_yaml(path), base_path=path.parent)

--- a/src/astra/validation/narrative.py
+++ b/src/astra/validation/narrative.py
@@ -445,8 +445,7 @@ def _walk_figure_embeds(
                 errors.append(
                     SemanticError(
                         "INVALID_FIGURE_EMBED",
-                        f"Figure embed '#{raw}' must reference an output "
-                        f"(e.g. '#outputs.<id>')",
+                        f"Figure embed '#{raw}' must reference an output (e.g. '#outputs.<id>')",
                         narrative_path,
                     )
                 )

--- a/tests/fixtures/invalid/narrative_broken_anchor.yaml
+++ b/tests/fixtures/invalid/narrative_broken_anchor.yaml
@@ -1,9 +1,8 @@
 version: "1.0"
 name: "Broken Anchor"
-narrative:
-  summary: |
-    References to [a missing decision](#decisions.nonexistent)
-    and [a missing finding](#findings.also_missing) should fail.
+narrative: |
+  References to [a missing decision](#decisions.nonexistent)
+  and [a missing finding](#findings.also_missing) should fail.
 
 inputs:
   - id: primary_data

--- a/tests/fixtures/invalid/path_field_conflict.yaml
+++ b/tests/fixtures/invalid/path_field_conflict.yaml
@@ -14,5 +14,4 @@ analyses:
     # the sub's own values pre-fix). Both are confusing — must be in the
     # sub's astra.yaml instead.
     name: "Preprocessing override"
-    narrative:
-      summary: "Parent-side override that does nothing useful."
+    narrative: "Parent-side override that does nothing useful."

--- a/tests/fixtures/valid/conditional_outputs.yaml
+++ b/tests/fixtures/valid/conditional_outputs.yaml
@@ -1,8 +1,8 @@
 # Analysis with conditional outputs using when conditions
 version: "1.0"
 name: "Conditional Outputs Analysis"
-narrative:
-  summary: "Tests when conditions on outputs with negation and lists"
+narrative: |
+  Tests when conditions on outputs with negation and lists
 inputs:
   - id: training_data
     type: data

--- a/tests/fixtures/valid/decision_list_when.yaml
+++ b/tests/fixtures/valid/decision_list_when.yaml
@@ -1,8 +1,8 @@
 # Analysis with a decision that has a list-valued when condition
 version: "1.0"
 name: "Decision List When"
-narrative:
-  summary: "Tests list-valued when on decisions"
+narrative: |
+  Tests list-valued when on decisions
 inputs:
   - id: data
     type: data

--- a/tests/fixtures/valid/full.yaml
+++ b/tests/fixtures/valid/full.yaml
@@ -1,10 +1,21 @@
 version: "1.0"
 name: "Full Analysis"
-narrative:
-  summary: "A comprehensive test analysis with all features"
-  methods: "Driven by preprocessing, model, test_split, and seed decisions."
-  inputs: "Uses primary_data and an optional reference_study."
-  outputs: "Emits a trained model, accuracy/f1 metrics, a plot, a summary table, and a conclusion."
+narrative: |
+  # Summary
+
+  A comprehensive test analysis with all features
+
+  # Methods
+
+  Driven by preprocessing, model, test_split, and seed decisions.
+
+  # Inputs
+
+  Uses primary_data and an optional reference_study.
+
+  # Outputs
+
+  Emits a trained model, accuracy/f1 metrics, a plot, a summary table, and a conclusion.
 authors:
   - "Test Author"
 tags:

--- a/tests/fixtures/valid/full_v2.yaml
+++ b/tests/fixtures/valid/full_v2.yaml
@@ -3,8 +3,8 @@
 $schema: "https://astra-spec.org/v1/schema.json"
 version: "1.0"
 name: "Full Analysis v2"
-narrative:
-  summary: "A comprehensive test analysis with all v2 features"
+narrative: |
+  A comprehensive test analysis with all v2 features
 authors:
   - "Test Author"
 tags:

--- a/tests/fixtures/valid/minimal.yaml
+++ b/tests/fixtures/valid/minimal.yaml
@@ -1,9 +1,17 @@
 version: "1.0"
 name: "Minimal Analysis"
-narrative:
-  methods: "Single [method](#decisions.method) decision."
-  inputs: "Consumes [test_data](#inputs.test_data)."
-  outputs: "Emits [result](#outputs.result)."
+narrative: |
+  # Methods
+
+  Single [method](#decisions.method) decision.
+
+  # Inputs
+
+  Consumes [test_data](#inputs.test_data).
+
+  # Outputs
+
+  Emits [result](#outputs.result).
 inputs:
   - id: test_data
     type: data

--- a/tests/fixtures/valid/narrative_full_coverage.yaml
+++ b/tests/fixtures/valid/narrative_full_coverage.yaml
@@ -1,22 +1,31 @@
 version: "1.0"
 name: "Narrative Full Coverage"
-narrative:
-  summary: |
-    Exercises the narrative anchor grammar with full coverage of
-    the local elements.
-  findings: |
-    Highlights the [best method finding](#findings.best_method).
-  methods: |
-    Driven by the [method decision](#decisions.method) with
-    [option a](#decisions.method.options.a) as the default. A
-    descendant reference like [child scaling](#preprocessing.decisions.scaling)
-    also counts toward the
-    [preprocessing sub-analysis](#analyses.preprocessing)'s
-    coverage.
-  inputs: |
-    Consumes the [primary_data](#inputs.primary_data) input.
-  outputs: |
-    Produces the [accuracy output](#outputs.accuracy).
+narrative: |
+  # Summary
+
+  Exercises the narrative anchor grammar with full coverage of
+  the local elements.
+
+  # Findings
+
+  Highlights the [best method finding](#findings.best_method).
+
+  # Methods
+
+  Driven by the [method decision](#decisions.method) with
+  [option a](#decisions.method.options.a) as the default. A
+  descendant reference like [child scaling](#preprocessing.decisions.scaling)
+  also counts toward the
+  [preprocessing sub-analysis](#analyses.preprocessing)'s
+  coverage.
+
+  # Inputs
+
+  Consumes the [primary_data](#inputs.primary_data) input.
+
+  # Outputs
+
+  Produces the [accuracy output](#outputs.accuracy).
 
 inputs:
   - id: primary_data
@@ -50,13 +59,18 @@ findings:
 
 analyses:
   preprocessing:
-    narrative:
-      summary: |
-        Sub-analysis narrative.
-      methods: |
-        Mentions its own [scaling decision](#decisions.scaling).
-      outputs: |
-        Produces the [scaled output](#outputs.scaled).
+    narrative: |
+      # Summary
+
+      Sub-analysis narrative.
+
+      # Methods
+
+      Mentions its own [scaling decision](#decisions.scaling).
+
+      # Outputs
+
+      Produces the [scaled output](#outputs.scaled).
     inputs:
       - id: raw
         from: ../primary_data

--- a/tests/fixtures/valid/narrative_full_coverage.yaml
+++ b/tests/fixtures/valid/narrative_full_coverage.yaml
@@ -10,6 +10,8 @@ narrative: |
 
   Highlights the [best method finding](#findings.best_method).
 
+  ![Confusion matrix on the held-out set](#outputs.confusion_matrix)
+
   # Methods
 
   Driven by the [method decision](#decisions.method) with
@@ -25,7 +27,11 @@ narrative: |
 
   # Outputs
 
-  Produces the [accuracy output](#outputs.accuracy).
+  Produces the [accuracy output](#outputs.accuracy). On its own line,
+  Markdown image syntax pointing at a previewable output renders as an
+  inline embed in the reader UI:
+
+  ![Accuracy on the held-out test set](#outputs.accuracy)
 
 inputs:
   - id: primary_data
@@ -38,6 +44,13 @@ outputs:
     description: "Accuracy"
     recipe:
       command: python src/main.py
+
+  - id: confusion_matrix
+    type: figure
+    description: "Confusion matrix"
+    inputs: [accuracy]
+    recipe:
+      command: python src/plot_cm.py {inputs.accuracy}
 
 decisions:
   method:

--- a/tests/test_narrative.py
+++ b/tests/test_narrative.py
@@ -248,9 +248,7 @@ class TestMarkdownHeadings:
         assert validate_narrative_anchors(data) == []
 
     def test_broken_anchor_reports_narrative_path(self) -> None:
-        data = _minimal_with_narrative(
-            "# Findings\n\n[bad](#decisions.nope)"
-        )
+        data = _minimal_with_narrative("# Findings\n\n[bad](#decisions.nope)")
         errs = validate_narrative_anchors(data)
         assert len(errs) == 1
         assert errs[0].path == "narrative"
@@ -272,9 +270,7 @@ class TestFigureEmbeds:
 
     def test_image_targeting_previewable_output_ok(self) -> None:
         # The minimal fixture's `y` output is a metric — previewable.
-        data = _minimal_with_narrative(
-            "Here is the headline result:\n\n![accuracy](#outputs.y)"
-        )
+        data = _minimal_with_narrative("Here is the headline result:\n\n![accuracy](#outputs.y)")
         assert validate_narrative_figure_embeds(data) == []
 
     def test_image_targeting_decision_errors(self) -> None:
@@ -298,9 +294,7 @@ class TestFigureEmbeds:
         assert errs[0].code == "INVALID_FIGURE_EMBED"
 
     def test_image_with_external_url_errors(self) -> None:
-        data = _minimal_with_narrative(
-            "![logo](https://example.com/logo.png)"
-        )
+        data = _minimal_with_narrative("![logo](https://example.com/logo.png)")
         errs = validate_narrative_figure_embeds(data)
         assert len(errs) == 1
         assert errs[0].code == "INVALID_FIGURE_EMBED"
@@ -359,9 +353,7 @@ class TestFigureEmbeds:
         # Position-agnostic: even mid-paragraph image syntax is checked,
         # because the renderer's block-vs-inline rule is for rendering,
         # not validation. The author still meant to embed something.
-        data = _minimal_with_narrative(
-            "Some prose, then ![bad](#decisions.method) more prose."
-        )
+        data = _minimal_with_narrative("Some prose, then ![bad](#decisions.method) more prose.")
         errs = validate_narrative_figure_embeds(data)
         assert len(errs) == 1
         assert errs[0].code == "INVALID_FIGURE_EMBED"

--- a/tests/test_narrative.py
+++ b/tests/test_narrative.py
@@ -9,23 +9,12 @@ from astra.validation.narrative import (
     check_narrative_coverage_file,
     validate_narrative_anchors,
     validate_narrative_anchors_file,
-    validate_narrative_sections,
+    validate_narrative_figure_embeds,
 )
 
-_FULL_SECTIONS = ("summary", "findings", "methods", "inputs", "outputs")
 
-
-def _full_narrative(**overrides: str) -> dict[str, str]:
-    """Build a narrative with placeholder prose in every section."""
-    base = {s: f"{s} placeholder." for s in _FULL_SECTIONS}
-    base.update(overrides)
-    return base
-
-
-def _minimal_with_narrative(narrative: dict[str, str] | str) -> dict[str, object]:
-    """Build a minimal analysis. Shorthand: a bare string is placed in ``summary``."""
-    if isinstance(narrative, str):
-        narrative = {"summary": narrative}
+def _minimal_with_narrative(narrative: str) -> dict[str, object]:
+    """Build a minimal analysis with the given narrative blob."""
     return {
         "version": "1.0",
         "name": "Test",
@@ -101,7 +90,7 @@ class TestAnchorResolution:
         data = _minimal_with_narrative("(placeholder)")
         data["analyses"] = {
             "sub": {
-                "narrative": {"summary": "[parent method](#../decisions.method)"},
+                "narrative": "[parent method](#../decisions.method)",
                 "inputs": [{"id": "x", "type": "data"}],
                 "outputs": [{"id": "y", "type": "metric"}],
             }
@@ -184,7 +173,7 @@ class TestCoverage:
         )
         data["analyses"] = {
             "sub": {
-                "narrative": {"summary": "[d](#decisions.d) [o](#outputs.y)"},
+                "narrative": "[d](#decisions.d) [o](#outputs.y)",
                 "inputs": [{"id": "x", "type": "data"}],
                 "outputs": [{"id": "y", "type": "metric"}],
                 "decisions": {
@@ -219,7 +208,7 @@ class TestCoverage:
         data = _minimal_with_narrative("[d](#decisions.method) [o](#outputs.y) [s](#sub.outputs.y)")
         data["analyses"] = {
             "sub": {
-                "narrative": {"summary": "[o](#outputs.y)"},
+                "narrative": "[o](#outputs.y)",
                 "inputs": [{"id": "x", "type": "data"}],
                 "outputs": [{"id": "y", "type": "metric"}],
                 "decisions": {
@@ -244,126 +233,141 @@ class TestFileHelpers:
         assert all(e.code == "BROKEN_NARRATIVE_ANCHOR" for e in errs)
 
 
-class TestSectionedNarrative:
-    """Anchors and coverage work the same when narrative is a dict of sections."""
+class TestMarkdownHeadings:
+    """Heading levels are render-time concerns; the validator just sees prose.
+    These tests pin the contract: anchors and coverage work the same whether
+    the prose is a single paragraph or carries `#`/`##`/`###` structure."""
 
-    def test_anchors_across_sections_resolve(self) -> None:
+    def test_anchors_resolve_under_h1_and_h2_and_h3(self) -> None:
         data = _minimal_with_narrative(
-            _full_narrative(
-                methods="[method](#decisions.method) with [option](#decisions.method.options.a)",
-                outputs="See [output](#outputs.y).",
-                inputs="See [input](#inputs.x).",
-            )
+            "# Methods\n\n[method](#decisions.method) with "
+            "[option](#decisions.method.options.a)\n\n"
+            "## Inputs\n\nSee [input](#inputs.x).\n\n"
+            "### Outputs\n\nSee [output](#outputs.y)."
         )
         assert validate_narrative_anchors(data) == []
 
-    def test_broken_anchor_reports_section_path(self) -> None:
-        data = _minimal_with_narrative(_full_narrative(findings="[bad](#decisions.nope)"))
+    def test_broken_anchor_reports_narrative_path(self) -> None:
+        data = _minimal_with_narrative(
+            "# Findings\n\n[bad](#decisions.nope)"
+        )
         errs = validate_narrative_anchors(data)
         assert len(errs) == 1
-        assert errs[0].path == "narrative.findings"
+        assert errs[0].path == "narrative"
 
-    def test_coverage_is_global_across_sections(self) -> None:
-        # Decision cited in summary, output cited in outputs — both count.
+    def test_coverage_is_global_across_headings(self) -> None:
+        # Decision cited in one section, output cited in another — both count.
         data = _minimal_with_narrative(
-            _full_narrative(
-                summary="Mentions [method](#decisions.method) up top.",
-                outputs="Produces [y](#outputs.y).",
-            )
+            "# Summary\n\nMentions [method](#decisions.method) up top.\n\n"
+            "# Outputs\n\nProduces [y](#outputs.y)."
         )
         assert check_narrative_coverage(data) == []
 
 
-class TestNarrativeSections:
-    """Section-requirement check: a section is required when the
-    corresponding structured data exists on the Analysis node."""
+class TestFigureEmbeds:
+    """Image syntax (``![alt](href)``) means 'embed this artefact' to the
+    renderer. The validator enforces that authors only point image syntax
+    at previewable outputs; everything else is an author mistake that
+    would silently degrade to a plain link or nothing at all."""
 
-    def test_full_narrative_no_errors(self) -> None:
-        data = _minimal_with_narrative(_full_narrative())
-        assert validate_narrative_sections(data) == []
+    def test_image_targeting_previewable_output_ok(self) -> None:
+        # The minimal fixture's `y` output is a metric — previewable.
+        data = _minimal_with_narrative(
+            "Here is the headline result:\n\n![accuracy](#outputs.y)"
+        )
+        assert validate_narrative_figure_embeds(data) == []
 
-    def test_missing_methods_when_decisions_present_errors(self) -> None:
-        narrative = _full_narrative()
-        del narrative["methods"]
-        data = _minimal_with_narrative(narrative)
-        errs = validate_narrative_sections(data)
+    def test_image_targeting_decision_errors(self) -> None:
+        data = _minimal_with_narrative("![the decision](#decisions.method)")
+        errs = validate_narrative_figure_embeds(data)
         assert len(errs) == 1
-        assert errs[0].code == "NARRATIVE_SECTION_REQUIRED"
-        assert errs[0].path == "narrative.methods"
-        assert "'decisions'" in errs[0].message
+        assert errs[0].code == "INVALID_FIGURE_EMBED"
+        assert "decisions" in errs[0].message
+        assert errs[0].path == "narrative"
 
-    def test_missing_inputs_section_errors(self) -> None:
-        narrative = _full_narrative()
-        del narrative["inputs"]
-        data = _minimal_with_narrative(narrative)
-        errs = validate_narrative_sections(data)
+    def test_image_targeting_option_errors(self) -> None:
+        data = _minimal_with_narrative("![option a](#decisions.method.options.a)")
+        errs = validate_narrative_figure_embeds(data)
         assert len(errs) == 1
-        assert errs[0].path == "narrative.inputs"
+        assert errs[0].code == "INVALID_FIGURE_EMBED"
 
-    def test_empty_section_treated_as_missing(self) -> None:
-        data = _minimal_with_narrative(_full_narrative(outputs="   "))
-        errs = validate_narrative_sections(data)
-        paths = {e.path for e in errs}
-        assert "narrative.outputs" in paths
-
-    def test_summary_always_optional(self) -> None:
-        narrative = _full_narrative()
-        del narrative["summary"]
-        data = _minimal_with_narrative(narrative)
-        assert validate_narrative_sections(data) == []
-
-    def test_missing_findings_section_ok_when_no_findings_declared(self) -> None:
-        # The minimal fixture has no `findings:` key — so narrative.findings
-        # is not required, even though it is absent from the narrative.
-        narrative = _full_narrative()
-        del narrative["findings"]
-        data = _minimal_with_narrative(narrative)
-        assert data.get("findings") is None
-        assert validate_narrative_sections(data) == []
-
-    def test_findings_section_required_when_finding_declared(self) -> None:
-        narrative = _full_narrative()
-        del narrative["findings"]
-        data = _minimal_with_narrative(narrative)
-        data["findings"] = {
-            "f1": {
-                "id": "f1",
-                "claim": "A finding.",
-                "created_at": "2026-01-01T00:00:00",
-                "evidence": [],
-            }
-        }
-        errs = validate_narrative_sections(data)
+    def test_image_targeting_input_errors(self) -> None:
+        data = _minimal_with_narrative("![the input](#inputs.x)")
+        errs = validate_narrative_figure_embeds(data)
         assert len(errs) == 1
-        assert errs[0].path == "narrative.findings"
+        assert errs[0].code == "INVALID_FIGURE_EMBED"
 
-    def test_methods_required_when_only_analyses_present(self) -> None:
-        # A parent node with no decisions but with sub-analyses still
-        # requires narrative.methods.
+    def test_image_with_external_url_errors(self) -> None:
+        data = _minimal_with_narrative(
+            "![logo](https://example.com/logo.png)"
+        )
+        errs = validate_narrative_figure_embeds(data)
+        assert len(errs) == 1
+        assert errs[0].code == "INVALID_FIGURE_EMBED"
+        assert "external" in errs[0].message.lower()
+
+    def test_image_targeting_non_previewable_output_errors(self) -> None:
+        # Build an analysis with a `data`-typed output and reference it
+        # via image syntax — should fail because data outputs have no
+        # preview.
         data = {
             "version": "1.0",
             "name": "Test",
-            "narrative": {"summary": "top"},
-            "analyses": {
-                "sub": {
-                    "narrative": {"summary": "child"},
-                }
-            },
+            "narrative": "![raw](#outputs.dump)",
+            "inputs": [{"id": "x", "type": "data"}],
+            "outputs": [{"id": "dump", "type": "data"}],
         }
-        errs = validate_narrative_sections(data)
-        assert any(e.path == "narrative.methods" and "'analyses'" in e.message for e in errs)
+        errs = validate_narrative_figure_embeds(data)
+        assert len(errs) == 1
+        assert errs[0].code == "INVALID_FIGURE_EMBED"
+        assert "data" in errs[0].message
 
-    def test_sub_analysis_requirements_checked(self) -> None:
-        data = _minimal_with_narrative(_full_narrative())
+    def test_image_with_broken_anchor_does_not_double_error(self) -> None:
+        # Broken anchors are reported by validate_narrative_anchors;
+        # the figure-embed validator should stay quiet so the same
+        # mistake isn't reported twice.
+        data = _minimal_with_narrative("![missing](#outputs.nope)")
+        assert validate_narrative_figure_embeds(data) == []
+
+    def test_image_with_invalid_grammar_does_not_double_error(self) -> None:
+        data = _minimal_with_narrative("![weird](#nope.foo)")
+        assert validate_narrative_figure_embeds(data) == []
+
+    def test_image_in_sub_analysis_reports_sub_path(self) -> None:
+        data = _minimal_with_narrative("(top placeholder)")
         data["analyses"] = {
             "sub": {
-                "narrative": {"summary": "only summary here"},
+                "narrative": "![bad](#decisions.d)",
                 "inputs": [{"id": "x", "type": "data"}],
                 "outputs": [{"id": "y", "type": "metric"}],
+                "decisions": {
+                    "d": {
+                        "label": "D",
+                        "rationale": "r",
+                        "default": "a",
+                        "options": {"a": {"label": "A"}},
+                    }
+                },
             }
         }
-        errs = validate_narrative_sections(data)
-        sub_paths = {e.path for e in errs if e.path and "analyses.sub" in e.path}
-        # Only inputs and outputs required on the sub-analysis (no decisions,
-        # no child analyses, no findings).
-        assert sub_paths == {"analyses.sub.narrative.inputs", "analyses.sub.narrative.outputs"}
+        errs = validate_narrative_figure_embeds(data)
+        assert len(errs) == 1
+        assert errs[0].code == "INVALID_FIGURE_EMBED"
+        assert errs[0].path == "analyses.sub.narrative"
+
+    def test_inline_image_in_paragraph_still_validated(self) -> None:
+        # Position-agnostic: even mid-paragraph image syntax is checked,
+        # because the renderer's block-vs-inline rule is for rendering,
+        # not validation. The author still meant to embed something.
+        data = _minimal_with_narrative(
+            "Some prose, then ![bad](#decisions.method) more prose."
+        )
+        errs = validate_narrative_figure_embeds(data)
+        assert len(errs) == 1
+        assert errs[0].code == "INVALID_FIGURE_EMBED"
+
+    def test_plain_text_link_to_decision_unaffected(self) -> None:
+        # Text links to decisions are normal citations — only image
+        # syntax is constrained to outputs.
+        data = _minimal_with_narrative("[the method](#decisions.method)")
+        assert validate_narrative_figure_embeds(data) == []


### PR DESCRIPTION
## Summary
- Tracks [astra-spec#23](https://github.com/LightconeResearch/astra-spec/pull/23). Narrative is now a single Markdown string per Analysis node.
- Anchor resolution + coverage already operated across sections; they now iterate the one blob.
- The section-requirements check (require `narrative.<section>` when the corresponding structured data exists) is removed — there are no sections to enforce. Coverage at warning level still nudges authors to mention what they declare.
- Adds `validate_narrative_figure_embeds`: image syntax (`![alt](href)`) in narrative is the renderer's signal to embed an artefact inline; the validator enforces shape so author mistakes don't silently degrade.

## What `INVALID_FIGURE_EMBED` rejects
- External URL → `![logo](https://example.com/foo.png)`
- Wrong category → `![bad](#decisions.X)`, `![bad](#inputs.X)`, etc.
- Option target → `![bad](#decisions.X.options.Y)`
- Non-previewable output type → `![raw](#outputs.dump)` where `dump` is `data` / `report`

Broken-anchor and bad-grammar errors are still reported by the existing `validate_narrative_anchors` pass; the embed validator skips those to avoid duplicate diagnostics.

## Other changes
- `astra info` prints one Narrative block instead of looping over five fields.
- `astra init` scaffolds `narrative: |` with `# Summary` / `# Methods` / `# Outputs` headings as a starter shape.
- 7 fixtures migrated to the new format.
- `test_narrative.py`: drop section-shape tests, add `TestMarkdownHeadings` (heading-agnostic anchor + coverage) and `TestFigureEmbeds` (the new validator).

## Test plan
- [x] `pytest tests/test_narrative.py` — 36 passed
- [x] `pytest` (full suite) — 198 passed, 21 skipped
- [ ] Merge after astra-spec#23 lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)