### PR TITLE
Add astra-tools script alias for the CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,9 @@ dev = [
 
 [project.scripts]
 astra = "astra.cli:main"
+# Alias matching the package name, so `uvx astra-tools@<version> <command>`
+# works without `--from astra-tools astra`.
+astra-tools = "astra.cli:main"
 
 [project.urls]
 Homepage = "https://astra-spec.org/"


### PR DESCRIPTION
## Summary
- Add an `astra-tools` console script alias pointing to the same `astra.cli:main` entry point, matching the package name.
- This lets `uvx astra-tools@<version> <command>` work directly, without needing `uvx --from astra-tools astra`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R1bSYSZjWkU5WZXqeWYfPA