### PR TITLE
Address review findings on `astra spec`

### DIFF
--- a/src/astra/cli.py
+++ b/src/astra/cli.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import click
 from rich.console import Console
+from rich.markup import escape
 from rich.table import Table
 from rich.tree import Tree
 
@@ -744,7 +745,10 @@ def spec(term: str | None, full: bool) -> None:
     if term:
         rendered = spec_render.render_term(term)
         if not rendered:
-            console.print(f"[red]Unknown term:[/red] {term}")
+            # Escape the user-supplied term: unescaped bracket syntax would be
+            # parsed as Rich markup, crashing with MarkupError (e.g. `[/red]`)
+            # or silently swallowing `[foo]`-style fragments.
+            console.print(f"[red]Unknown term:[/red] {escape(term)}")
             console.print("Valid terms: " + ", ".join(spec_render.list_terms()))
             raise SystemExit(1)
         click.echo(rendered, nl=False)

--- a/src/astra/spec_render.py
+++ b/src/astra/spec_render.py
@@ -296,7 +296,10 @@ def render_summary() -> str:
 
 def render_full() -> str:
     """Every entry concatenated: summary, then each term in schema order."""
-    parts = [render_summary(), ""]
+    # No empty-string sentinel here: joining `sep` against one would place two
+    # `====` rules (with a blank line between) at the summary->first-entry seam,
+    # inconsistent with every other single-rule boundary.
+    parts = [render_summary()]
     class_groups = _classes_by_schema()
     enum_groups = _enums_by_schema()
     sep = "\n" + "=" * 74 + "\n\n"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -662,6 +662,56 @@ class TestSpecCommand:
         assert input_pattern not in output_from
         assert output_pattern not in input_from
 
+    def test_field_table_renders_requiredness(self, runner: CliRunner):
+        # Requiredness is a contract-named field-table property. Option pins both
+        # tokens in one class: `label` is a required slot, the rest are optional.
+        # Inverting the ternary (required<->optional) must fail this.
+        result = runner.invoke(main, ["spec", "option"])
+        assert result.exit_code == 0
+        lines = result.output.splitlines()
+
+        def field_line(name: str) -> str:
+            return next(ln for ln in lines if ln.strip().startswith(name + " "))
+
+        label = field_line("label")
+        assert "required" in label and "optional" not in label
+        for optional_field in ("id", "description", "excluded"):
+            ln = field_line(optional_field)
+            assert "optional" in ln and "required" not in ln
+
+    def test_field_table_flattens_field_descriptions_to_first_sentence(self, runner: CliRunner):
+        # First-sentence flattening is an accepted judgment call and load-bearing:
+        # Recipe.command carries a multi-paragraph template description that would
+        # dump into the table verbatim if `_first_sentence` were dropped. Only the
+        # opening sentence survives; the later-paragraph body does not.
+        result = runner.invoke(main, ["spec", "recipe"])
+        assert result.exit_code == 0
+        out = result.output
+        assert "POSIX shell command to execute" in out
+        # Tokens exclusive to later paragraphs of the command description; their
+        # presence would mean the field description was rendered verbatim.
+        assert "{inputs.<id>}" not in out
+        assert "placeholders" not in out
+        assert "Runners substitute" not in out
+
+    def test_full_includes_every_schema_group(self, runner: CliRunner):
+        # --full completeness is the whole point of the command. Pin at least one
+        # heading from each of the three schema buckets so a regression dropping a
+        # whole group (e.g. the insight per-schema loop) is caught, not just the
+        # already-guarded analysis/universe ones.
+        result = runner.invoke(main, ["spec", "--full"])
+        assert result.exit_code == 0
+        out = result.output
+        for heading in (
+            "# Analysis",  # analysis group
+            "# Universe",  # universe group
+            "# Evidence",  # insight group
+            "# Insight",
+            "# InsightCollection",
+            "# TextQuoteSelector",
+        ):
+            assert heading in out, f"{heading} missing from --full"
+
     def test_full_with_term_is_rejected(self, runner: CliRunner):
         # --full and a positional TERM are mutually exclusive; passing both
         # errors rather than silently dumping the whole reference.


### PR DESCRIPTION
Fixes the confirmed review findings on the `astra spec` renderer (PR #94), based off `astra-spec-command` so the spec code under review is present. Targets `astra-spec-command` so it folds back into #94 rather than opening a parallel line to `main`.

## Code fixes
- **Doubled separator at the summary seam in `--full`** — `render_full()` joined the `====` rule between the summary and an empty-string sentinel, producing two rules at the summary→first-entry seam while every other boundary shows one. Dropped the sentinel.
- **Rich `MarkupError` crash on bracket input** — the unknown-term error interpolated the raw TERM into a Rich markup string, so `astra spec '[/red]'` crashed with a traceback and `'[foo]bar'` silently swallowed the `[foo]` fragment. Now escaped via `rich.markup.escape`.

## Test coverage
Three contract-named behaviors were unpinned (regressions passed green); now covered:
- Field-table **requiredness** (`required`/`optional`) — inverting the ternary now fails.
- **First-sentence flattening** of field descriptions — dropping `_first_sentence` now fails (Recipe.command's multi-paragraph body would leak in).
- **`--full` completeness** across all three schema groups — a bug dropping the whole insight bucket now fails.

## Verification
- `astra spec --full` seam now shows a single rule; `astra spec '[/red]'` and `'[foo]bar'` echo the term verbatim and exit 1.
- `TestSpecCommand`: 20 passed (17 existing + 3 new).
- The 3 failures elsewhere in `test_cli.py` (`TestValidateCommand`, `TestInitCommand`) are pre-existing on `astra-spec-command` and unrelated to this change.

Reverted a stray uncommitted working-tree edit that had inverted the requiredness ternary (leftover from verifying the coverage gap).

— Fable on behalf of Cail

🤖 Generated with [Claude Code](https://claude.com/claude-code)