### PR TITLE
Warn when analysis declares a different ASTRA spec version than installed

### DIFF
--- a/examples/iris/astra.yaml
+++ b/examples/iris/astra.yaml
@@ -1,5 +1,5 @@
 id: iris_classification
-version: "0.0.7"
+version: "0.0.10"
 name: Iris Classification Study
 container: python:3.12-slim
 narrative:

--- a/examples/iris/astra.yaml
+++ b/examples/iris/astra.yaml
@@ -1,5 +1,5 @@
 id: iris_classification
-version: "0.1.0"
+version: "0.0.7"
 name: Iris Classification Study
 container: python:3.12-slim
 narrative:

--- a/examples/iris_pipeline/astra.yaml
+++ b/examples/iris_pipeline/astra.yaml
@@ -1,5 +1,5 @@
 id: iris_pipeline
-version: "0.1.0"
+version: "0.0.7"
 name: Iris Two-Stage Classification
 container: python:3.12-slim
 narrative:

--- a/examples/iris_pipeline/astra.yaml
+++ b/examples/iris_pipeline/astra.yaml
@@ -1,5 +1,5 @@
 id: iris_pipeline
-version: "0.0.7"
+version: "0.0.10"
 name: Iris Two-Stage Classification
 container: python:3.12-slim
 narrative:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "astra-spec>=0.0.7",
+    "astra-spec>=0.0.10",
     "click>=8.0",
     "pydantic>=2.0",
     "pyyaml>=6.0",

--- a/src/astra/cli.py
+++ b/src/astra/cli.py
@@ -29,6 +29,7 @@ from astra.validation.narrative import (
     validate_narrative_sections,
 )
 from astra.validation.schema import (
+    check_spec_version,
     validate_analysis_data,
     validate_universe_data,
 )
