### PR TITLE
Add `astra spec`: schema-derived reference renderer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,12 @@ module = [
 ]
 follow_untyped_imports = true
 
+[[tool.mypy.overrides]]
+module = [
+    "linkml_runtime.*",
+]
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 markers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ classifiers = [
 
 dependencies = [
     "astra-spec>=0.0.11",
+    "linkml-runtime>=1.8",
     "click>=8.0",
     "pydantic>=2.0",
     "pyyaml>=6.0",

--- a/src/astra/cli.py
+++ b/src/astra/cli.py
@@ -725,6 +725,31 @@ def _viz_mermaid_node(lines: list[str], node: dict[str, Any], node_prefix: str) 
         lines.append("    end")
 
 
+@main.command()
+@click.argument("term", required=False)
+@click.option("--full", is_flag=True, help="Dump the entire reference (VERY long).")
+def spec(term: str | None, full: bool) -> None:
+    """Render the ASTRA schema as agent-friendly reference text.
+
+    No args prints a concept summary; TERM prints one entry (case-insensitive);
+    --full concatenates every entry (VERY long).
+    """
+    from astra import spec_render
+
+    if full:
+        click.echo(spec_render.render_full(), nl=False)
+        return
+    if term:
+        rendered = spec_render.render_term(term)
+        if not rendered:
+            console.print(f"[red]Unknown term:[/red] {term}")
+            console.print("Valid terms: " + ", ".join(spec_render.list_terms()))
+            raise SystemExit(1)
+        click.echo(rendered, nl=False)
+        return
+    click.echo(spec_render.render_summary())
+
+
 @main.group()
 def schema() -> None:
     """Schema commands."""

--- a/src/astra/cli.py
+++ b/src/astra/cli.py
@@ -736,6 +736,8 @@ def spec(term: str | None, full: bool) -> None:
     """
     from astra import spec_render
 
+    if full and term:
+        raise click.UsageError("--full dumps every entry; drop TERM or drop --full.")
     if full:
         click.echo(spec_render.render_full(), nl=False)
         return

--- a/src/astra/cli.py
+++ b/src/astra/cli.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import click
 from rich.console import Console
+from rich.markup import escape
 from rich.table import Table
 from rich.tree import Tree
 
@@ -744,7 +745,10 @@ def spec(term: str | None, full: bool) -> None:
     if term:
         rendered = spec_render.render_term(term)
         if not rendered:
-            console.print(f"[red]Unknown term:[/red] {term}")
+            # Escape the user-supplied term: unescaped bracket syntax would be
+            # parsed as Rich markup, crashing with MarkupError (e.g. `[/red]`)
+            # or silently swallowing `[foo]`-style fragments.
+            console.print(f"[red]Unknown term:[/red] {escape(term)}")
             console.print("Valid terms: " + ", ".join(spec_render.list_terms()))
             raise SystemExit(1)
         click.echo(rendered, nl=False)

--- a/src/astra/spec_render.py
+++ b/src/astra/spec_render.py
@@ -7,6 +7,8 @@ Pure transformation: every string emitted here comes from the schema via
 from __future__ import annotations
 
 import os
+import shutil
+import textwrap
 from functools import lru_cache
 from typing import Any
 
@@ -33,7 +35,16 @@ def _first_sentence(text: str | None) -> str:
         return ""
     flat = " ".join(text.split())
     head, sep, _ = flat.partition(". ")
-    return head + "." if sep else flat
+    return (head if sep else flat).rstrip(".") + "."
+
+
+def _two_col(name: str, desc: str, width: int) -> list[str]:
+    """One vocabulary-map row: name column, then desc wrapped within its own column."""
+    indent = " " * (2 + width + 2)
+    cols = max(shutil.get_terminal_size(fallback=(100, 24)).columns, len(indent) + 20)
+    lines = textwrap.wrap(desc, width=cols - len(indent)) or [""]
+    first = f"  {name:<{width}}  {lines[0]}".rstrip()
+    return [first] + [indent + line for line in lines[1:]]
 
 
 def _humanize(token: str) -> str:
@@ -288,9 +299,11 @@ def render_summary() -> str:
         out.append(f"{schema.upper()}")
         width = max((len(n) for n in names + enums), default=0)
         for n in names:
-            out.append(f"  {n:<{width}}  {_first_sentence(sv.get_class(n).description)}")
+            out.extend(_two_col(n, _first_sentence(sv.get_class(n).description), width))
         for n in enums:
-            out.append(f"  {n:<{width}}  (enum) {_first_sentence(sv.get_enum(n).description)}")
+            out.extend(
+                _two_col(n, "(enum) " + _first_sentence(sv.get_enum(n).description), width)
+            )
         out.append("")
     out.append(
         "astra spec <term> for detail; astra spec --full dumps the entire reference (very long)."

--- a/src/astra/spec_render.py
+++ b/src/astra/spec_render.py
@@ -38,10 +38,16 @@ def _first_sentence(text: str | None) -> str:
     return (head if sep else flat).rstrip(".") + "."
 
 
-def _wrap_at(text: str, indent: int) -> list[str]:
-    """Wrap text to the terminal width with every line indented `indent` spaces."""
-    cols = max(shutil.get_terminal_size(fallback=(100, 24)).columns, indent + 20)
-    return [" " * indent + line for line in textwrap.wrap(text, width=cols - indent)] or [""]
+def _wrap_at(text: str, indent: int, hang: int = 0) -> list[str]:
+    """Wrap text to the terminal width, indented `indent` spaces; continuation
+    lines hang `hang` further so they read as part of the paragraph above."""
+    cols = max(shutil.get_terminal_size(fallback=(100, 24)).columns, indent + hang + 20)
+    return textwrap.wrap(
+        text,
+        width=cols,
+        initial_indent=" " * indent,
+        subsequent_indent=" " * (indent + hang),
+    ) or [""]
 
 
 def _two_col(name: str, desc: str, width: int) -> list[str]:
@@ -181,7 +187,7 @@ def _render_field_table(name: str) -> list[str]:
             line += f"  {r['flags']}"
         out.append(line.rstrip())
         if r["desc"]:
-            out.extend(_wrap_at(r["desc"], 6))
+            out.extend(_wrap_at(r["desc"], 6, hang=2))
         if r["pattern"]:
             out.append(f"      pattern: {r['pattern']}")
     return out
@@ -232,7 +238,7 @@ def _render_rules(name: str) -> list[str]:
             for r, _ in members:
                 out.append(f"  {_humanize(r.title)}")
                 if r.description:
-                    out.extend(_wrap_at(_first_sentence(r.description), 6))
+                    out.extend(_wrap_at(_first_sentence(r.description), 6, hang=2))
     return out
 
 

--- a/src/astra/spec_render.py
+++ b/src/astra/spec_render.py
@@ -53,7 +53,8 @@ def _wrap_at(text: str, indent: int, hang: int = 0) -> list[str]:
 def _hard_wrap_at(text: str, indent: int, hang: int = 0) -> list[str]:
     """Like ``_wrap_at`` but chunks unbreakable text (regexes) at the width limit."""
     cols = max(shutil.get_terminal_size(fallback=(100, 24)).columns, indent + hang + 20)
-    out, pos, width = [f"{' ' * indent}{text[: cols - indent]}"], cols - indent, cols - indent - hang
+    pos, width = cols - indent, cols - indent - hang
+    out = [f"{' ' * indent}{text[:pos]}"]
     while pos < len(text):
         out.append(f"{' ' * (indent + hang)}{text[pos : pos + width]}")
         pos += width
@@ -320,9 +321,7 @@ def render_summary() -> str:
         for n in names:
             out.extend(_two_col(n, _first_sentence(sv.get_class(n).description), width))
         for n in enums:
-            out.extend(
-                _two_col(n, "(enum) " + _first_sentence(sv.get_enum(n).description), width)
-            )
+            out.extend(_two_col(n, "(enum) " + _first_sentence(sv.get_enum(n).description), width))
         out.append("")
     out.append(
         "astra spec <term> for detail; astra spec --full dumps the entire reference (very long)."

--- a/src/astra/spec_render.py
+++ b/src/astra/spec_render.py
@@ -50,6 +50,16 @@ def _wrap_at(text: str, indent: int, hang: int = 0) -> list[str]:
     ) or [""]
 
 
+def _hard_wrap_at(text: str, indent: int, hang: int = 0) -> list[str]:
+    """Like ``_wrap_at`` but chunks unbreakable text (regexes) at the width limit."""
+    cols = max(shutil.get_terminal_size(fallback=(100, 24)).columns, indent + hang + 20)
+    out, pos, width = [f"{' ' * indent}{text[: cols - indent]}"], cols - indent, cols - indent - hang
+    while pos < len(text):
+        out.append(f"{' ' * (indent + hang)}{text[pos : pos + width]}")
+        pos += width
+    return out
+
+
 def _two_col(name: str, desc: str, width: int) -> list[str]:
     """One vocabulary-map row: name column, then desc wrapped within its own column."""
     lines = _wrap_at(desc, 2 + width + 2)
@@ -189,7 +199,7 @@ def _render_field_table(name: str) -> list[str]:
         if r["desc"]:
             out.extend(_wrap_at(r["desc"], 6, hang=2))
         if r["pattern"]:
-            out.append(f"      pattern: {r['pattern']}")
+            out.extend(_hard_wrap_at(f"pattern: {r['pattern']}", 6, hang=2))
     return out
 
 

--- a/src/astra/spec_render.py
+++ b/src/astra/spec_render.py
@@ -134,8 +134,9 @@ def _used_by(target: str) -> list[str]:
 
 
 def _references(name: str) -> list[str]:
+    # Enums are inlined into field rows, so only classes count as references.
     sv = _view()
-    known = set(sv.all_classes()) | set(sv.all_enums())
+    known = set(sv.all_classes())
     seen: list[str] = []
     for s in sv.class_induced_slots(name):
         if s.range in known and s.range not in seen:
@@ -157,9 +158,26 @@ def _term_ref(name: str, current: str) -> str:
 # --------------------------------------------------------------------------
 
 
+def _enum_inline(name: str) -> tuple[str, str]:
+    """(range text, description suffix) inlining an enum's values into a field row.
+
+    Enums are rendered as facts about the fields that use them, not standalone
+    concepts: the range column carries the literal values, and any per-value
+    glosses fold into the field description.
+    """
+    values = _view().get_enum(name).permissible_values or {}
+    rng = " | ".join(values)
+    glosses = "; ".join(
+        f"{v}: {_first_sentence(pv.description).rstrip('.')}"
+        for v, pv in values.items()
+        if pv.description
+    )
+    return rng, f" ({glosses})." if glosses else ""
+
+
 def _render_field_table(name: str) -> list[str]:
     sv = _view()
-    known = set(sv.all_classes()) | set(sv.all_enums())
+    enums = set(sv.all_enums())
     rows = []
     for s in sv.class_induced_slots(name):
         flags = []
@@ -167,11 +185,13 @@ def _render_field_table(name: str) -> list[str]:
             flags.append("multivalued")
         if s.inlined or s.inlined_as_list:
             flags.append("inlined")
-        rng = (
-            f"-> astra spec {s.range.lower()}"
-            if s.range in known
-            else (s.range or sv.schema.default_range)
-        )
+        desc_suffix = ""
+        if s.range in enums:
+            rng, desc_suffix = _enum_inline(s.range)
+        elif s.range in sv.all_classes():
+            rng = f"-> astra spec {s.range.lower()}"
+        else:
+            rng = s.range or sv.schema.default_range
         rows.append(
             {
                 "name": s.name,
@@ -179,7 +199,9 @@ def _render_field_table(name: str) -> list[str]:
                 "range": rng,
                 "flags": " ".join(flags),
                 "pattern": s.pattern or "",
-                "desc": _first_sentence(s.description),
+                "desc": (_first_sentence(s.description).rstrip(".") + desc_suffix)
+                if desc_suffix
+                else _first_sentence(s.description),
             }
         )
     if not rows:
@@ -313,15 +335,12 @@ def render_summary() -> str:
     out = ["ASTRA specification -- concept vocabulary", ""]
     for schema in _schema_display_order(class_groups, enum_groups):
         names = class_groups.get(schema, [])
-        enums = enum_groups.get(schema, [])
-        if not names and not enums:
+        if not names:
             continue
         out.append(f"{schema.upper()}")
-        width = max((len(n) for n in names + enums), default=0)
+        width = max((len(n) for n in names), default=0)
         for n in names:
             out.extend(_two_col(n, _first_sentence(sv.get_class(n).description), width))
-        for n in enums:
-            out.extend(_two_col(n, "(enum) " + _first_sentence(sv.get_enum(n).description), width))
         out.append("")
     out.append(
         "astra spec <term> for detail; astra spec --full dumps the entire reference (very long)."
@@ -339,7 +358,7 @@ def render_full() -> str:
     enum_groups = _enums_by_schema()
     sep = "\n" + "=" * 74 + "\n\n"
     for schema in _schema_display_order(class_groups, enum_groups):
-        for name in class_groups.get(schema, []) + enum_groups.get(schema, []):
+        for name in class_groups.get(schema, []):
             parts.append(render_term(name).rstrip())
     return sep.join(parts) + "\n"
 

--- a/src/astra/spec_render.py
+++ b/src/astra/spec_render.py
@@ -38,13 +38,16 @@ def _first_sentence(text: str | None) -> str:
     return (head if sep else flat).rstrip(".") + "."
 
 
+def _wrap_at(text: str, indent: int) -> list[str]:
+    """Wrap text to the terminal width with every line indented `indent` spaces."""
+    cols = max(shutil.get_terminal_size(fallback=(100, 24)).columns, indent + 20)
+    return [" " * indent + line for line in textwrap.wrap(text, width=cols - indent)] or [""]
+
+
 def _two_col(name: str, desc: str, width: int) -> list[str]:
     """One vocabulary-map row: name column, then desc wrapped within its own column."""
-    indent = " " * (2 + width + 2)
-    cols = max(shutil.get_terminal_size(fallback=(100, 24)).columns, len(indent) + 20)
-    lines = textwrap.wrap(desc, width=cols - len(indent)) or [""]
-    first = f"  {name:<{width}}  {lines[0]}".rstrip()
-    return [first] + [indent + line for line in lines[1:]]
+    lines = _wrap_at(desc, 2 + width + 2)
+    return [f"  {name:<{width}}  {lines[0].lstrip()}".rstrip()] + lines[1:]
 
 
 def _humanize(token: str) -> str:
@@ -178,7 +181,7 @@ def _render_field_table(name: str) -> list[str]:
             line += f"  {r['flags']}"
         out.append(line.rstrip())
         if r["desc"]:
-            out.append(f"      {r['desc']}")
+            out.extend(_wrap_at(r["desc"], 6))
         if r["pattern"]:
             out.append(f"      pattern: {r['pattern']}")
     return out
@@ -229,7 +232,7 @@ def _render_rules(name: str) -> list[str]:
             for r, _ in members:
                 out.append(f"  {_humanize(r.title)}")
                 if r.description:
-                    out.append(f"      {_first_sentence(r.description)}")
+                    out.extend(_wrap_at(_first_sentence(r.description), 6))
     return out
 
 

--- a/src/astra/spec_render.py
+++ b/src/astra/spec_render.py
@@ -158,34 +158,52 @@ def _render_field_table(name: str) -> list[str]:
     return out
 
 
+def _forbidden_slot(rule: Any) -> str | None:
+    """The single slot a forbid-rule marks absent, or ``None``.
+
+    Read from the postcondition -- the real slot name, underscores intact --
+    not the title, so multi-token names like ``ref_version`` survive.
+    """
+    conds = getattr(rule.postconditions, "slot_conditions", None) or {}
+    if len(conds) != 1:
+        return None
+    ((slot, cond),) = conds.items()
+    presence = getattr(cond, "value_presence", None)
+    return slot if presence is not None and str(presence) == "ABSENT" else None
+
+
 def _render_rules(name: str) -> list[str]:
     cls = _view().get_class(name)
     rules = [r for r in (cls.rules or []) if r.title]
     if not rules:
         return []
 
-    # Collapse parallel rules that share a title stem (everything but the last
-    # underscore-delimited token), e.g. from_alias_forbids_{label,options,...}.
-    groups: dict[str, list[Any]] = {}
+    # Collapse parallel forbid-rules -- those marking one slot absent under a
+    # shared precondition, e.g. from_alias_forbids_{label,ref_version,...}. The
+    # forbidden slot comes from the postcondition (so underscored names stay
+    # intact); the group label is the title with that suffix stripped. Stripping
+    # a whole shared prefix this way, rather than one trailing token, is what
+    # keeps ref_version/use_outputs in their family instead of orphaning them.
+    groups: dict[str, list[tuple[Any, str | None]]] = {}
     order: list[str] = []
     for r in rules:
-        stem, _, _ = r.title.rpartition("_")
-        stem = stem or r.title
+        slot = _forbidden_slot(r)
+        stem = r.title[: -(len(slot) + 1)] if slot and r.title.endswith("_" + slot) else r.title
         if stem not in groups:
             order.append(stem)
-        groups.setdefault(stem, []).append(r)
+        groups.setdefault(stem, []).append((r, slot))
 
     out = ["Rules:"]
     for stem in order:
         members = groups[stem]
-        if len(members) > 1:
-            suffixes = ", ".join(m.title.rpartition("_")[2] for m in members)
-            out.append(f"  {_humanize(stem)}: {suffixes}")
+        forbids = [slot for _, slot in members if slot is not None]
+        if len(members) > 1 and len(forbids) == len(members):
+            out.append(f"  {_humanize(stem)}: {', '.join(forbids)}")
         else:
-            r = members[0]
-            out.append(f"  {_humanize(r.title)}")
-            if r.description:
-                out.append(f"      {_first_sentence(r.description)}")
+            for r, _ in members:
+                out.append(f"  {_humanize(r.title)}")
+                if r.description:
+                    out.append(f"      {_first_sentence(r.description)}")
     return out
 
 

--- a/src/astra/spec_render.py
+++ b/src/astra/spec_render.py
@@ -296,7 +296,10 @@ def render_summary() -> str:
 
 def render_full() -> str:
     """Every entry concatenated: summary, then each term in schema order."""
-    parts = [render_summary(), ""]
+    # No empty-string sentinel here: joining `sep` against one would place two
+    # `====` rules (with a blank line between) at the summary->first-entry seam,
+    # inconsistent with every other single-rule boundary.
+    parts = [render_summary()]
     class_groups = _classes_by_schema()
     enum_groups = _enums_by_schema()
     sep = "\n" + "=" * 74 + "\n\n"

--- a/src/astra/spec_render.py
+++ b/src/astra/spec_render.py
@@ -8,10 +8,10 @@ from __future__ import annotations
 
 import os
 from functools import lru_cache
-
-from linkml_runtime.utils.schemaview import SchemaView
+from typing import Any
 
 from astra.datamodel import SCHEMA_DIRECTORY
+from linkml_runtime.utils.schemaview import SchemaView
 
 # The three schema files map to the three conceptual layers ASTRA groups by.
 # `from_schema` on each class carries the source schema URI; we key on its tail.
@@ -45,6 +45,7 @@ def _humanize(token: str) -> str:
 # Term registry
 # --------------------------------------------------------------------------
 
+
 def _terms() -> dict[str, tuple[str, str]]:
     """Map lowercased term -> (canonical name, kind) for every class and enum."""
     sv = _view()
@@ -75,6 +76,7 @@ def _enums_by_schema() -> dict[str, list[str]]:
 # --------------------------------------------------------------------------
 # Cross-reference graph
 # --------------------------------------------------------------------------
+
 
 def _used_by(target: str) -> list[str]:
     # Self-edges (a class holding a slot ranged at itself) are kept, not
@@ -111,6 +113,7 @@ def _term_ref(name: str, current: str) -> str:
 # --------------------------------------------------------------------------
 # Rendering
 # --------------------------------------------------------------------------
+
 
 def _render_field_table(name: str) -> list[str]:
     sv = _view()
@@ -163,7 +166,7 @@ def _render_rules(name: str) -> list[str]:
 
     # Collapse parallel rules that share a title stem (everything but the last
     # underscore-delimited token), e.g. from_alias_forbids_{label,options,...}.
-    groups: dict[str, list] = {}
+    groups: dict[str, list[Any]] = {}
     order: list[str] = []
     for r in rules:
         stem, _, _ = r.title.rpartition("_")
@@ -256,8 +259,9 @@ def render_summary() -> str:
         for n in enums:
             out.append(f"  {n:<{width}}  (enum) {_first_sentence(sv.get_enum(n).description)}")
         out.append("")
-    out.append("astra spec <term> for detail; astra spec --full dumps the entire "
-               "reference (very long).")
+    out.append(
+        "astra spec <term> for detail; astra spec --full dumps the entire reference (very long)."
+    )
     return "\n".join(out)
 
 

--- a/src/astra/spec_render.py
+++ b/src/astra/spec_render.py
@@ -77,12 +77,14 @@ def _enums_by_schema() -> dict[str, list[str]]:
 # --------------------------------------------------------------------------
 
 def _used_by(target: str) -> list[str]:
+    # Self-edges (a class holding a slot ranged at itself) are kept, not
+    # dropped: Analysis contains sub-Analyses, and that recursion is a real
+    # part of the graph. It is flagged at render time via `_term_ref`.
     sv = _view()
     users = [
         name
         for name, _ in sv.all_classes().items()
-        if name != target
-        and any(s.range == target for s in sv.class_induced_slots(name))
+        if any(s.range == target for s in sv.class_induced_slots(name))
     ]
     return users
 
@@ -92,13 +94,18 @@ def _references(name: str) -> list[str]:
     known = set(sv.all_classes()) | set(sv.all_enums())
     seen: list[str] = []
     for s in sv.class_induced_slots(name):
-        if s.range in known and s.range != name and s.range not in seen:
+        if s.range in known and s.range not in seen:
             seen.append(s.range)
     return seen
 
 
 def _term_link(name: str) -> str:
     return f"{name} (astra spec {name.lower()})"
+
+
+def _term_ref(name: str, current: str) -> str:
+    """Cross-reference link, marking an edge back to the current term."""
+    return f"{name} (self-recursive)" if name == current else _term_link(name)
 
 
 # --------------------------------------------------------------------------
@@ -224,9 +231,9 @@ def render_term(term: str) -> str:
     if refs or used:
         out.append("")
     if refs:
-        out.append("References: " + ", ".join(_term_link(r) for r in refs))
+        out.append("References: " + ", ".join(_term_ref(r, name) for r in refs))
     if used:
-        out.append("Used by: " + ", ".join(_term_link(u) for u in used))
+        out.append("Used by: " + ", ".join(_term_ref(u, name) for u in used))
     return "\n".join(out).rstrip() + "\n"
 
 

--- a/src/astra/spec_render.py
+++ b/src/astra/spec_render.py
@@ -1,0 +1,270 @@
+"""Mechanical rendering of the ASTRA LinkML schema into agent-friendly text.
+
+Pure transformation: every string emitted here comes from the schema via
+``SchemaView``. No hand-authored prose about the data model lives in this file.
+"""
+
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+
+from linkml_runtime.utils.schemaview import SchemaView
+
+from astra.datamodel import SCHEMA_DIRECTORY
+
+# The three schema files map to the three conceptual layers ASTRA groups by.
+# `from_schema` on each class carries the source schema URI; we key on its tail.
+SCHEMA_ORDER = ["analysis", "universe", "insight"]
+
+
+@lru_cache(maxsize=1)
+def _view() -> SchemaView:
+    # analysis.yaml imports insight + universe, so one load closes over all three.
+    return SchemaView(os.path.join(SCHEMA_DIRECTORY, "analysis.yaml"))
+
+
+def _schema_of(from_schema: str | None) -> str:
+    return (from_schema or "").rstrip("/").rsplit("/", 1)[-1]
+
+
+def _first_sentence(text: str | None) -> str:
+    if not text:
+        return ""
+    flat = " ".join(text.split())
+    head, sep, _ = flat.partition(". ")
+    return head + "." if sep else flat
+
+
+def _humanize(token: str) -> str:
+    s = token.replace("_", " ").strip()
+    return s[:1].upper() + s[1:] if s else s
+
+
+# --------------------------------------------------------------------------
+# Term registry
+# --------------------------------------------------------------------------
+
+def _terms() -> dict[str, tuple[str, str]]:
+    """Map lowercased term -> (canonical name, kind) for every class and enum."""
+    sv = _view()
+    terms: dict[str, tuple[str, str]] = {}
+    for name in sv.all_classes():
+        terms[name.lower()] = (name, "class")
+    for name in sv.all_enums():
+        terms[name.lower()] = (name, "enum")
+    return terms
+
+
+def _classes_by_schema() -> dict[str, list[str]]:
+    sv = _view()
+    groups: dict[str, list[str]] = {s: [] for s in SCHEMA_ORDER}
+    for name, cls in sv.all_classes().items():
+        groups.setdefault(_schema_of(cls.from_schema), []).append(name)
+    return groups
+
+
+def _enums_by_schema() -> dict[str, list[str]]:
+    sv = _view()
+    groups: dict[str, list[str]] = {s: [] for s in SCHEMA_ORDER}
+    for name, enm in sv.all_enums().items():
+        groups.setdefault(_schema_of(enm.from_schema), []).append(name)
+    return groups
+
+
+# --------------------------------------------------------------------------
+# Cross-reference graph
+# --------------------------------------------------------------------------
+
+def _used_by(target: str) -> list[str]:
+    sv = _view()
+    users = [
+        name
+        for name, _ in sv.all_classes().items()
+        if name != target
+        and any(s.range == target for s in sv.class_induced_slots(name))
+    ]
+    return users
+
+
+def _references(name: str) -> list[str]:
+    sv = _view()
+    known = set(sv.all_classes()) | set(sv.all_enums())
+    seen: list[str] = []
+    for s in sv.class_induced_slots(name):
+        if s.range in known and s.range != name and s.range not in seen:
+            seen.append(s.range)
+    return seen
+
+
+def _term_link(name: str) -> str:
+    return f"{name} (astra spec {name.lower()})"
+
+
+# --------------------------------------------------------------------------
+# Rendering
+# --------------------------------------------------------------------------
+
+def _render_field_table(name: str) -> list[str]:
+    sv = _view()
+    known = set(sv.all_classes()) | set(sv.all_enums())
+    rows = []
+    for s in sv.class_induced_slots(name):
+        flags = []
+        if s.multivalued:
+            flags.append("multivalued")
+        if s.inlined or s.inlined_as_list:
+            flags.append("inlined")
+        rng = f"-> astra spec {s.range.lower()}" if s.range in known else (s.range or "string")
+        rows.append(
+            {
+                "name": s.name,
+                "req": "required" if s.required else "optional",
+                "range": rng,
+                "flags": " ".join(flags),
+                "pattern": s.pattern or "",
+                "desc": _first_sentence(s.description),
+            }
+        )
+    if not rows:
+        return []
+
+    widths = {k: max(len(r[k]) for r in rows) for k in ("name", "req", "range", "flags")}
+    widths = {k: max(v, len(h)) for (k, v), h in zip(widths.items(), ("field", "", "range", ""))}
+    out = ["Fields:"]
+    for r in rows:
+        line = (
+            f"  {r['name']:<{widths['name']}}  "
+            f"{r['req']:<{widths['req']}}  "
+            f"{r['range']:<{widths['range']}}"
+        )
+        if r["flags"]:
+            line += f"  {r['flags']}"
+        out.append(line.rstrip())
+        if r["desc"]:
+            out.append(f"      {r['desc']}")
+        if r["pattern"]:
+            out.append(f"      pattern: {r['pattern']}")
+    return out
+
+
+def _render_rules(name: str) -> list[str]:
+    cls = _view().get_class(name)
+    rules = [r for r in (cls.rules or []) if r.title]
+    if not rules:
+        return []
+
+    # Collapse parallel rules that share a title stem (everything but the last
+    # underscore-delimited token), e.g. from_alias_forbids_{label,options,...}.
+    groups: dict[str, list] = {}
+    order: list[str] = []
+    for r in rules:
+        stem, _, _ = r.title.rpartition("_")
+        stem = stem or r.title
+        if stem not in groups:
+            order.append(stem)
+        groups.setdefault(stem, []).append(r)
+
+    out = ["Rules:"]
+    for stem in order:
+        members = groups[stem]
+        if len(members) > 1:
+            suffixes = ", ".join(m.title.rpartition("_")[2] for m in members)
+            out.append(f"  {_humanize(stem)}: {suffixes}")
+        else:
+            r = members[0]
+            out.append(f"  {_humanize(r.title)}")
+            if r.description:
+                out.append(f"      {_first_sentence(r.description)}")
+    return out
+
+
+def _render_enum(name: str) -> str:
+    enm = _view().get_enum(name)
+    out = [f"# {name}  (enum)", ""]
+    if enm.description:
+        out.append(_first_sentence(enm.description))
+        out.append("")
+    out.append("Values:")
+    for vname, v in (enm.permissible_values or {}).items():
+        desc = _first_sentence(v.description) if v.description else ""
+        out.append(f"  {vname}" + (f"  -- {desc}" if desc else ""))
+    out.append("")
+    used = _used_by(name)
+    if used:
+        out.append("Used by: " + ", ".join(_term_link(u) for u in used))
+    return "\n".join(out).rstrip() + "\n"
+
+
+def render_term(term: str) -> str:
+    """Full rendered entry for a single class or enum. Returns '' if unknown."""
+    hit = _terms().get(term.lower())
+    if hit is None:
+        return ""
+    name, kind = hit
+    if kind == "enum":
+        return _render_enum(name)
+
+    sv = _view()
+    cls = sv.get_class(name)
+    out = [f"# {name}" + ("  (tree root)" if cls.tree_root else ""), ""]
+    if cls.description:
+        # Verbatim: folded-scalar descriptions carry intentional grammar/example
+        # blocks (indented lines survive YAML folding), so keep the line breaks.
+        out.append("\n".join(line.rstrip() for line in cls.description.rstrip().splitlines()))
+        out.append("")
+    out.extend(_render_field_table(name))
+    rules = _render_rules(name)
+    if rules:
+        out.append("")
+        out.extend(rules)
+
+    refs = _references(name)
+    used = _used_by(name)
+    if refs or used:
+        out.append("")
+    if refs:
+        out.append("References: " + ", ".join(_term_link(r) for r in refs))
+    if used:
+        out.append("Used by: " + ", ".join(_term_link(u) for u in used))
+    return "\n".join(out).rstrip() + "\n"
+
+
+def render_summary() -> str:
+    """One line per class/enum, grouped by schema, with a usage footer."""
+    class_groups = _classes_by_schema()
+    enum_groups = _enums_by_schema()
+    sv = _view()
+
+    out = ["ASTRA specification -- concept vocabulary", ""]
+    for schema in SCHEMA_ORDER:
+        names = class_groups.get(schema, [])
+        enums = enum_groups.get(schema, [])
+        if not names and not enums:
+            continue
+        out.append(f"{schema.upper()}")
+        width = max((len(n) for n in names + enums), default=0)
+        for n in names:
+            out.append(f"  {n:<{width}}  {_first_sentence(sv.get_class(n).description)}")
+        for n in enums:
+            out.append(f"  {n:<{width}}  (enum) {_first_sentence(sv.get_enum(n).description)}")
+        out.append("")
+    out.append("astra spec <term> for detail; astra spec --full dumps the entire "
+               "reference (very long).")
+    return "\n".join(out)
+
+
+def render_full() -> str:
+    """Every entry concatenated: summary, then each term in schema order."""
+    parts = [render_summary(), ""]
+    class_groups = _classes_by_schema()
+    enum_groups = _enums_by_schema()
+    sep = "\n" + "=" * 74 + "\n\n"
+    for schema in SCHEMA_ORDER:
+        for name in class_groups.get(schema, []) + enum_groups.get(schema, []):
+            parts.append(render_term(name).rstrip())
+    return sep.join(parts) + "\n"
+
+
+def list_terms() -> list[str]:
+    return sorted(t[0] for t in _terms().values())

--- a/src/astra/spec_render.py
+++ b/src/astra/spec_render.py
@@ -73,6 +73,17 @@ def _enums_by_schema() -> dict[str, list[str]]:
     return groups
 
 
+def _schema_display_order(*group_dicts: dict[str, list[str]]) -> list[str]:
+    """SCHEMA_ORDER first, then any other schema buckets (sorted).
+
+    Guarantees every bucket is rendered: a schema file astra-spec grows beyond
+    the three known layers still appears, appended after them, rather than being
+    silently dropped from the summary and full dump.
+    """
+    extra = sorted({s for g in group_dicts for s in g} - set(SCHEMA_ORDER))
+    return SCHEMA_ORDER + extra
+
+
 # --------------------------------------------------------------------------
 # Cross-reference graph
 # --------------------------------------------------------------------------
@@ -265,7 +276,7 @@ def render_summary() -> str:
     sv = _view()
 
     out = ["ASTRA specification -- concept vocabulary", ""]
-    for schema in SCHEMA_ORDER:
+    for schema in _schema_display_order(class_groups, enum_groups):
         names = class_groups.get(schema, [])
         enums = enum_groups.get(schema, [])
         if not names and not enums:
@@ -289,7 +300,7 @@ def render_full() -> str:
     class_groups = _classes_by_schema()
     enum_groups = _enums_by_schema()
     sep = "\n" + "=" * 74 + "\n\n"
-    for schema in SCHEMA_ORDER:
+    for schema in _schema_display_order(class_groups, enum_groups):
         for name in class_groups.get(schema, []) + enum_groups.get(schema, []):
             parts.append(render_term(name).rstrip())
     return sep.join(parts) + "\n"

--- a/src/astra/spec_render.py
+++ b/src/astra/spec_render.py
@@ -136,7 +136,11 @@ def _render_field_table(name: str) -> list[str]:
             flags.append("multivalued")
         if s.inlined or s.inlined_as_list:
             flags.append("inlined")
-        rng = f"-> astra spec {s.range.lower()}" if s.range in known else (s.range or "string")
+        rng = (
+            f"-> astra spec {s.range.lower()}"
+            if s.range in known
+            else (s.range or sv.schema.default_range)
+        )
         rows.append(
             {
                 "name": s.name,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -597,6 +597,78 @@ class TestSpecCommand:
         assert "Analysis (self-recursive)" in out
         assert "Used by:" in out
 
+    def test_term_collapses_forbid_rules_with_underscored_slots(self, runner: CliRunner):
+        # Input's forbidden slots include multi-token names (ref_version,
+        # use_outputs). All from_alias_forbids_* rules must collapse to ONE
+        # line, with the underscored names intact as suffixes -- not orphaned
+        # onto standalone "From alias forbids ref version" lines.
+        result = runner.invoke(main, ["spec", "input"])
+        assert result.exit_code == 0
+        lines = result.output.splitlines()
+        forbid_lines = [ln for ln in lines if "From alias forbids:" in ln]
+        assert len(forbid_lines) == 1
+        collapsed = forbid_lines[0]
+        for slot in ("type", "label", "description", "source", "ref", "ref_version", "use_outputs"):
+            assert slot in collapsed
+        # No forbid slot fragments onto its own humanized rule line.
+        assert not any("From alias forbids ref version" in ln for ln in lines)
+        assert not any("From alias forbids use outputs" in ln for ln in lines)
+
+    def test_class_description_rendered_verbatim(self, runner: CliRunner):
+        # A class description renders VERBATIM with newlines preserved -- in
+        # deliberate contrast to first-sentence-flattened field descriptions.
+        # Decision carries an indented reference-grammar block that only
+        # survives if the line breaks are kept.
+        result = runner.invoke(main, ["spec", "decision"])
+        assert result.exit_code == 0
+        lines = result.output.splitlines()
+        assert "Reference grammar:" in lines  # its own line, not folded in
+        grammar_idx = lines.index("Reference grammar:")
+        # The indented example lines follow on their own separate lines.
+        block = lines[grammar_idx : grammar_idx + 4]
+        assert any(ln.startswith("  from: ../id") for ln in block)
+        assert any(ln.startswith("  from: ../../id") for ln in block)
+
+    def test_field_table_derives_flags_and_pattern(self, runner: CliRunner):
+        # Requiredness, multivalued/inlined flags, and pattern are induced from
+        # the slots. Decision exercises all three.
+        result = runner.invoke(main, ["spec", "decision"])
+        out = result.output
+        lines = out.splitlines()
+
+        def field_line(name: str) -> str:
+            return next(ln for ln in lines if ln.strip().startswith(name + " "))
+
+        # `options` is a multivalued, inlined map of Option.
+        opts = field_line("options")
+        assert "multivalued" in opts and "inlined" in opts
+        # `when` is multivalued but not inlined.
+        when = field_line("when")
+        assert "multivalued" in when and "inlined" not in when
+        # `from` carries a pattern, emitted on its own indented line.
+        assert any(ln.strip().startswith("pattern: ^(\\.\\./)") for ln in lines)
+
+    def test_field_table_honors_slot_usage_overrides(self, runner: CliRunner):
+        # Input.from and Output.from are the same slot with per-class
+        # slot_usage overrides; they must render distinct patterns. This holds
+        # only because the renderer reads class_induced_slots, not plain slots.
+        input_from = runner.invoke(main, ["spec", "input"]).output
+        output_from = runner.invoke(main, ["spec", "output"]).output
+        input_pattern = r"^(\.\./)+[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)*$"
+        output_pattern = r"^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)+$"
+        assert input_pattern in input_from
+        assert output_pattern in output_from
+        # The override is real: neither class shows the other's pattern.
+        assert input_pattern not in output_from
+        assert output_pattern not in input_from
+
+    def test_full_with_term_is_rejected(self, runner: CliRunner):
+        # --full and a positional TERM are mutually exclusive; passing both
+        # errors rather than silently dumping the whole reference.
+        result = runner.invoke(main, ["spec", "analysis", "--full"])
+        assert result.exit_code != 0
+        assert "--full" in result.output
+
     def test_spec_help(self, runner: CliRunner):
         result = runner.invoke(main, ["spec", "--help"])
         assert result.exit_code == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -579,8 +579,11 @@ class TestSpecCommand:
         out = result.output
         # Sanity: substantial, spanning far more than any single entry.
         assert len(out.splitlines()) > 300
-        for heading in ("# Analysis", "# Decision", "# Universe", "# InputType"):
+        for heading in ("# Analysis", "# Decision", "# Universe"):
             assert heading in out
+        # Enums are inlined into the fields that use them, not standalone entries.
+        assert "# InputType" not in out
+        assert "data | analysis" in out
 
     def test_cross_references_link_related_terms(self, runner: CliRunner):
         result = runner.invoke(main, ["spec", "decision"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -664,8 +664,9 @@ class TestSpecCommand:
 
     def test_field_table_renders_requiredness(self, runner: CliRunner):
         # Requiredness is a contract-named field-table property. Option pins both
-        # tokens in one class: `label` is a required slot, the rest are optional.
-        # Inverting the ternary (required<->optional) must fail this.
+        # tokens in one class: `label` is explicitly required and `id` is required
+        # by LinkML identifier semantics, while the rest are optional. Inverting the
+        # ternary (required<->optional) must fail this.
         result = runner.invoke(main, ["spec", "option"])
         assert result.exit_code == 0
         lines = result.output.splitlines()
@@ -673,9 +674,11 @@ class TestSpecCommand:
         def field_line(name: str) -> str:
             return next(ln for ln in lines if ln.strip().startswith(name + " "))
 
-        label = field_line("label")
-        assert "required" in label and "optional" not in label
-        for optional_field in ("id", "description", "excluded"):
+        # `id` is `identifier: true`; class_induced_slots resolves it to required.
+        for required_field in ("label", "id"):
+            ln = field_line(required_field)
+            assert "required" in ln and "optional" not in ln
+        for optional_field in ("description", "excluded"):
             ln = field_line(optional_field)
             assert "optional" in ln and "required" not in ln
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -499,3 +499,105 @@ class TestBatchQuoteVerification:
         assert "Verify multiple quotes" in result.output
         assert "stdin" in result.output
         assert "JSON" in result.output
+
+
+class TestSpecCommand:
+    """Tests for the `spec` schema-reference renderer.
+
+    Output is a pure transformation of the installed astra-spec schema, so
+    these assert structural invariants and a few load-bearing concepts rather
+    than exact prose.
+    """
+
+    def test_summary_groups_by_schema(self, runner: CliRunner):
+        result = runner.invoke(main, ["spec"])
+        assert result.exit_code == 0
+        out = result.output
+        assert "concept vocabulary" in out
+        # The three schema layers appear as group headers, in display order.
+        for label in ("ANALYSIS", "UNIVERSE", "INSIGHT"):
+            assert label in out
+        assert out.index("ANALYSIS") < out.index("UNIVERSE") < out.index("INSIGHT")
+
+    def test_summary_footer_points_at_term_and_full(self, runner: CliRunner):
+        result = runner.invoke(main, ["spec"])
+        assert result.exit_code == 0
+        assert "astra spec <term>" in result.output
+        assert "astra spec --full" in result.output
+
+    def test_summary_lists_core_concepts(self, runner: CliRunner):
+        result = runner.invoke(main, ["spec"])
+        for term in ("Analysis", "Decision", "Universe", "Insight"):
+            assert term in result.output
+
+    def test_term_renders_class_in_full(self, runner: CliRunner):
+        result = runner.invoke(main, ["spec", "analysis"])
+        assert result.exit_code == 0
+        out = result.output
+        assert out.startswith("# Analysis")
+        assert "Fields:" in out
+        # Slot ranges that are classes render as `astra spec <term>` links.
+        assert "-> astra spec input" in out
+
+    def test_term_lookup_is_case_insensitive(self, runner: CliRunner):
+        lower = runner.invoke(main, ["spec", "analysis"])
+        upper = runner.invoke(main, ["spec", "ANALYSIS"])
+        assert lower.exit_code == upper.exit_code == 0
+        assert lower.output == upper.output
+        assert upper.output.startswith("# Analysis")
+
+    def test_term_collapses_parallel_forbid_rules(self, runner: CliRunner):
+        result = runner.invoke(main, ["spec", "decision"])
+        assert result.exit_code == 0
+        out = result.output
+        assert "Rules:" in out
+        # Rules sharing a title stem collapse to one line listing the suffixes.
+        forbid_lines = [ln for ln in out.splitlines() if "From alias forbids:" in ln]
+        assert len(forbid_lines) == 1
+        assert forbid_lines[0].count(",") >= 1
+
+    def test_enum_renders_values_and_used_by(self, runner: CliRunner):
+        result = runner.invoke(main, ["spec", "inputtype"])
+        assert result.exit_code == 0
+        out = result.output
+        assert "(enum)" in out
+        assert "Values:" in out
+        assert "data" in out
+        assert "Used by:" in out
+
+    def test_unknown_term_exits_1_and_lists_terms(self, runner: CliRunner):
+        result = runner.invoke(main, ["spec", "not_a_real_term"])
+        assert result.exit_code == 1
+        assert "Unknown term" in result.output
+        assert "Valid terms" in result.output
+        # A genuine term is offered among the valid ones.
+        assert "Analysis" in result.output
+
+    def test_full_concatenates_every_entry(self, runner: CliRunner):
+        result = runner.invoke(main, ["spec", "--full"])
+        assert result.exit_code == 0
+        out = result.output
+        # Sanity: substantial, spanning far more than any single entry.
+        assert len(out.splitlines()) > 300
+        for heading in ("# Analysis", "# Decision", "# Universe", "# InputType"):
+            assert heading in out
+
+    def test_cross_references_link_related_terms(self, runner: CliRunner):
+        result = runner.invoke(main, ["spec", "decision"])
+        out = result.output
+        assert "References:" in out
+        assert "Option (astra spec option)" in out
+        assert "Used by:" in out
+        assert "Analysis (astra spec analysis)" in out
+
+    def test_self_recursive_edge_is_marked_not_dropped(self, runner: CliRunner):
+        result = runner.invoke(main, ["spec", "analysis"])
+        out = result.output
+        # Analysis contains sub-Analyses; the self edge is flagged, not silent.
+        assert "Analysis (self-recursive)" in out
+        assert "Used by:" in out
+
+    def test_spec_help(self, runner: CliRunner):
+        result = runner.invoke(main, ["spec", "--help"])
+        assert result.exit_code == 0
+        assert "reference" in result.output.lower()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -662,6 +662,56 @@ class TestSpecCommand:
         assert input_pattern not in output_from
         assert output_pattern not in input_from
 
+    def test_field_table_renders_requiredness(self, runner: CliRunner):
+        # Requiredness is a contract-named field-table property. Option pins both
+        # tokens in one class: `label` is a required slot, the rest are optional.
+        # Inverting the ternary (required<->optional) must fail this.
+        result = runner.invoke(main, ["spec", "option"])
+        assert result.exit_code == 0
+        lines = result.output.splitlines()
+
+        def field_line(name: str) -> str:
+            return next(ln for ln in lines if ln.strip().startswith(name + " "))
+
+        label = field_line("label")
+        assert "required" in label and "optional" not in label
+        for optional_field in ("id", "description", "excluded"):
+            ln = field_line(optional_field)
+            assert "optional" in ln and "required" not in ln
+
+    def test_field_table_flattens_field_descriptions_to_first_sentence(self, runner: CliRunner):
+        # First-sentence flattening is an accepted judgment call and load-bearing:
+        # Recipe.command carries a multi-paragraph template description that would
+        # dump into the table verbatim if `_first_sentence` were dropped. Only the
+        # opening sentence survives; the later-paragraph body does not.
+        result = runner.invoke(main, ["spec", "recipe"])
+        assert result.exit_code == 0
+        out = result.output
+        assert "POSIX shell command to execute" in out
+        # Tokens exclusive to later paragraphs of the command description; their
+        # presence would mean the field description was rendered verbatim.
+        assert "{inputs.<id>}" not in out
+        assert "placeholders" not in out
+        assert "Runners substitute" not in out
+
+    def test_full_includes_every_schema_group(self, runner: CliRunner):
+        # --full completeness is the whole point of the command. Pin at least one
+        # heading from each of the three schema buckets so a regression dropping a
+        # whole group (e.g. the insight per-schema loop) is caught, not just the
+        # already-guarded analysis/universe ones.
+        result = runner.invoke(main, ["spec", "--full"])
+        assert result.exit_code == 0
+        out = result.output
+        for heading in (
+            "# Analysis",  # analysis group
+            "# Universe",  # universe group
+            "# Evidence",  # insight group
+            "# Insight",
+            "# InsightCollection",
+            "# TextQuoteSelector",
+        ):
+            assert heading in out, f"{heading} missing from --full"
+
     def test_full_with_term_is_rejected(self, runner: CliRunner):
         # --full and a positional TERM are mutually exclusive; passing both
         # errors rather than silently dumping the whole reference.


### PR DESCRIPTION
Adds an `astra spec` command that renders the ASTRA specification — the LinkML schemas in `astra-spec` that `astra validate` checks against — in human- and agent-readable form. A pure mechanical transformation over the installed schema via `SchemaView`: zero hand-authored prose, so the reference can't drift from the spec.

Three commands:

- `astra spec` — vocabulary map: one line per concept, grouped by the three schemas (analysis, universe, insight).
- `astra spec <term>` — one concept in full: description, field table, rules, and `Used by` / `References` edges. Case-insensitive; an unknown term lists valid terms and exits 1.
- `astra spec --full` — every entry concatenated (very long).

Enums (`InputType`, `OutputType`) are inlined into the fields that use them — the range column shows the literal values (`data | analysis`) with per-value glosses in the description — rather than rendered as standalone concepts. The full vocabulary, i.e. every valid `<term>`:

| Schema | Terms |
|---|---|
| analysis | `KeyValuePair`, `Resources`, `Recipe`, `Input`, `Output`, `Option`, `Decision`, `Analysis` |
| universe | `DecisionSelection`, `UniverseNode`, `Universe` |
| insight | `TextQuoteSelector`, `FragmentSelector`, `Evidence`, `Insight`, `InsightCollection` |

**Changes**
- `src/astra/spec_render.py` — the renderer.
- `src/astra/cli.py` — wires the `spec` command.
- `tests/test_cli.py` — pins contract-critical behavior (requiredness, first-sentence flattening, `--full` completeness, forbid-rule collapsing, self-recursive marking).
- `pyproject.toml` — declares `linkml-runtime>=1.8` as a direct dependency.

**Try it**
```
uvx astra spec              # vocabulary map
uvx astra spec decision     # one concept in full
uvx astra spec --full       # everything (very long)
```

Product requirements doc (PRD): https://linear.app/lightcone-research/document/prd-astra-plugin-rework-85c9365aa561

Part of LCR-173.

— Fable on behalf of Cail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0125iYpfLx77XTCZwS7vfy2Y


<!-- dco-signed-off-by -->
Signed-off-by: Cail Daley <cailmdaley@gmail.com>