### PR TITLE
fix(semantic): resolve Option.insights against ancestor + node-local prior_insights

### DIFF
--- a/src/astra/validation/semantic.py
+++ b/src/astra/validation/semantic.py
@@ -346,7 +346,15 @@ def _validate_analysis_node(
         target_decisions = target_scope.get("decisions") or {}
         if segments[0] in target_decisions:
             constraint_scope[decision_id] = target_decisions[segments[0]]
-    errors.extend(_validate_decisions(node_decisions, prior_insights, node_path, constraint_scope))
+
+    # `Option.insights:` resolves against any prior_insight defined at this
+    # scope OR any ancestor scope, not just the root. Merge node-local
+    # prior_insights onto the inherited map so local definitions shadow
+    # ancestors on id conflict (innermost wins).
+    node_prior_insights = node.get("prior_insights") or {}
+    insight_scope = {**prior_insights, **node_prior_insights}
+
+    errors.extend(_validate_decisions(node_decisions, insight_scope, node_path, constraint_scope))
 
     # Validate evidence artifact references in prior_insights and findings
     errors.extend(
@@ -386,7 +394,7 @@ def _validate_analysis_node(
             _validate_analysis_node(
                 sub_id,
                 sub_node,
-                prior_insights,
+                insight_scope,
                 ancestor_chain=ancestor_chain + [node],
                 path_prefix=f"{node_path}.analyses",
             )

--- a/tests/fixtures/valid/sub_scope_insight_ref.yaml
+++ b/tests/fixtures/valid/sub_scope_insight_ref.yaml
@@ -1,0 +1,100 @@
+# Option.insights resolves against the prior_insight defined at the
+# same sub-analysis scope (or any ancestor scope, not just the root).
+version: "1.0"
+name: "Sub-Scope Insight Reference"
+
+inputs:
+  - id: survey_catalog
+    type: data
+    source: "data/survey.parquet"
+
+outputs:
+  - id: final_result
+    from: two_point.xi_pm
+
+# A root-level prior_insight, used by a root-level decision. Demonstrates
+# the legacy behavior keeps working.
+prior_insights:
+  root_motivation:
+    id: root_motivation
+    claim: "A root-level motivating result."
+    created_at: "2026-05-11T00:00:00Z"
+    evidence:
+      - id: ev1
+        doi: "10.1234/root.example"
+
+decisions:
+  cosmology_model:
+    label: "Cosmological Model"
+    default: flat_lcdm
+    options:
+      flat_lcdm:
+        label: "Flat LCDM"
+        insights: [root_motivation]
+      wcdm:
+        label: "wCDM"
+
+analyses:
+  two_point:
+    inputs:
+      - id: catalog
+        from: ../survey_catalog
+    outputs:
+      - id: xi_pm
+        type: data
+        inputs: [catalog]
+        decisions: [xi_pm_estimator]
+        recipe:
+          command: python src/xi_pm.py {inputs.catalog}
+
+    # A sub-analysis-local prior_insight, referenced by a sub-analysis
+    # Option.insights at the SAME scope. Before the fix, this raised
+    # INVALID_INSIGHT_REF because the validator only consulted the root
+    # prior_insights map at every recursion level.
+    prior_insights:
+      jarvis15_treecorr:
+        id: jarvis15_treecorr
+        claim: "TreeCorr provides correlation-function estimation."
+        created_at: "2026-05-11T00:00:00Z"
+        evidence:
+          - id: ev1
+            doi: "10.1234/jarvis.2015"
+
+    decisions:
+      xi_pm_estimator:
+        label: "Correlation Function Estimator"
+        default: treecorr
+        options:
+          treecorr:
+            label: "TreeCorr"
+            insights: [jarvis15_treecorr]   # same-scope ref
+          athena:
+            label: "athena"
+            insights: [root_motivation]     # ancestor-scope ref (also works)
+
+    analyses:
+      validation:
+        inputs:
+          - id: catalog_in
+            from: ../catalog
+        outputs:
+          - id: validation_report
+            type: report
+            inputs: [catalog_in]
+            recipe:
+              command: python src/validate.py {inputs.catalog_in}
+
+        # Grandchild scope. An ancestor-scope reference (to the sub-
+        # analysis-local prior_insight one level up) must resolve too —
+        # the merge has to compose across levels, not just root + node.
+        decisions:
+          coverage_check:
+            label: "Coverage Check Method"
+            default: bootstrap
+            options:
+              bootstrap:
+                label: "Bootstrap"
+                insights: [jarvis15_treecorr]   # two-point scope, one ancestor up
+              jackknife:
+                label: "Jackknife"
+                insights: [root_motivation]      # root scope, two ancestors up

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -72,6 +72,23 @@ class TestSemanticValidation:
         errors = validate_analysis_file(invalid_dir / "invalid_insight_ref.yaml")
         assert any(e.code == "INVALID_INSIGHT_REF" for e in errors)
 
+    def test_option_insights_resolve_in_local_and_ancestor_scope(self, valid_dir: Path):
+        """`Option.insights` must resolve against the merged map of root +
+        ancestor + node-local `prior_insights`, not just the root map.
+
+        Regression test for the bug where `_validate_analysis_node` passed
+        the root-level `prior_insights` at every recursion level, rejecting
+        Option.insights references to same-scope or ancestor (non-root)
+        prior_insight ids.
+        """
+        errors = validate_analysis_file(valid_dir / "sub_scope_insight_ref.yaml")
+        insight_errors = [e for e in errors if e.code == "INVALID_INSIGHT_REF"]
+        assert insight_errors == [], (
+            "Option.insights references to same-scope or ancestor "
+            f"prior_insights should resolve; got: {insight_errors}"
+        )
+        assert errors == [], f"Expected no semantic errors; got: {[str(e) for e in errors]}"
+
     def test_invalid_finding_output(self, invalid_dir: Path):
         errors = validate_analysis_file(invalid_dir / "invalid_finding_output.yaml")
         assert any(e.code == "INVALID_ARTIFACT_REF" for e in errors)


### PR DESCRIPTION
## Summary

Fixes #85. `_validate_analysis_node` previously passed only the root-level `prior_insights` map at every recursion depth, so `Option.insights` references to a `prior_insight` declared at the same sub-analysis scope (or any non-root ancestor scope) raised `INVALID_INSIGHT_REF` even though the insight was defined right there in the node.

The fix merges node-local `prior_insights` onto the inherited map as the validator recurses, so an option's `insights:` refs resolve against the full visible scope: root + every intervening ancestor + node-local. Local definitions shadow ancestors on id conflict (innermost wins).

## Why

The natural authoring shape is for an option's supporting citation to cluster near the sub-analysis it backs — declared as `analyses.<sub>.prior_insights.<id>` and referenced by `analyses.<sub>.decisions.<dec>.options.<opt>.insights: [<id>]`. Before the fix, the only workaround was to lift every prior_insight referenced anywhere to the root, breaking that natural locality. The lc-from-paper SPECIFY phase hit this immediately when authoring sub-analysis-local placeholders.

## Test

Adds `tests/fixtures/valid/sub_scope_insight_ref.yaml` which exercises:

- same-scope reference (option in `two_point` → prior_insight in `two_point`)
- one-ancestor reference (option in `two_point.validation` → prior_insight in `two_point`)
- two-ancestor reference (option in `two_point.validation` → root prior_insight)
- root reference (option at root → root prior_insight — the legacy path keeps working)

## Test plan

- [x] new `test_option_insights_resolve_in_local_and_ancestor_scope` passes
- [x] full pytest suite passes (205 passed, 21 network-skipped)
- [ ] reviewer: confirm the merge-direction (innermost-wins) is the right policy on id conflict — alternative would be reject-on-conflict

— Claude on behalf of Cail