@@ -281,6 +282,12 @@ def validate(file: Path, analysis: Path | None, verify_evidence: bool, skip_evid
 
     # Load once — all downstream checks take data dicts.
     data = load_yaml(file)
+
+    # Spec-version compatibility (analysis files only; non-fatal)
+    if not is_universe:
+        version_warning = check_spec_version(data)
+        if version_warning:
+            console.print(f"[yellow]⚠[/yellow]  [yellow]{version_warning}[/yellow]")
 
     # Schema validation
     if is_universe:

--- a/src/astra/validation/__init__.py
+++ b/src/astra/validation/__init__.py
@@ -10,6 +10,8 @@ from astra.validation.narrative import (
     validate_narrative_sections_file,
 )
 from astra.validation.schema import (
+    check_spec_version,
+    installed_spec_version,
     is_valid_analysis,
     is_valid_universe,
     validate_analysis_data,
@@ -30,6 +32,8 @@ __all__ = [
     "SemanticError",
     "check_narrative_coverage",
     "check_narrative_coverage_file",
+    "check_spec_version",
+    "installed_spec_version",
     "is_valid_analysis",
     "is_valid_universe",
     "validate_analysis",

--- a/src/astra/validation/schema.py
+++ b/src/astra/validation/schema.py
@@ -9,6 +9,8 @@ models expect an explicit ``id`` on each object.
 from __future__ import annotations
 
 import copy
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
 from pathlib import Path
 from typing import Any
 
@@ -105,6 +107,52 @@ def validate_universe_data(data: dict[str, Any]) -> list[str]:
         return []
     except PydanticValidationError as exc:
         return _format_pydantic_errors(exc)
+
+
+def installed_spec_version() -> str | None:
+    """Return the installed ``astra-spec`` package version, or None if unknown."""
+    try:
+        return _pkg_version("astra-spec")
+    except PackageNotFoundError:
+        return None
+
+
+def _normalize_version(v: str) -> tuple[int, ...] | None:
+    parts = v.split(".")
+    while len(parts) < 3:
+        parts.append("0")
+    try:
+        return tuple(int(p) for p in parts[:3])
+    except ValueError:
+        return None
+
+
+def check_spec_version(data: dict[str, Any]) -> str | None:
+    """Compare an analysis's declared ASTRA spec version to the installed astra-spec.
+
+    Returns a human-readable warning string when the declared ``version``
+    differs from the installed ``astra-spec`` package version, else None.
+    Returns None if either version is missing or unparseable — those cases
+    are surfaced (or ignored) by other validation layers.
+    """
+    declared = data.get("version")
+    if not isinstance(declared, str):
+        return None
+    installed = installed_spec_version()
+    if installed is None:
+        return None
+    declared_t = _normalize_version(declared)
+    installed_t = _normalize_version(installed)
+    if declared_t is None or installed_t is None:
+        return None
+    if declared_t == installed_t:
+        return None
+    return (
+        f"analysis declares ASTRA spec version {declared}, but astra-spec "
+        f"{installed} is installed; validation reflects the installed version. "
+        f"Pin astra-spec=={declared} to validate against the original spec, or "
+        f"update the analysis's version field after confirming compatibility."
+    )
 
 
 def is_valid_analysis(path: str | Path) -> bool:

--- a/tests/fixtures/invalid/duplicate_input_ids.yaml
+++ b/tests/fixtures/invalid/duplicate_input_ids.yaml
@@ -1,5 +1,5 @@
 # Duplicate input IDs
-version: "1.0"
+version: "0.0.7"
 name: "Test"
 inputs:
   - id: data

--- a/tests/fixtures/invalid/duplicate_input_ids.yaml
+++ b/tests/fixtures/invalid/duplicate_input_ids.yaml
@@ -1,5 +1,5 @@
 # Duplicate input IDs
-version: "0.0.7"
+version: "0.0.10"
 name: "Test"
 inputs:
   - id: data

--- a/tests/fixtures/invalid/duplicate_output_ids.yaml
+++ b/tests/fixtures/invalid/duplicate_output_ids.yaml
@@ -1,5 +1,5 @@
 # Duplicate output IDs
-version: "0.0.7"
+version: "0.0.10"
 name: "Test"
 inputs:
   - id: data

--- a/tests/fixtures/invalid/duplicate_output_ids.yaml
+++ b/tests/fixtures/invalid/duplicate_output_ids.yaml
@@ -1,5 +1,5 @@
 # Duplicate output IDs
-version: "1.0"
+version: "0.0.7"
 name: "Test"
 inputs:
   - id: data

--- a/tests/fixtures/invalid/excluded_default.yaml
+++ b/tests/fixtures/invalid/excluded_default.yaml
@@ -1,5 +1,5 @@
 # Default option is marked as excluded
-version: "1.0"
+version: "0.0.7"
 name: "Test"
 inputs:
   - id: data

--- a/tests/fixtures/invalid/excluded_default.yaml
+++ b/tests/fixtures/invalid/excluded_default.yaml
@@ -1,5 +1,5 @@
 # Default option is marked as excluded
-version: "0.0.7"
+version: "0.0.10"
 name: "Test"
 inputs:
   - id: data

--- a/tests/fixtures/invalid/excluded_no_reason.yaml
+++ b/tests/fixtures/invalid/excluded_no_reason.yaml
@@ -1,5 +1,5 @@
 # Excluded option without excluded_reason
-version: "1.0"
+version: "0.0.7"
 name: "Test"
 inputs:
   - id: data

--- a/tests/fixtures/invalid/excluded_no_reason.yaml
+++ b/tests/fixtures/invalid/excluded_no_reason.yaml
@@ -1,5 +1,5 @@
 # Excluded option without excluded_reason
-version: "0.0.7"
+version: "0.0.10"
 name: "Test"
 inputs:
   - id: data

--- a/tests/fixtures/invalid/input_from_downward.yaml
+++ b/tests/fixtures/invalid/input_from_downward.yaml
@@ -1,4 +1,4 @@
-version: "0.0.7"
+version: "0.0.10"
 name: "Test Input.from with downward path"
 description: "Input.from must escape upward, not descend into own children."
 inputs:

--- a/tests/fixtures/invalid/input_from_downward.yaml
+++ b/tests/fixtures/invalid/input_from_downward.yaml
@@ -1,4 +1,4 @@
-version: "1.0"
+version: "0.0.7"
 name: "Test Input.from with downward path"
 description: "Input.from must escape upward, not descend into own children."
 inputs:

--- a/tests/fixtures/invalid/invalid_constraint_ref.yaml
+++ b/tests/fixtures/invalid/invalid_constraint_ref.yaml
@@ -1,5 +1,5 @@
 # Constraint references non-existent decision/option
-version: "1.0"
+version: "0.0.7"
 name: "Test"
 inputs:
   - id: data

--- a/tests/fixtures/invalid/invalid_constraint_ref.yaml
+++ b/tests/fixtures/invalid/invalid_constraint_ref.yaml
@@ -1,5 +1,5 @@
 # Constraint references non-existent decision/option
-version: "0.0.7"
+version: "0.0.10"
 name: "Test"
 inputs:
   - id: data

--- a/tests/fixtures/invalid/invalid_default.yaml
+++ b/tests/fixtures/invalid/invalid_default.yaml
@@ -1,5 +1,5 @@
 # Default option doesn't exist in options
-version: "1.0"
+version: "0.0.7"
 name: "Test"
 inputs:
   - id: data

--- a/tests/fixtures/invalid/invalid_default.yaml
+++ b/tests/fixtures/invalid/invalid_default.yaml
@@ -1,5 +1,5 @@
 # Default option doesn't exist in options
-version: "0.0.7"
+version: "0.0.10"
 name: "Test"
 inputs:
   - id: data

--- a/tests/fixtures/invalid/invalid_finding_output.yaml
+++ b/tests/fixtures/invalid/invalid_finding_output.yaml
@@ -1,5 +1,5 @@
 # Finding references non-existent output artifact in evidence
-version: "0.0.7"
+version: "0.0.10"
 name: "Test"
 inputs:
   - id: data

--- a/tests/fixtures/invalid/invalid_finding_output.yaml
+++ b/tests/fixtures/invalid/invalid_finding_output.yaml
@@ -1,5 +1,5 @@
 # Finding references non-existent output artifact in evidence
-version: "1.0"
+version: "0.0.7"
 name: "Test"
 inputs:
   - id: data

--- a/tests/fixtures/invalid/invalid_input_type.yaml
+++ b/tests/fixtures/invalid/invalid_input_type.yaml
@@ -1,5 +1,5 @@
 # Invalid input type
-version: "1.0"
+version: "0.0.7"
 name: "Test"
 inputs:
   - id: data

--- a/tests/fixtures/invalid/invalid_input_type.yaml
+++ b/tests/fixtures/invalid/invalid_input_type.yaml
@@ -1,5 +1,5 @@
 # Invalid input type
-version: "0.0.7"
+version: "0.0.10"
 name: "Test"
 inputs:
   - id: data

--- a/tests/fixtures/invalid/invalid_insight_ref.yaml
+++ b/tests/fixtures/invalid/invalid_insight_ref.yaml
@@ -1,5 +1,5 @@
 # Option references non-existent insight
-version: "1.0"
+version: "0.0.7"
 name: "Test"
 inputs:
   - id: data

--- a/tests/fixtures/invalid/invalid_insight_ref.yaml
+++ b/tests/fixtures/invalid/invalid_insight_ref.yaml
@@ -1,5 +1,5 @@
 # Option references non-existent insight
-version: "0.0.7"
+version: "0.0.10"
 name: "Test"
 inputs:
   - id: data

--- a/tests/fixtures/invalid/invalid_output_type.yaml
+++ b/tests/fixtures/invalid/invalid_output_type.yaml
@@ -1,5 +1,5 @@
 # Invalid output type
-version: "0.0.7"
+version: "0.0.10"
 name: "Test"
 inputs:
   - id: data

--- a/tests/fixtures/invalid/invalid_output_type.yaml
+++ b/tests/fixtures/invalid/invalid_output_type.yaml
@@ -1,5 +1,5 @@
 # Invalid output type
-version: "1.0"
+version: "0.0.7"
 name: "Test"
 inputs:
   - id: data

--- a/tests/fixtures/invalid/invalid_output_when_ref.yaml
+++ b/tests/fixtures/invalid/invalid_output_when_ref.yaml
@@ -1,5 +1,5 @@
 # Output with when referencing a non-existent decision
-version: "1.0"
+version: "0.0.7"
 name: "Invalid Output When"
 inputs:
   - id: data

--- a/tests/fixtures/invalid/invalid_output_when_ref.yaml
+++ b/tests/fixtures/invalid/invalid_output_when_ref.yaml
@@ -1,5 +1,5 @@
 # Output with when referencing a non-existent decision
-version: "0.0.7"
+version: "0.0.10"
 name: "Invalid Output When"
 inputs:
   - id: data

--- a/tests/fixtures/invalid/invalid_parent_decision.yaml
+++ b/tests/fixtures/invalid/invalid_parent_decision.yaml
@@ -1,4 +1,4 @@
-version: "0.0.7"
+version: "0.0.10"
 name: "Test invalid decision from reference"
 description: "Sub-analysis references non-existent parent decision via from:"
 inputs:

--- a/tests/fixtures/invalid/invalid_parent_decision.yaml
+++ b/tests/fixtures/invalid/invalid_parent_decision.yaml
@@ -1,4 +1,4 @@
-version: "1.0"
+version: "0.0.7"
 name: "Test invalid decision from reference"
 description: "Sub-analysis references non-existent parent decision via from:"
 inputs:

--- a/tests/fixtures/invalid/narrative_broken_anchor.yaml
+++ b/tests/fixtures/invalid/narrative_broken_anchor.yaml
@@ -1,4 +1,4 @@
-version: "0.0.7"
+version: "0.0.10"
 name: "Broken Anchor"
 narrative:
   summary: |

--- a/tests/fixtures/invalid/narrative_broken_anchor.yaml
+++ b/tests/fixtures/invalid/narrative_broken_anchor.yaml
@@ -1,4 +1,4 @@
-version: "1.0"
+version: "0.0.7"
 name: "Broken Anchor"
 narrative:
   summary: |

--- a/tests/fixtures/invalid/orphan_excluded_reason.yaml
+++ b/tests/fixtures/invalid/orphan_excluded_reason.yaml
@@ -1,5 +1,5 @@
 # Option has excluded_reason but excluded is not true
-version: "0.0.7"
+version: "0.0.10"
 name: "Test"
 inputs:
   - id: data

--- a/tests/fixtures/invalid/orphan_excluded_reason.yaml
+++ b/tests/fixtures/invalid/orphan_excluded_reason.yaml
@@ -1,5 +1,5 @@
 # Option has excluded_reason but excluded is not true
-version: "1.0"
+version: "0.0.7"
 name: "Test"
 inputs:
   - id: data

--- a/tests/fixtures/invalid/output_from_unknown_child.yaml
+++ b/tests/fixtures/invalid/output_from_unknown_child.yaml
@@ -1,4 +1,4 @@
-version: "0.0.7"
+version: "0.0.10"
 name: "Test Output.from points at non-existent child"
 description: "Output.from references a sub-analysis that doesn't exist."
 inputs:

--- a/tests/fixtures/invalid/output_from_unknown_child.yaml
+++ b/tests/fixtures/invalid/output_from_unknown_child.yaml
@@ -1,4 +1,4 @@
-version: "1.0"
+version: "0.0.7"
 name: "Test Output.from points at non-existent child"
 description: "Output.from references a sub-analysis that doesn't exist."
 inputs:

--- a/tests/fixtures/invalid/output_from_upward.yaml
+++ b/tests/fixtures/invalid/output_from_upward.yaml
@@ -1,4 +1,4 @@
-version: "0.0.7"
+version: "0.0.10"
 name: "Test Output.from with upward path"
 description: "Output.from must descend into a sub-analysis, not escape upward."
 inputs:

--- a/tests/fixtures/invalid/output_from_upward.yaml
+++ b/tests/fixtures/invalid/output_from_upward.yaml
@@ -1,4 +1,4 @@
-version: "1.0"
+version: "0.0.7"
 name: "Test Output.from with upward path"
 description: "Output.from must descend into a sub-analysis, not escape upward."
 inputs:

--- a/tests/fixtures/invalid/path_field_conflict.yaml
+++ b/tests/fixtures/invalid/path_field_conflict.yaml
@@ -1,4 +1,4 @@
-version: "0.0.7"
+version: "0.0.10"
 name: "Test path/content conflict"
 inputs:
   - id: data

--- a/tests/fixtures/invalid/path_field_conflict.yaml
+++ b/tests/fixtures/invalid/path_field_conflict.yaml
@@ -1,4 +1,4 @@
-version: "1.0"
+version: "0.0.7"
 name: "Test path/content conflict"
 inputs:
   - id: data

--- a/tests/fixtures/invalid/recipe_invalid_input.yaml
+++ b/tests/fixtures/invalid/recipe_invalid_input.yaml
@@ -1,4 +1,4 @@
-version: "1.0"
+version: "0.0.7"
 name: "Invalid recipe input"
 inputs: []
 outputs:

--- a/tests/fixtures/invalid/recipe_invalid_input.yaml
+++ b/tests/fixtures/invalid/recipe_invalid_input.yaml
@@ -1,4 +1,4 @@
-version: "0.0.7"
+version: "0.0.10"
 name: "Invalid recipe input"
 inputs: []
 outputs:

--- a/tests/fixtures/invalid/recipe_output_cycle.yaml
+++ b/tests/fixtures/invalid/recipe_output_cycle.yaml
@@ -1,4 +1,4 @@
-version: "0.0.7"
+version: "0.0.10"
 name: "Recipe cycle"
 inputs: []
 outputs:

--- a/tests/fixtures/invalid/recipe_output_cycle.yaml
+++ b/tests/fixtures/invalid/recipe_output_cycle.yaml
@@ -1,4 +1,4 @@
-version: "1.0"
+version: "0.0.7"
 name: "Recipe cycle"
 inputs: []
 outputs:

--- a/tests/fixtures/invalid/sub_missing_outputs.yaml
+++ b/tests/fixtures/invalid/sub_missing_outputs.yaml
@@ -1,4 +1,4 @@
-version: "0.0.7"
+version: "0.0.10"
 name: "Test sub-analysis missing outputs"
 description: "Sub-analysis is missing required outputs"
 inputs:

--- a/tests/fixtures/invalid/sub_missing_outputs.yaml
+++ b/tests/fixtures/invalid/sub_missing_outputs.yaml
@@ -1,4 +1,4 @@
-version: "1.0"
+version: "0.0.7"
 name: "Test sub-analysis missing outputs"
 description: "Sub-analysis is missing required outputs"
 inputs:

--- a/tests/fixtures/valid/conditional_outputs.yaml
+++ b/tests/fixtures/valid/conditional_outputs.yaml
@@ -1,5 +1,5 @@
 # Analysis with conditional outputs using when conditions
-version: "0.0.7"
+version: "0.0.10"
 name: "Conditional Outputs Analysis"
 narrative:
   summary: "Tests when conditions on outputs with negation and lists"

--- a/tests/fixtures/valid/conditional_outputs.yaml
+++ b/tests/fixtures/valid/conditional_outputs.yaml
@@ -1,5 +1,5 @@
 # Analysis with conditional outputs using when conditions
-version: "1.0"
+version: "0.0.7"
 name: "Conditional Outputs Analysis"
 narrative:
   summary: "Tests when conditions on outputs with negation and lists"

--- a/tests/fixtures/valid/decision_list_when.yaml
+++ b/tests/fixtures/valid/decision_list_when.yaml
@@ -1,5 +1,5 @@
 # Analysis with a decision that has a list-valued when condition
-version: "1.0"
+version: "0.0.7"
 name: "Decision List When"
 narrative:
   summary: "Tests list-valued when on decisions"

--- a/tests/fixtures/valid/decision_list_when.yaml
+++ b/tests/fixtures/valid/decision_list_when.yaml
@@ -1,5 +1,5 @@
 # Analysis with a decision that has a list-valued when condition
-version: "0.0.7"
+version: "0.0.10"
 name: "Decision List When"
 narrative:
   summary: "Tests list-valued when on decisions"

--- a/tests/fixtures/valid/full.yaml
+++ b/tests/fixtures/valid/full.yaml
@@ -1,4 +1,4 @@
-version: "0.0.7"
+version: "0.0.10"
 name: "Full Analysis"
 narrative:
   summary: "A comprehensive test analysis with all features"

--- a/tests/fixtures/valid/full.yaml
+++ b/tests/fixtures/valid/full.yaml
@@ -1,4 +1,4 @@
-version: "1.0"
+version: "0.0.7"
 name: "Full Analysis"
 narrative:
   summary: "A comprehensive test analysis with all features"

--- a/tests/fixtures/valid/full_v2.yaml
+++ b/tests/fixtures/valid/full_v2.yaml
@@ -1,7 +1,7 @@
 # Full analysis with v2 features: decision tags,
 # conditional decisions, excluded options, and evidence snapshots.
 $schema: "https://astra-spec.org/v1/schema.json"
-version: "1.0"
+version: "0.0.7"
 name: "Full Analysis v2"
 narrative:
   summary: "A comprehensive test analysis with all v2 features"

--- a/tests/fixtures/valid/full_v2.yaml
+++ b/tests/fixtures/valid/full_v2.yaml
@@ -1,7 +1,7 @@
 # Full analysis with v2 features: decision tags,
 # conditional decisions, excluded options, and evidence snapshots.
 $schema: "https://astra-spec.org/v1/schema.json"
-version: "0.0.7"
+version: "0.0.10"
 name: "Full Analysis v2"
 narrative:
   summary: "A comprehensive test analysis with all v2 features"

--- a/tests/fixtures/valid/minimal.yaml
+++ b/tests/fixtures/valid/minimal.yaml
@@ -1,4 +1,4 @@
-version: "0.0.7"
+version: "0.0.10"
 name: "Minimal Analysis"
 narrative:
   methods: "Single [method](#decisions.method) decision."

--- a/tests/fixtures/valid/minimal.yaml
+++ b/tests/fixtures/valid/minimal.yaml
@@ -1,4 +1,4 @@
-version: "1.0"
+version: "0.0.7"
 name: "Minimal Analysis"
 narrative:
   methods: "Single [method](#decisions.method) decision."

--- a/tests/fixtures/valid/multilevel_from.yaml
+++ b/tests/fixtures/valid/multilevel_from.yaml
@@ -1,4 +1,4 @@
-version: "0.0.7"
+version: "0.0.10"
 name: "Test multi-level from: paths"
 
 inputs:

--- a/tests/fixtures/valid/multilevel_from.yaml
+++ b/tests/fixtures/valid/multilevel_from.yaml
@@ -1,4 +1,4 @@
-version: "1.0"
+version: "0.0.7"
 name: "Test multi-level from: paths"
 
 inputs:

--- a/tests/fixtures/valid/narrative_full_coverage.yaml
+++ b/tests/fixtures/valid/narrative_full_coverage.yaml
@@ -1,4 +1,4 @@
-version: "0.0.7"
+version: "0.0.10"
 name: "Narrative Full Coverage"
 narrative:
   summary: |

--- a/tests/fixtures/valid/narrative_full_coverage.yaml
+++ b/tests/fixtures/valid/narrative_full_coverage.yaml
@@ -1,4 +1,4 @@
-version: "1.0"
+version: "0.0.7"
 name: "Narrative Full Coverage"
 narrative:
   summary: |

--- a/tests/fixtures/valid/nested.yaml
+++ b/tests/fixtures/valid/nested.yaml
@@ -1,4 +1,4 @@
-version: "0.0.7"
+version: "0.0.10"
 name: "SBI Cosmological Parameter Estimation"
 
 inputs:

--- a/tests/fixtures/valid/nested.yaml
+++ b/tests/fixtures/valid/nested.yaml
@@ -1,4 +1,4 @@
-version: "1.0"
+version: "0.0.7"
 name: "SBI Cosmological Parameter Estimation"
 
 inputs:

--- a/tests/test_evidence_verification.py
+++ b/tests/test_evidence_verification.py
@@ -276,7 +276,7 @@ class TestFullValidationWorkflow:
 
         # Create a test analysis file
         analysis = {
-            "version": "1.0",
+            "version": "0.0.7",
             "name": "Test Analysis",
             "inputs": [{"id": "data", "type": "data"}],
             "outputs": [{"id": "result", "type": "metric"}],

--- a/tests/test_evidence_verification.py
+++ b/tests/test_evidence_verification.py
@@ -276,7 +276,7 @@ class TestFullValidationWorkflow:
 
         # Create a test analysis file
         analysis = {
-            "version": "0.0.7",
+            "version": "0.0.10",
             "name": "Test Analysis",
             "inputs": [{"id": "data", "type": "data"}],
             "outputs": [{"id": "result", "type": "metric"}],

--- a/tests/test_narrative.py
+++ b/tests/test_narrative.py
@@ -27,7 +27,7 @@ def _minimal_with_narrative(narrative: dict[str, str] | str) -> dict[str, object
     if isinstance(narrative, str):
         narrative = {"summary": narrative}
     return {
-        "version": "0.0.7",
+        "version": "0.0.10",
         "name": "Test",
         "narrative": narrative,
         "inputs": [{"id": "x", "type": "data"}],
@@ -407,7 +407,7 @@ class TestNarrativeSections:
         # A parent node with no decisions but with sub-analyses still
         # requires narrative.methods.
         data = {
-            "version": "0.0.7",
+            "version": "0.0.10",
             "name": "Test",
             "narrative": {"summary": "top"},
             "analyses": {

--- a/tests/test_narrative.py
+++ b/tests/test_narrative.py
@@ -27,7 +27,7 @@ def _minimal_with_narrative(narrative: dict[str, str] | str) -> dict[str, object
     if isinstance(narrative, str):
         narrative = {"summary": narrative}
     return {
-        "version": "1.0",
+        "version": "0.0.7",
         "name": "Test",
         "narrative": narrative,
         "inputs": [{"id": "x", "type": "data"}],
@@ -407,7 +407,7 @@ class TestNarrativeSections:
         # A parent node with no decisions but with sub-analyses still
         # requires narrative.methods.
         data = {
-            "version": "1.0",
+            "version": "0.0.7",
             "name": "Test",
             "narrative": {"summary": "top"},
             "analyses": {

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,6 +1,9 @@
 """Tests for schema validation using astra-spec Pydantic models."""
 
+from unittest.mock import patch
+
 from astra.validation.schema import (
+    check_spec_version,
     validate_analysis_data,
     validate_universe_data,
 )
@@ -11,7 +14,7 @@ class TestAnalysisValidation:
 
     def test_valid_analysis_passes(self):
         data = {
-            "version": "0.1",
+            "version": "0.0.7",
             "name": "test",
             "inputs": [{"id": "data", "type": "data"}],
             "outputs": [{"id": "result", "type": "metric"}],
@@ -33,7 +36,7 @@ class TestAnalysisValidation:
 
     def test_invalid_enum_caught(self):
         data = {
-            "version": "0.1",
+            "version": "0.0.7",
             "name": "test",
             "inputs": [{"id": "x", "type": "INVALID"}],
         }
@@ -42,7 +45,7 @@ class TestAnalysisValidation:
 
     def test_extra_fields_rejected(self):
         data = {
-            "version": "0.1",
+            "version": "0.0.7",
             "name": "test",
             "bogus_field": "should fail",
         }
@@ -65,3 +68,34 @@ class TestUniverseValidation:
         data = {"decisions": {"method": "a"}}
         errors = validate_universe_data(data)
         assert any("id" in e for e in errors)
+
+
+class TestCheckSpecVersion:
+    """Tests for the spec-version compatibility warning."""
+
+    def test_match_returns_none(self):
+        with patch("astra.validation.schema.installed_spec_version", return_value="0.0.7"):
+            assert check_spec_version({"version": "0.0.7"}) is None
+
+    def test_two_part_normalizes_to_three(self):
+        with patch("astra.validation.schema.installed_spec_version", return_value="1.0.0"):
+            assert check_spec_version({"version": "1.0"}) is None
+
+    def test_mismatch_returns_warning(self):
+        with patch("astra.validation.schema.installed_spec_version", return_value="0.1.0"):
+            warning = check_spec_version({"version": "0.0.7"})
+            assert warning is not None
+            assert "0.0.7" in warning
+            assert "0.1.0" in warning
+
+    def test_missing_declared_version_returns_none(self):
+        with patch("astra.validation.schema.installed_spec_version", return_value="0.0.7"):
+            assert check_spec_version({}) is None
+
+    def test_unknown_installed_version_returns_none(self):
+        with patch("astra.validation.schema.installed_spec_version", return_value=None):
+            assert check_spec_version({"version": "0.0.7"}) is None
+
+    def test_unparseable_declared_version_returns_none(self):
+        with patch("astra.validation.schema.installed_spec_version", return_value="0.0.7"):
+            assert check_spec_version({"version": "not-a-version"}) is None

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -14,7 +14,7 @@ class TestAnalysisValidation:
 
     def test_valid_analysis_passes(self):
         data = {
-            "version": "0.0.7",
+            "version": "0.0.10",
             "name": "test",
             "inputs": [{"id": "data", "type": "data"}],
             "outputs": [{"id": "result", "type": "metric"}],
@@ -36,7 +36,7 @@ class TestAnalysisValidation:
 
     def test_invalid_enum_caught(self):
         data = {
-            "version": "0.0.7",
+            "version": "0.0.10",
             "name": "test",
             "inputs": [{"id": "x", "type": "INVALID"}],
         }
@@ -45,7 +45,7 @@ class TestAnalysisValidation:
 
     def test_extra_fields_rejected(self):
         data = {
-            "version": "0.0.7",
+            "version": "0.0.10",
             "name": "test",
             "bogus_field": "should fail",
         }
@@ -74,8 +74,8 @@ class TestCheckSpecVersion:
     """Tests for the spec-version compatibility warning."""
 
     def test_match_returns_none(self):
-        with patch("astra.validation.schema.installed_spec_version", return_value="0.0.7"):
-            assert check_spec_version({"version": "0.0.7"}) is None
+        with patch("astra.validation.schema.installed_spec_version", return_value="0.0.10"):
+            assert check_spec_version({"version": "0.0.10"}) is None
 
     def test_two_part_normalizes_to_three(self):
         with patch("astra.validation.schema.installed_spec_version", return_value="1.0.0"):
@@ -83,19 +83,19 @@ class TestCheckSpecVersion:
 
     def test_mismatch_returns_warning(self):
         with patch("astra.validation.schema.installed_spec_version", return_value="0.1.0"):
-            warning = check_spec_version({"version": "0.0.7"})
+            warning = check_spec_version({"version": "0.0.10"})
             assert warning is not None
-            assert "0.0.7" in warning
+            assert "0.0.10" in warning
             assert "0.1.0" in warning
 
     def test_missing_declared_version_returns_none(self):
-        with patch("astra.validation.schema.installed_spec_version", return_value="0.0.7"):
+        with patch("astra.validation.schema.installed_spec_version", return_value="0.0.10"):
             assert check_spec_version({}) is None
 
     def test_unknown_installed_version_returns_none(self):
         with patch("astra.validation.schema.installed_spec_version", return_value=None):
-            assert check_spec_version({"version": "0.0.7"}) is None
+            assert check_spec_version({"version": "0.0.10"}) is None
 
     def test_unparseable_declared_version_returns_none(self):
-        with patch("astra.validation.schema.installed_spec_version", return_value="0.0.7"):
+        with patch("astra.validation.schema.installed_spec_version", return_value="0.0.10"):
             assert check_spec_version({"version": "not-a-version"}) is None

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -212,7 +212,7 @@ class TestOutputDependencyValidation:
     def test_output_input_must_reference_declared_id(self):
         """Output.inputs must reference an analysis input or sibling output."""
         data = {
-            "version": "1.0",
+            "version": "0.0.7",
             "name": "test",
             "inputs": [],
             "outputs": [
@@ -230,7 +230,7 @@ class TestOutputDependencyValidation:
     def test_output_dependency_cycle(self):
         """Cycle in output dependencies should be caught."""
         data = {
-            "version": "1.0",
+            "version": "0.0.7",
             "name": "test",
             "inputs": [],
             "outputs": [
@@ -245,7 +245,7 @@ class TestOutputDependencyValidation:
     def test_valid_output_chain(self):
         """Output that references a sibling output should pass validation."""
         data = {
-            "version": "1.0",
+            "version": "0.0.7",
             "name": "test",
             "inputs": [],
             "outputs": [
@@ -264,7 +264,7 @@ class TestOutputDependencyValidation:
     def test_output_input_can_reference_analysis_input(self):
         """Output.inputs can resolve to an analysis-level Input."""
         data = {
-            "version": "1.0",
+            "version": "0.0.7",
             "name": "test",
             "inputs": [{"id": "raw", "type": "data", "source": "x.csv"}],
             "outputs": [
@@ -282,7 +282,7 @@ class TestOutputDependencyValidation:
     def test_valid_output_no_inputs(self):
         """Output with no inputs/decisions should pass validation."""
         data = {
-            "version": "1.0",
+            "version": "0.0.7",
             "name": "test",
             "inputs": [],
             "outputs": [
@@ -299,7 +299,7 @@ class TestOutputDependencyValidation:
     def test_self_referencing_output_input(self):
         """Output input referencing its own ID should create a cycle."""
         data = {
-            "version": "1.0",
+            "version": "0.0.7",
             "name": "test",
             "inputs": [],
             "outputs": [
@@ -313,7 +313,7 @@ class TestOutputDependencyValidation:
     def test_output_decision_must_be_in_scope(self):
         """Output.decisions must reference a decision in scope."""
         data = {
-            "version": "1.0",
+            "version": "0.0.7",
             "name": "test",
             "inputs": [],
             "outputs": [
@@ -337,7 +337,7 @@ class TestCommandTemplateValidation:
 
     def _make(self, output: dict, decisions: dict | None = None) -> dict:
         return {
-            "version": "1.0",
+            "version": "0.0.7",
             "name": "test",
             "inputs": [{"id": "raw", "type": "data", "source": "x"}],
             "outputs": [output],
@@ -555,7 +555,7 @@ class TestConditionalOutputs:
     def test_output_when_negation(self):
         """Output with ~decision.option negation should pass validation."""
         data = {
-            "version": "1.0",
+            "version": "0.0.7",
             "name": "test",
             "inputs": [],
             "outputs": [
@@ -583,7 +583,7 @@ class TestConditionalOutputs:
     def test_output_when_list(self):
         """Output with when as list (AND logic) should pass validation."""
         data = {
-            "version": "1.0",
+            "version": "0.0.7",
             "name": "test",
             "inputs": [],
             "outputs": [
@@ -624,7 +624,7 @@ class TestConditionalOutputs:
     def test_invalid_output_when_bad_option(self):
         """Output when referencing non-existent option should fail."""
         data = {
-            "version": "1.0",
+            "version": "0.0.7",
             "name": "test",
             "inputs": [],
             "outputs": [
@@ -653,7 +653,7 @@ class TestConditionalOutputs:
     def test_decision_when_negation(self):
         """Decision with ~decision.option negation should pass validation."""
         data = {
-            "version": "1.0",
+            "version": "0.0.7",
             "name": "test",
             "inputs": [],
             "outputs": [{"id": "result", "type": "metric"}],

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -212,7 +212,7 @@ class TestOutputDependencyValidation:
     def test_output_input_must_reference_declared_id(self):
         """Output.inputs must reference an analysis input or sibling output."""
         data = {
-            "version": "0.0.7",
+            "version": "0.0.10",
             "name": "test",
             "inputs": [],
             "outputs": [
@@ -230,7 +230,7 @@ class TestOutputDependencyValidation:
     def test_output_dependency_cycle(self):
         """Cycle in output dependencies should be caught."""
         data = {
-            "version": "0.0.7",
+            "version": "0.0.10",
             "name": "test",
             "inputs": [],
             "outputs": [
@@ -245,7 +245,7 @@ class TestOutputDependencyValidation:
     def test_valid_output_chain(self):
         """Output that references a sibling output should pass validation."""
         data = {
-            "version": "0.0.7",
+            "version": "0.0.10",
             "name": "test",
             "inputs": [],
             "outputs": [
@@ -264,7 +264,7 @@ class TestOutputDependencyValidation:
     def test_output_input_can_reference_analysis_input(self):
         """Output.inputs can resolve to an analysis-level Input."""
         data = {
-            "version": "0.0.7",
+            "version": "0.0.10",
             "name": "test",
             "inputs": [{"id": "raw", "type": "data", "source": "x.csv"}],
             "outputs": [
@@ -282,7 +282,7 @@ class TestOutputDependencyValidation:
     def test_valid_output_no_inputs(self):
         """Output with no inputs/decisions should pass validation."""
         data = {
-            "version": "0.0.7",
+            "version": "0.0.10",
             "name": "test",
             "inputs": [],
             "outputs": [
@@ -299,7 +299,7 @@ class TestOutputDependencyValidation:
     def test_self_referencing_output_input(self):
         """Output input referencing its own ID should create a cycle."""
         data = {
-            "version": "0.0.7",
+            "version": "0.0.10",
             "name": "test",
             "inputs": [],
             "outputs": [
@@ -313,7 +313,7 @@ class TestOutputDependencyValidation:
     def test_output_decision_must_be_in_scope(self):
         """Output.decisions must reference a decision in scope."""
         data = {
-            "version": "0.0.7",
+            "version": "0.0.10",
             "name": "test",
             "inputs": [],
             "outputs": [
@@ -337,7 +337,7 @@ class TestCommandTemplateValidation:
 
     def _make(self, output: dict, decisions: dict | None = None) -> dict:
         return {
-            "version": "0.0.7",
+            "version": "0.0.10",
             "name": "test",
             "inputs": [{"id": "raw", "type": "data", "source": "x"}],
             "outputs": [output],
@@ -555,7 +555,7 @@ class TestConditionalOutputs:
     def test_output_when_negation(self):
         """Output with ~decision.option negation should pass validation."""
         data = {
-            "version": "0.0.7",
+            "version": "0.0.10",
             "name": "test",
             "inputs": [],
             "outputs": [
@@ -583,7 +583,7 @@ class TestConditionalOutputs:
     def test_output_when_list(self):
         """Output with when as list (AND logic) should pass validation."""
         data = {
-            "version": "0.0.7",
+            "version": "0.0.10",
             "name": "test",
             "inputs": [],
             "outputs": [
@@ -624,7 +624,7 @@ class TestConditionalOutputs:
     def test_invalid_output_when_bad_option(self):
         """Output when referencing non-existent option should fail."""
         data = {
-            "version": "0.0.7",
+            "version": "0.0.10",
             "name": "test",
             "inputs": [],
             "outputs": [
@@ -653,7 +653,7 @@ class TestConditionalOutputs:
     def test_decision_when_negation(self):
         """Decision with ~decision.option negation should pass validation."""
         data = {
-            "version": "0.0.7",
+            "version": "0.0.10",
             "name": "test",
             "inputs": [],
             "outputs": [{"id": "result", "type": "metric"}],


### PR DESCRIPTION
## Summary

- Adds `check_spec_version()` (and `installed_spec_version()`) in `astra.validation.schema`. Compares the analysis's declared `version:` to the installed `astra-spec` package version; returns a human-readable warning string on mismatch, `None` otherwise. Normalizes `1.0` and `1.0.0` as equal.
- The `astra validate` CLI surfaces it as a non-fatal yellow `⚠` line, printed before schema validation so the warning is visible even when the version drift causes the schema check to fail.
- Re-aligns examples and fixtures with the schema's stated meaning of `version:` (spec version, not free-form doc version) — every YAML and inline test dict that used `1.0` or `0.1.0` now uses `0.0.7`. Paper-version ints (`"version": 1`, `VERSION`) were left alone since they're DOI-related, not spec-related.

## Why this and not version-aware validation

Discussed in chat: dispatching validation on a per-instance version is what large LinkML projects (Biolink, NMDC, MIxS) deliberately *don't* do — the consumer pins a release and validates against that. Frozen JSON Schemas at `astra-spec.org/schema/<version>/...` already exist as a hedge, but a validator that fetches them won't help unless every other tool that reads `astra-spec` Pydantic models also dispatches on version. The version-warning is the cheap, honest middle ground until (a) we accumulate frozen versions and (b) we have a migration story.

## Test plan

- [x] `uv run pytest -q` — 210 passed, 21 skipped
- [x] `uv run ruff check` clean on changed files
- [x] `uv run mypy src/astra/validation/schema.py` clean
- [x] CLI smoke test: warning fires when `examples/iris/astra.yaml` (`0.0.7`) is validated against an installed `astra-spec 0.0.8`; stays silent on match
- [x] 6 unit tests covering match, normalization, mismatch, missing declared version, missing installed version, unparseable version

🤖 Generated with [Claude Code](https://claude.com/claude-code)