### PR TITLE
fix(semantic): scope Option.insights locally; require ../ for ancestor refs (alt to #86)

### DIFF
--- a/src/astra/validation/semantic.py
+++ b/src/astra/validation/semantic.py
@@ -196,7 +196,7 @@ def validate_analysis(data: dict[str, Any], base_path: Path | None = None) -> li
     root_decisions = _collect_node_decisions(data)
 
     # Validate all decisions
-    errors.extend(_validate_decisions(root_decisions, prior_insights, ""))
+    errors.extend(_validate_decisions(root_decisions, prior_insights, "", ancestor_chain=[]))
 
     # Validate evidence artifact references in prior_insights and findings
     errors.extend(
@@ -239,7 +239,6 @@ def validate_analysis(data: dict[str, Any], base_path: Path | None = None) -> li
             _validate_analysis_node(
                 analysis_id,
                 analysis_node,
-                prior_insights,
                 ancestor_chain=[data],
                 path_prefix="analyses",
             )
@@ -251,7 +250,6 @@ def validate_analysis(data: dict[str, Any], base_path: Path | None = None) -> li
 def _validate_analysis_node(
     node_id: str,
     node: dict[str, Any],
-    prior_insights: dict[str, Any],
     ancestor_chain: list[dict[str, Any]],
     path_prefix: str,
 ) -> list[SemanticError]:
@@ -346,7 +344,20 @@ def _validate_analysis_node(
         target_decisions = target_scope.get("decisions") or {}
         if segments[0] in target_decisions:
             constraint_scope[decision_id] = target_decisions[segments[0]]
-    errors.extend(_validate_decisions(node_decisions, prior_insights, node_path, constraint_scope))
+    # `Option.insights` resolves only against this node's own
+    # `prior_insights` map. Cross-scope refs must be written explicitly
+    # as `../id`, `../../id`, ... (matching `Input.from` / `Decision.from`
+    # convention) — `_validate_decisions` parses those via the ancestor chain.
+    node_prior_insights = node.get("prior_insights") or {}
+    errors.extend(
+        _validate_decisions(
+            node_decisions,
+            node_prior_insights,
+            node_path,
+            constraint_scope,
+            ancestor_chain=ancestor_chain,
+        )
+    )
 
     # Validate evidence artifact references in prior_insights and findings
     errors.extend(
@@ -386,7 +397,6 @@ def _validate_analysis_node(
             _validate_analysis_node(
                 sub_id,
                 sub_node,
-                prior_insights,
                 ancestor_chain=ancestor_chain + [node],
                 path_prefix=f"{node_path}.analyses",
             )
@@ -454,16 +464,24 @@ def _validate_decisions(
     prior_insights: dict[str, Any],
     path_prefix: str,
     constraint_scope: dict[str, Any] | None = None,
+    ancestor_chain: list[dict[str, Any]] | None = None,
 ) -> list[SemanticError]:
     """Validate a set of decisions at a given node.
 
     Args:
+        prior_insights: Node-local ``prior_insights`` map. Bare-id
+            ``Option.insights`` refs resolve here.
         constraint_scope: Decisions available for constraint resolution. Defaults to
             decisions themselves, but may include parent decisions for sub-analyses.
+        ancestor_chain: Root-first chain of ancestor scopes for resolving
+            ``../id``-form ``Option.insights`` refs against ancestor
+            ``prior_insights``. Empty/None at the root.
     """
     errors: list[SemanticError] = []
     if constraint_scope is None:
         constraint_scope = decisions
+    if ancestor_chain is None:
+        ancestor_chain = []
 
     decisions_prefix = f"{path_prefix}.decisions" if path_prefix else "decisions"
     for decision_id, decision in decisions.items():
@@ -534,15 +552,57 @@ def _validate_decisions(
         for option_id, option in options.items():
             option_path = f"{decision_path}.options.{option_id}"
 
-            # Check insight references (options reference prior_insights)
+            # Check insight references (options reference prior_insights).
+            # Same-scope: bare id (resolves in this node's prior_insights).
+            # Ancestor: `../id`, `../../id`, ... (matches Input.from / Decision.from).
             insight_refs = option.get("insights") or []
             for i, insight_ref in enumerate(insight_refs):
-                if insight_ref not in prior_insights:
+                ref_path = f"{option_path}.insights[{i}]"
+                parsed = _parse_from_path(insight_ref)
+                if parsed is None:
                     errors.append(
                         SemanticError(
                             "INVALID_INSIGHT_REF",
-                            f"Option insight '{insight_ref}' not found in prior_insights",
-                            f"{option_path}.insights[{i}]",
+                            f"Option insight '{insight_ref}' has invalid path syntax",
+                            ref_path,
+                        )
+                    )
+                    continue
+                up, segments = parsed
+                if len(segments) != 1:
+                    errors.append(
+                        SemanticError(
+                            "INVALID_INSIGHT_REF",
+                            f"Option insight '{insight_ref}' must reference a single "
+                            "insight id (descent into sub-analyses is not allowed)",
+                            ref_path,
+                        )
+                    )
+                    continue
+                insight_id = segments[0]
+                if up == 0:
+                    target_insights = prior_insights
+                    scope_desc = "this node's prior_insights"
+                else:
+                    target_scope = _resolve_ancestor_scope(ancestor_chain, up)
+                    if target_scope is None:
+                        errors.append(
+                            SemanticError(
+                                "INVALID_INSIGHT_REF",
+                                f"Option insight '{insight_ref}' escapes {up} level(s) "
+                                f"but only {len(ancestor_chain)} ancestor scope(s) available",
+                                ref_path,
+                            )
+                        )
+                        continue
+                    target_insights = target_scope.get("prior_insights") or {}
+                    scope_desc = f"{up}-level ancestor's prior_insights"
+                if insight_id not in target_insights:
+                    errors.append(
+                        SemanticError(
+                            "INVALID_INSIGHT_REF",
+                            f"Option insight '{insight_ref}' not found in {scope_desc}",
+                            ref_path,
                         )
                     )
 

--- a/src/astra/validation/semantic.py
+++ b/src/astra/validation/semantic.py
@@ -552,59 +552,15 @@ def _validate_decisions(
         for option_id, option in options.items():
             option_path = f"{decision_path}.options.{option_id}"
 
-            # Check insight references (options reference prior_insights).
-            # Same-scope: bare id (resolves in this node's prior_insights).
-            # Ancestor: `../id`, `../../id`, ... (matches Input.from / Decision.from).
-            insight_refs = option.get("insights") or []
-            for i, insight_ref in enumerate(insight_refs):
-                ref_path = f"{option_path}.insights[{i}]"
-                parsed = _parse_from_path(insight_ref)
-                if parsed is None:
-                    errors.append(
-                        SemanticError(
-                            "INVALID_INSIGHT_REF",
-                            f"Option insight '{insight_ref}' has invalid path syntax",
-                            ref_path,
-                        )
+            for i, insight_ref in enumerate(option.get("insights") or []):
+                errors.extend(
+                    _validate_option_insight_ref(
+                        insight_ref,
+                        prior_insights,
+                        ancestor_chain,
+                        f"{option_path}.insights[{i}]",
                     )
-                    continue
-                up, segments = parsed
-                if len(segments) != 1:
-                    errors.append(
-                        SemanticError(
-                            "INVALID_INSIGHT_REF",
-                            f"Option insight '{insight_ref}' must reference a single "
-                            "insight id (descent into sub-analyses is not allowed)",
-                            ref_path,
-                        )
-                    )
-                    continue
-                insight_id = segments[0]
-                if up == 0:
-                    target_insights = prior_insights
-                    scope_desc = "this node's prior_insights"
-                else:
-                    target_scope = _resolve_ancestor_scope(ancestor_chain, up)
-                    if target_scope is None:
-                        errors.append(
-                            SemanticError(
-                                "INVALID_INSIGHT_REF",
-                                f"Option insight '{insight_ref}' escapes {up} level(s) "
-                                f"but only {len(ancestor_chain)} ancestor scope(s) available",
-                                ref_path,
-                            )
-                        )
-                        continue
-                    target_insights = target_scope.get("prior_insights") or {}
-                    scope_desc = f"{up}-level ancestor's prior_insights"
-                if insight_id not in target_insights:
-                    errors.append(
-                        SemanticError(
-                            "INVALID_INSIGHT_REF",
-                            f"Option insight '{insight_ref}' not found in {scope_desc}",
-                            ref_path,
-                        )
-                    )
+                )
 
             # Check incompatible_with refs (scoped to constraint_scope)
             incompatible_with = option.get("incompatible_with") or []
@@ -951,6 +907,52 @@ def _validate_decision_from(
         return _error(
             f"Decision.from '{ref}' points to non-existent ancestor decision '{segments[0]}'"
         )
+    return []
+
+
+def _validate_option_insight_ref(
+    ref: str,
+    prior_insights: dict[str, Any],
+    ancestor_chain: list[dict[str, Any]],
+    ref_path: str,
+) -> list[SemanticError]:
+    """Validate a single ``Option.insights`` reference.
+
+    Bare id resolves against ``prior_insights`` (the node-local map);
+    ``../id``, ``../../id``, ... resolves against the corresponding
+    ancestor's ``prior_insights``. Mirrors the ``../`` grammar used by
+    ``Input.from`` and ``Decision.from``.
+    """
+
+    def _error(message: str) -> list[SemanticError]:
+        return [SemanticError("INVALID_INSIGHT_REF", message, ref_path)]
+
+    parsed = _parse_from_path(ref)
+    if parsed is None:
+        return _error(f"Option insight '{ref}' has invalid path syntax")
+    up, segments = parsed
+    if len(segments) != 1:
+        return _error(
+            f"Option insight '{ref}' must reference a single insight id "
+            "(descent into sub-analyses is not allowed)"
+        )
+    insight_id = segments[0]
+
+    if up == 0:
+        target_insights = prior_insights
+        scope_desc = "this node's prior_insights"
+    else:
+        target_scope = _resolve_ancestor_scope(ancestor_chain, up)
+        if target_scope is None:
+            return _error(
+                f"Option insight '{ref}' escapes {up} level(s) but only "
+                f"{len(ancestor_chain)} ancestor scope(s) available"
+            )
+        target_insights = target_scope.get("prior_insights") or {}
+        scope_desc = f"{up}-level ancestor's prior_insights"
+
+    if insight_id not in target_insights:
+        return _error(f"Option insight '{ref}' not found in {scope_desc}")
     return []
 
 

--- a/tests/fixtures/invalid/insight_ref_bare_id_crosses_scope.yaml
+++ b/tests/fixtures/invalid/insight_ref_bare_id_crosses_scope.yaml
@@ -1,0 +1,43 @@
+# A sub-analysis option uses a BARE id that only exists in the root's
+# prior_insights map. This must fail INVALID_INSIGHT_REF: cross-scope refs
+# require the explicit `../id` form (matching Input.from / Decision.from).
+version: "0.0.10"
+name: "Test"
+
+inputs:
+  - id: data
+    type: data
+
+outputs:
+  - id: result
+    from: sub.sub_out
+
+prior_insights:
+  root_insight:
+    id: root_insight
+    claim: "Root claim."
+    created_at: "2026-05-11T00:00:00Z"
+    evidence:
+      - id: ev1
+        doi: "10.1234/root.example"
+
+analyses:
+  sub:
+    inputs:
+      - id: x
+        from: ../data
+    outputs:
+      - id: sub_out
+        type: data
+        inputs: [x]
+        recipe:
+          command: python src/run.py {inputs.x}
+    decisions:
+      method:
+        label: "Method"
+        default: a
+        options:
+          a:
+            label: "A"
+            insights: [root_insight]   # BARE id — but `root_insight` lives at root.
+                                       # Must be written `../root_insight`.

--- a/tests/fixtures/invalid/insight_ref_escapes_too_far.yaml
+++ b/tests/fixtures/invalid/insight_ref_escapes_too_far.yaml
@@ -1,0 +1,30 @@
+# Option.insights ref escapes more levels than the ancestor chain has.
+# A root-level option cannot use `../id` — there's no ancestor above root.
+version: "0.0.10"
+name: "Test"
+
+inputs:
+  - id: data
+    type: data
+
+outputs:
+  - id: result
+    type: metric
+
+prior_insights:
+  root_insight:
+    id: root_insight
+    claim: "Root claim."
+    created_at: "2026-05-11T00:00:00Z"
+    evidence:
+      - id: ev1
+        doi: "10.1234/root.example"
+
+decisions:
+  method:
+    label: "Method"
+    default: a
+    options:
+      a:
+        label: "A"
+        insights: [../root_insight]   # root has no ancestor scope.

--- a/tests/fixtures/valid/sub_scope_insight_ref.yaml
+++ b/tests/fixtures/valid/sub_scope_insight_ref.yaml
@@ -3,7 +3,7 @@
 #   - ../id, ../../id    -> resolved against an ancestor node's prior_insights
 # Cross-scope refs must be EXPLICIT (../-form), matching the convention
 # used by Input.from / Decision.from. There is no silent ancestor walk.
-version: "1.0"
+version: "0.0.10"
 name: "Sub-Scope Insight Reference"
 
 inputs:

--- a/tests/fixtures/valid/sub_scope_insight_ref.yaml
+++ b/tests/fixtures/valid/sub_scope_insight_ref.yaml
@@ -1,0 +1,94 @@
+# Option.insights resolution across scopes:
+#   - bare id            -> resolved in this node's prior_insights
+#   - ../id, ../../id    -> resolved against an ancestor node's prior_insights
+# Cross-scope refs must be EXPLICIT (../-form), matching the convention
+# used by Input.from / Decision.from. There is no silent ancestor walk.
+version: "1.0"
+name: "Sub-Scope Insight Reference"
+
+inputs:
+  - id: survey_catalog
+    type: data
+    source: "data/survey.parquet"
+
+outputs:
+  - id: final_result
+    from: two_point.xi_pm
+
+prior_insights:
+  root_motivation:
+    id: root_motivation
+    claim: "A root-level motivating result."
+    created_at: "2026-05-11T00:00:00Z"
+    evidence:
+      - id: ev1
+        doi: "10.1234/root.example"
+
+decisions:
+  cosmology_model:
+    label: "Cosmological Model"
+    default: flat_lcdm
+    options:
+      flat_lcdm:
+        label: "Flat LCDM"
+        insights: [root_motivation]   # bare id resolves locally (root)
+      wcdm:
+        label: "wCDM"
+
+analyses:
+  two_point:
+    inputs:
+      - id: catalog
+        from: ../survey_catalog
+    outputs:
+      - id: xi_pm
+        type: data
+        inputs: [catalog]
+        decisions: [xi_pm_estimator]
+        recipe:
+          command: python src/xi_pm.py {inputs.catalog}
+
+    prior_insights:
+      jarvis15_treecorr:
+        id: jarvis15_treecorr
+        claim: "TreeCorr provides correlation-function estimation."
+        created_at: "2026-05-11T00:00:00Z"
+        evidence:
+          - id: ev1
+            doi: "10.1234/jarvis.2015"
+
+    decisions:
+      xi_pm_estimator:
+        label: "Correlation Function Estimator"
+        default: treecorr
+        options:
+          treecorr:
+            label: "TreeCorr"
+            insights: [jarvis15_treecorr]      # same-scope, bare id
+          athena:
+            label: "athena"
+            insights: [../root_motivation]     # one ancestor up, explicit
+
+    analyses:
+      validation:
+        inputs:
+          - id: catalog_in
+            from: ../catalog
+        outputs:
+          - id: validation_report
+            type: report
+            inputs: [catalog_in]
+            recipe:
+              command: python src/validate.py {inputs.catalog_in}
+
+        decisions:
+          coverage_check:
+            label: "Coverage Check Method"
+            default: bootstrap
+            options:
+              bootstrap:
+                label: "Bootstrap"
+                insights: [../jarvis15_treecorr]   # one level up
+              jackknife:
+                label: "Jackknife"
+                insights: [../../root_motivation]  # two levels up

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -72,6 +72,36 @@ class TestSemanticValidation:
         errors = validate_analysis_file(invalid_dir / "invalid_insight_ref.yaml")
         assert any(e.code == "INVALID_INSIGHT_REF" for e in errors)
 
+    def test_option_insights_resolve_in_local_and_ancestor_scope(self, valid_dir: Path):
+        """`Option.insights` resolves bare ids against the node-local
+        ``prior_insights`` map, and ``../id`` / ``../../id`` against the
+        corresponding ancestor scope. Mirrors the ``../`` convention used
+        by ``Input.from`` and ``Decision.from``.
+        """
+        errors = validate_analysis_file(valid_dir / "sub_scope_insight_ref.yaml")
+        insight_errors = [e for e in errors if e.code == "INVALID_INSIGHT_REF"]
+        assert insight_errors == [], (
+            "Same-scope (bare id) and explicit `../`-form ancestor refs "
+            f"should both resolve; got: {insight_errors}"
+        )
+
+    def test_insight_ref_bare_id_does_not_walk_ancestors(self, invalid_dir: Path):
+        """A bare-id ``Option.insights`` ref in a sub-analysis must NOT
+        silently resolve against the root's ``prior_insights``. Cross-scope
+        refs require explicit ``../id``.
+        """
+        errors = validate_analysis_file(invalid_dir / "insight_ref_bare_id_crosses_scope.yaml")
+        bad = [e for e in errors if e.code == "INVALID_INSIGHT_REF"]
+        assert len(bad) == 1, f"expected 1 INVALID_INSIGHT_REF, got: {bad}"
+        assert "root_insight" in bad[0].message
+
+    def test_insight_ref_escapes_too_far(self, invalid_dir: Path):
+        """A ``../id`` ref at root has no ancestor scope to resolve against."""
+        errors = validate_analysis_file(invalid_dir / "insight_ref_escapes_too_far.yaml")
+        bad = [e for e in errors if e.code == "INVALID_INSIGHT_REF"]
+        assert len(bad) == 1, f"expected 1 INVALID_INSIGHT_REF, got: {bad}"
+        assert "escapes" in bad[0].message
+
     def test_invalid_finding_output(self, invalid_dir: Path):
         errors = validate_analysis_file(invalid_dir / "invalid_finding_output.yaml")
         assert any(e.code == "INVALID_ARTIFACT_REF" for e in errors)


### PR DESCRIPTION
## Summary

Fixes #85 with a stricter, more consistent policy than #86.

`Option.insights: [foo]` (bare id) now resolves **only** against the
**node-local** `prior_insights` map. Cross-scope references must be
written explicitly as `../id`, `../../id`, ... — the same `../`
convention already used by `Input.from` and `Decision.from`.

## Why this over #86

#86 fixes the same-scope failure but does so by silently merging
ancestor `prior_insights` into the lookup at every depth. That makes
`Option.insights` the only cross-scope reference in ASTRA that resolves
ambiently, with no syntactic hint at the call site. Concretely it
introduces:

- **Inconsistency.** Every other cross-scope ref is explicit:
  - `Input.from` rejects bare ids: *"must start with `../` to escape upward"*
  - `Decision.from` rejects bare ids: *"must start with `../` to reference an ancestor decision"*
  - `Option.insights` would silently walk up.
- **Silent shadowing.** Two scopes with the same insight id (e.g. authors
  copy-paste between subs) silently override; innermost wins with no error.
- **Loss of refactor signal.** A sub-analysis can be factored out via
  `path:` into its own `astra.yaml`. Under #86's silent walk, refs that
  used a parent insight break in isolation with no clue at the ref site
  that they had a cross-scope dependency. With explicit `../`, the
  dependency is visible — broken refs surface immediately on split.

## Behavior

| ref form              | resolves against                         |
|-----------------------|------------------------------------------|
| `[foo]`               | this node's `prior_insights`             |
| `[../foo]`            | parent's `prior_insights`                |
| `[../../foo]`         | grandparent's `prior_insights`           |
| `[a.b]` (descent)     | rejected (`INVALID_INSIGHT_REF`)         |
| `[../foo]` at root    | rejected — no ancestor scope             |
| missing in target     | rejected — id not found in target scope  |

## Implementation

- `_validate_analysis_node` no longer takes a `prior_insights` arg —
  each level uses its own `node.get("prior_insights")`.
- `_validate_decisions` gains an `ancestor_chain` param and parses each
  `Option.insights` ref via the existing `_parse_from_path` /
  `_resolve_ancestor_scope` helpers (the same helpers that back
  `Input.from` / `Decision.from`).

## Tests

Adds:
- `tests/fixtures/valid/sub_scope_insight_ref.yaml` — same-scope, one
  ancestor (`../`), two ancestors (`../../`), and root cases.
- `tests/fixtures/invalid/insight_ref_bare_id_crosses_scope.yaml` —
  the exact silent-walk case #86 would accept; this PR rejects it
  with a guiding message pointing to `../id`.
- `tests/fixtures/invalid/insight_ref_escapes_too_far.yaml` — a root-level
  option using `../id` (no ancestor available).

## Test plan

- [x] full pytest suite passes (213 passed, 21 network-skipped)
- [x] ruff check + format clean
- [x] manual repro from issue #85 now passes semantic validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)