### PR TITLE
Flesh out pyproject metadata for PyPI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ dev = [
 astra = "astra.cli:main"
 
 [project.urls]
-Homepage = "https://github.com/LightconeResearch/astra-tools"
+Homepage = "https://astra-spec.org/"
 Repository = "https://github.com/LightconeResearch/astra-tools"
 Issues = "https://github.com/LightconeResearch/astra-tools/issues"
 Specification = "https://github.com/LightconeResearch/astra-spec"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ requires-python = ">=3.11"
 authors = [
     { name = "Francois Lanusse", email = "francois.lanusse@cnrs.fr" },
     { name = "Liam Parker", email = "lhparker@berkeley.edu" },
+    { name = "Cail Daley", email = "cail.daley@cea.fr" },
 ]
 keywords = [
     "astra",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,8 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Scientific/Engineering",
     "Topic :: Software Development :: Libraries :: Python Modules",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,39 @@
 [project]
 name = "astra-tools"
 dynamic = ["version"]
-description = "ASTRA CLI."
-license = { text = "BSD-3-Clause" }
+description = "Python CLI and SDK for working with ASTRA (Agentic Schema for Transparent Research Analysis) specifications: validation, paper management, and evidence verification."
+readme = "README.md"
+license = "BSD-3-Clause"
+license-files = ["LICENSE"]
 requires-python = ">=3.11"
 authors = [
     { name = "Francois Lanusse", email = "francois.lanusse@cnrs.fr" },
     { name = "Liam Parker", email = "lhparker@berkeley.edu" },
+]
+keywords = [
+    "astra",
+    "research",
+    "reproducibility",
+    "multiverse-analysis",
+    "scientific-computing",
+    "schema",
+    "validation",
+    "linkml",
+    "agentic",
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Science/Research",
+    "Intended Audience :: Developers",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3 :: Only",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Typing :: Typed",
 ]
 
 dependencies = [
@@ -31,6 +58,12 @@ dev = [
 
 [project.scripts]
 astra = "astra.cli:main"
+
+[project.urls]
+Homepage = "https://github.com/LightconeResearch/astra-tools"
+Repository = "https://github.com/LightconeResearch/astra-tools"
+Issues = "https://github.com/LightconeResearch/astra-tools/issues"
+Specification = "https://github.com/LightconeResearch/astra-spec"
 
 [build-system]
 requires = ["hatchling", "hatch-vcs"]


### PR DESCRIPTION
## Summary
- Replace placeholder description with a proper one-line summary of what the package does
- Add `readme`, `keywords`, trove `classifiers`, and `[project.urls]` (Homepage, Repository, Issues, Specification) so the PyPI page is informative
- Switch to PEP 639 SPDX license expression (`license = "BSD-3-Clause"`) plus `license-files = ["LICENSE"]`

The package was previously kept intentionally terse; now that it's public on PyPI as `astra-tools`, this gives users browsing PyPI the context they need.

## Test plan
- [x] `uv build` succeeds
- [x] Inspected wheel `METADATA` — Summary, Project-URLs, License-Expression, License-File, Keywords, and Classifiers all present and correct
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)