### PR TITLE
Add astra guide: print the packaged llms.txt agent briefing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,8 @@ classifiers = [
 ]
 
 dependencies = [
-    "astra-spec>=0.0.11",
+    # >=0.0.13: first release shipping the packaged agent guide (astra guide)
+    "astra-spec>=0.0.13",
     "linkml-runtime>=1.8",
     "click>=8.0",
     "pydantic>=2.0",

--- a/src/astra/cli.py
+++ b/src/astra/cli.py
@@ -726,21 +726,21 @@ def _viz_mermaid_node(lines: list[str], node: dict[str, Any], node_prefix: str) 
         lines.append("    end")
 
 
-_GUIDE_URL = "https://astra-spec.org/llms.txt"
-
-
 @main.command()
 def guide() -> None:
     """Print the agent guide to the ASTRA format.
 
-    Prefers the guide (llms.txt) shipped inside the installed astra-spec
-    package, which matches the schema the validator enforces. When the
-    installed release predates the packaged copy, falls back to fetching
-    the latest published guide from https://astra-spec.org/llms.txt.
+    The guide (llms.txt) ships inside the installed astra-spec package, so it
+    always matches the schema the validator enforces. It is also published at
+    https://astra-spec.org/llms.txt.
     """
     text = _packaged_guide()
     if text is None:
-        text = _fetch_published_guide()
+        console.print(
+            "[red]Error:[/red] the installed astra-spec release predates the packaged "
+            "agent guide. Upgrade astra-spec, or read it at https://astra-spec.org/llms.txt."
+        )
+        raise SystemExit(1)
     click.echo(text, nl=False)
 
 
@@ -752,29 +752,6 @@ def _packaged_guide() -> str | None:
         return (resources.files("astra") / "docs" / "llms.txt").read_text(encoding="utf-8")
     except (FileNotFoundError, ModuleNotFoundError, OSError):
         return None
-
-
-def _fetch_published_guide() -> str:
-    """Fetch the published guide; exits with an error when unreachable."""
-    import httpx
-
-    try:
-        response = httpx.get(_GUIDE_URL, timeout=10.0, follow_redirects=True)
-        response.raise_for_status()
-    except httpx.HTTPError as exc:
-        console.print(
-            "[red]Error:[/red] the installed astra-spec release does not ship the "
-            f"agent guide, and fetching {_GUIDE_URL} failed ({escape(str(exc))})."
-        )
-        console.print(f"Upgrade astra-spec, or read the guide at {_GUIDE_URL}.")
-        raise SystemExit(1) from None
-    # Keep stdout pure guide content; the provenance note goes to stderr.
-    click.echo(
-        f"# Note: fetched from {_GUIDE_URL}; describes the latest published spec, "
-        "which may be newer than the installed astra-spec.",
-        err=True,
-    )
-    return response.text
 
 
 @main.command()

--- a/src/astra/cli.py
+++ b/src/astra/cli.py
@@ -726,6 +726,57 @@ def _viz_mermaid_node(lines: list[str], node: dict[str, Any], node_prefix: str) 
         lines.append("    end")
 
 
+_GUIDE_URL = "https://astra-spec.org/llms.txt"
+
+
+@main.command()
+def guide() -> None:
+    """Print the agent guide to the ASTRA format.
+
+    Prefers the guide (llms.txt) shipped inside the installed astra-spec
+    package, which matches the schema the validator enforces. When the
+    installed release predates the packaged copy, falls back to fetching
+    the latest published guide from https://astra-spec.org/llms.txt.
+    """
+    text = _packaged_guide()
+    if text is None:
+        text = _fetch_published_guide()
+    click.echo(text, nl=False)
+
+
+def _packaged_guide() -> str | None:
+    """The llms.txt shipped inside the installed astra-spec package, if any."""
+    from importlib import resources
+
+    try:
+        return (resources.files("astra") / "docs" / "llms.txt").read_text(encoding="utf-8")
+    except (FileNotFoundError, ModuleNotFoundError, OSError):
+        return None
+
+
+def _fetch_published_guide() -> str:
+    """Fetch the published guide; exits with an error when unreachable."""
+    import httpx
+
+    try:
+        response = httpx.get(_GUIDE_URL, timeout=10.0, follow_redirects=True)
+        response.raise_for_status()
+    except httpx.HTTPError as exc:
+        console.print(
+            "[red]Error:[/red] the installed astra-spec release does not ship the "
+            f"agent guide, and fetching {_GUIDE_URL} failed ({escape(str(exc))})."
+        )
+        console.print(f"Upgrade astra-spec, or read the guide at {_GUIDE_URL}.")
+        raise SystemExit(1) from None
+    # Keep stdout pure guide content; the provenance note goes to stderr.
+    click.echo(
+        f"# Note: fetched from {_GUIDE_URL}; describes the latest published spec, "
+        "which may be newer than the installed astra-spec.",
+        err=True,
+    )
+    return response.text
+
+
 @main.command()
 @click.argument("term", required=False)
 @click.option("--full", is_flag=True, help="Dump the entire reference (VERY long).")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -76,46 +76,13 @@ class TestGuideCommand:
         assert result.exit_code == 0
         assert result.output == "# ASTRA\npackaged briefing\n"
 
-    def test_guide_falls_back_to_published_copy(self, runner: CliRunner, monkeypatch):
-        import httpx
-
+    def test_guide_errors_when_unpackaged(self, runner: CliRunner, monkeypatch):
         import astra.cli
 
-        class FakeResponse:
-            text = "# ASTRA\npublished briefing\n"
-
-            def raise_for_status(self) -> None:
-                pass
-
         monkeypatch.setattr(astra.cli, "_packaged_guide", lambda: None)
-        monkeypatch.setattr(httpx, "get", lambda url, **kwargs: FakeResponse())
-        result = runner.invoke(main, ["guide"])
-        assert result.exit_code == 0
-        assert "published briefing" in result.output
-        # The provenance note goes to stderr, keeping stdout pure guide content.
-        assert "# Note: fetched from" not in result.stdout
-
-    def test_guide_errors_when_offline_and_unpackaged(self, runner: CliRunner, monkeypatch):
-        import httpx
-
-        import astra.cli
-
-        def refuse(url, **kwargs):
-            raise httpx.ConnectError("no network")
-
-        monkeypatch.setattr(astra.cli, "_packaged_guide", lambda: None)
-        monkeypatch.setattr(httpx, "get", refuse)
         result = runner.invoke(main, ["guide"])
         assert result.exit_code == 1
         assert "astra-spec.org" in result.output
-
-    @pytest.mark.network
-    def test_guide_live(self, runner: CliRunner):
-        # End to end against the real environment: packaged copy if the
-        # installed astra-spec ships it, otherwise the live website.
-        result = runner.invoke(main, ["guide"])
-        assert result.exit_code == 0
-        assert "# ASTRA" in result.output
 
 
 class TestInfoCommand:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -65,6 +65,59 @@ class TestValidateCommand:
         assert result.exit_code != 0
 
 
+class TestGuideCommand:
+    """Tests for the guide command."""
+
+    def test_guide_prints_packaged_guide(self, runner: CliRunner, monkeypatch):
+        import astra.cli
+
+        monkeypatch.setattr(astra.cli, "_packaged_guide", lambda: "# ASTRA\npackaged briefing\n")
+        result = runner.invoke(main, ["guide"])
+        assert result.exit_code == 0
+        assert result.output == "# ASTRA\npackaged briefing\n"
+
+    def test_guide_falls_back_to_published_copy(self, runner: CliRunner, monkeypatch):
+        import httpx
+
+        import astra.cli
+
+        class FakeResponse:
+            text = "# ASTRA\npublished briefing\n"
+
+            def raise_for_status(self) -> None:
+                pass
+
+        monkeypatch.setattr(astra.cli, "_packaged_guide", lambda: None)
+        monkeypatch.setattr(httpx, "get", lambda url, **kwargs: FakeResponse())
+        result = runner.invoke(main, ["guide"])
+        assert result.exit_code == 0
+        assert "published briefing" in result.output
+        # The provenance note goes to stderr, keeping stdout pure guide content.
+        assert "# Note: fetched from" not in result.stdout
+
+    def test_guide_errors_when_offline_and_unpackaged(self, runner: CliRunner, monkeypatch):
+        import httpx
+
+        import astra.cli
+
+        def refuse(url, **kwargs):
+            raise httpx.ConnectError("no network")
+
+        monkeypatch.setattr(astra.cli, "_packaged_guide", lambda: None)
+        monkeypatch.setattr(httpx, "get", refuse)
+        result = runner.invoke(main, ["guide"])
+        assert result.exit_code == 1
+        assert "astra-spec.org" in result.output
+
+    @pytest.mark.network
+    def test_guide_live(self, runner: CliRunner):
+        # End to end against the real environment: packaged copy if the
+        # installed astra-spec ships it, otherwise the live website.
+        result = runner.invoke(main, ["guide"])
+        assert result.exit_code == 0
+        assert "# ASTRA" in result.output
+
+
 class TestInfoCommand:
     """Tests for the info command."""
 


### PR DESCRIPTION
## Summary
- `astra guide` prints the agent briefing (llms.txt) for the ASTRA format.
- The content comes from the copy shipped inside the installed astra-spec package (`astra/docs/llms.txt`, added by LightconeResearch/astra-spec#69, released in astra-spec 0.0.13), so it always matches the schema the installed validator enforces.
- The dependency floor is bumped to `astra-spec>=0.0.13`, guaranteeing the guide is present; if the resource is somehow missing anyway, the command exits 1 with an upgrade hint and a pointer to https://astra-spec.org/llms.txt.

## Testing
- Unit tests cover the packaged path and the missing-copy error via monkeypatching.
- Verified end-to-end against astra-spec 0.0.13: `astra guide` prints the packaged llms.txt with exit 0.
- Full suite passes; ruff and mypy strict clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R1bSYSZjWkU5WZXqeWYfPA