### PR TITLE
Idempotent astra init + public create_boilerplate() scaffold API

### DIFF
--- a/src/astra/cli.py
+++ b/src/astra/cli.py
@@ -84,42 +84,68 @@ def main() -> None:
 @main.command()
 @click.argument("directory", type=click.Path(path_type=Path), default=".")
 @click.option("--no-git", is_flag=True, help="Don't initialize git repository")
-def init(directory: Path, no_git: bool) -> None:
-    """Create a minimal ASTRA analysis scaffold.
+@click.option(
+    "--check",
+    "check_only",
+    is_flag=True,
+    help=(
+        "Report what would be created without writing anything; "
+        "exit 1 if the scaffold is not converged."
+    ),
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    help="Emit the convergence report as JSON on stdout.",
+)
+def init(directory: Path, no_git: bool, check_only: bool, as_json: bool) -> None:
+    """Converge DIRECTORY into a minimal ASTRA analysis scaffold (idempotent).
 
-    Creates astra.yaml, universes/baseline.yaml, and .gitignore.
+    Safe to re-run at any time: creates whatever is missing (astra.yaml
+    + universes/baseline.yaml, src/, .gitignore, git repo) and never
+    overwrites existing files. A directory that already holds an
+    astra.yaml — or any other files — is adopted, not rejected.
 
-    DIRECTORY is the project folder to create (default: current directory).
+    DIRECTORY is the project folder to converge (default: current directory).
 
     Examples:
         astra init my-analysis
         astra init my-analysis --no-git
+        astra init --check --json   # is this directory scaffolded? (for scripts/agents)
     """
-    # Check if this is already an ASTRA project
-    if (directory / "astra.yaml").exists():
-        console.print(
-            f"[red]Error:[/red] [cyan]{directory}[/cyan] is already an ASTRA project "
-            f"(astra.yaml exists)."
-        )
-        console.print(
-            "Use [cyan]astra validate[/cyan] to check it, or delete astra.yaml to re-init."
-        )
-        raise SystemExit(1)
+    write = not check_only
+    report: dict[str, list[str]] = {
+        "created": [],
+        "repaired": [],
+        "unchanged": [],
+        "warnings": [],
+    }
 
-    # Create project directory
-    if directory != Path("."):
-        if directory.exists() and any(directory.iterdir()):
-            console.print(
-                f"[red]Error:[/red] [cyan]{directory}[/cyan] already exists and is not empty. "
-                "Please specify an empty or non-existing directory."
-            )
-            raise SystemExit(1)
-        directory.mkdir(parents=True, exist_ok=True)
+    # Snapshot presence before scaffolding: create_boilerplate also
+    # makes universes/ and src/, and they must be attributed to this
+    # run, not reported as pre-existing.
+    had_spec = (directory / "astra.yaml").exists()
+    had_dir = {sub: (directory / sub).is_dir() for sub in ("universes", "src")}
 
-    # Create boilerplate directory structure and spec
-    create_boilerplate(directory)
+    # The boilerplate astra.yaml and universes/baseline.yaml are one
+    # unit: baseline references the boilerplate's example decision, so
+    # writing it next to a user-authored astra.yaml would be wrong.
+    if had_spec:
+        report["unchanged"].append("astra.yaml")
+    else:
+        report["created"].append("astra.yaml")
+        if write:
+            create_boilerplate(directory)
 
-    # Create .gitignore
+    for subdir, present in had_dir.items():
+        if present:
+            report["unchanged"].append(f"{subdir}/")
+        else:
+            report["created"].append(f"{subdir}/")
+            if write:
+                (directory / subdir).mkdir(parents=True, exist_ok=True)
+
     gitignore = """# ASTRA Analysis
 __pycache__/
 *.py[cod]
@@ -127,13 +153,42 @@ __pycache__/
 .ipynb_checkpoints/
 .DS_Store
 """
-    (directory / ".gitignore").write_text(gitignore)
+    if (directory / ".gitignore").exists():
+        report["unchanged"].append(".gitignore")
+    else:
+        report["created"].append(".gitignore")
+        if write:
+            (directory / ".gitignore").write_text(gitignore)
 
-    # Initialize git repository
-    _init_git_repo(directory, no_git)
+    if not no_git:
+        if (directory / ".git").exists():
+            report["unchanged"].append(".git")
+        else:
+            report["created"].append(".git")
+            if write:
+                _init_git_repo(directory, no_git, quiet=as_json)
 
-    # Print success message
-    console.print(f"[green]✓[/green] Created ASTRA analysis scaffold: [cyan]{directory}[/cyan]")
+    converged = not report["created"]
+
+    if as_json:
+        print(json.dumps({"converged": converged, **report}, indent=2))
+    elif check_only:
+        if converged:
+            console.print(f"[green]✓[/green] [cyan]{directory}[/cyan] is converged — nothing to do")
+        else:
+            for item in report["created"]:
+                console.print(f"  [yellow]would create[/yellow] {item}")
+    elif converged:
+        console.print(f"[green]✓[/green] [cyan]{directory}[/cyan] already converged")
+    else:
+        for item in report["created"]:
+            console.print(f"[green]✓[/green] created {item}")
+        console.print(
+            f"[green]✓[/green] Converged ASTRA analysis scaffold: [cyan]{directory}[/cyan]"
+        )
+
+    if check_only and not converged:
+        raise SystemExit(1)
 
 
 def create_boilerplate(directory: Path) -> None:
@@ -217,7 +272,7 @@ decisions:
     (directory / "universes" / "baseline.yaml").write_text(baseline_universe)
 
 
-def _init_git_repo(directory: Path, no_git: bool) -> None:
+def _init_git_repo(directory: Path, no_git: bool, quiet: bool = False) -> None:
     """Initialize git repository if requested."""
     if no_git or (directory / ".git").exists():
         return
@@ -229,7 +284,8 @@ def _init_git_repo(directory: Path, no_git: bool) -> None:
             capture_output=True,
             check=True,
         )
-        console.print("[green]✓[/green] Initialized git repository")
+        if not quiet:
+            console.print("[green]✓[/green] Initialized git repository")
         # Try to create initial commit
         try:
             subprocess.run(["git", "add", "."], cwd=directory, capture_output=True, check=True)

--- a/src/astra/cli.py
+++ b/src/astra/cli.py
@@ -116,9 +116,8 @@ def init(directory: Path, no_git: bool) -> None:
             raise SystemExit(1)
         directory.mkdir(parents=True, exist_ok=True)
 
-    # Create directory structure
-    (directory / "universes").mkdir(parents=True, exist_ok=True)
-    (directory / "src").mkdir(parents=True, exist_ok=True)
+    # Create boilerplate directory structure and spec
+    create_boilerplate(directory)
 
     # Create .gitignore
     gitignore = """# ASTRA Analysis
@@ -130,14 +129,27 @@ __pycache__/
 """
     (directory / ".gitignore").write_text(gitignore)
 
-    # Create boilerplate astra.yaml
-    _create_boilerplate_astra_yaml(directory)
-
     # Initialize git repository
     _init_git_repo(directory, no_git)
 
     # Print success message
     console.print(f"[green]✓[/green] Created ASTRA analysis scaffold: [cyan]{directory}[/cyan]")
+
+
+def create_boilerplate(directory: Path) -> None:
+    """Write the boilerplate spec scaffold into ``directory``.
+
+    Creates ``universes/`` and ``src/`` and writes the boilerplate
+    ``astra.yaml`` and ``universes/baseline.yaml``. Touches nothing
+    else — no ``.gitignore``, no git init, no emptiness checks — so
+    downstream tools (e.g. lightcone-cli) can scaffold into existing
+    directories under their own conventions. Existing files are
+    overwritten; callers guard on ``astra.yaml`` presence.
+    """
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "universes").mkdir(parents=True, exist_ok=True)
+    (directory / "src").mkdir(parents=True, exist_ok=True)
+    _create_boilerplate_astra_yaml(directory)
 
 
 def _create_boilerplate_astra_yaml(directory: Path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -477,7 +477,7 @@ class TestInitCommand:
             ["init", str(project_dir), "--no-git"],
         )
         assert result.exit_code == 0
-        assert "Created ASTRA analysis scaffold" in result.output
+        assert "Converged ASTRA analysis scaffold" in result.output
 
         # Check directory structure (minimal scaffold)
         assert (project_dir / "astra.yaml").exists()
@@ -525,54 +525,86 @@ class TestInitCommand:
         assert ".venv/" in gitignore
         assert "outputs/" not in gitignore
 
-    def test_init_existing_nonempty_dir_fails(self, runner: CliRunner, tmp_path: Path):
-        """Test that init fails on existing non-empty directory."""
+    def test_init_adopts_existing_nonempty_dir(self, runner: CliRunner, tmp_path: Path):
+        """Init converges a non-empty directory, leaving existing files alone."""
         project_dir = tmp_path / "existing"
         project_dir.mkdir()
         (project_dir / "some_file.txt").write_text("existing content")
+        (project_dir / ".gitignore").write_text("*.log\n")
 
-        result = runner.invoke(
-            main,
-            ["init", str(project_dir), "--no-git"],
-        )
-        assert result.exit_code == 1
-        assert "not empty" in result.output
-        assert not (project_dir / "astra.yaml").exists()
-
-    def test_init_refuses_if_astra_yaml_exists(self, runner: CliRunner, tmp_path: Path):
-        """Test that init refuses to run in an existing ASTRA project."""
-        project_dir = tmp_path / "already-init"
-        # First init should succeed
         result = runner.invoke(
             main,
             ["init", str(project_dir), "--no-git"],
         )
         assert result.exit_code == 0
         assert (project_dir / "astra.yaml").exists()
+        assert (project_dir / "some_file.txt").read_text() == "existing content"
+        # Existing .gitignore is never overwritten.
+        assert (project_dir / ".gitignore").read_text() == "*.log\n"
 
-        # Second init should fail
+    def test_init_is_idempotent(self, runner: CliRunner, tmp_path: Path):
+        """A second init reports converged and rewrites nothing."""
+        project_dir = tmp_path / "already-init"
         result = runner.invoke(
             main,
             ["init", str(project_dir), "--no-git"],
         )
+        assert result.exit_code == 0
+        before = {p: p.read_text() for p in project_dir.rglob("*") if p.is_file()}
+
+        result = runner.invoke(
+            main,
+            ["init", str(project_dir), "--no-git", "--json"],
+        )
+        assert result.exit_code == 0
+        report = json.loads(result.output)
+        assert report["converged"] is True
+        assert report["created"] == []
+        assert {p: p.read_text() for p in project_dir.rglob("*") if p.is_file()} == before
+
+    def test_init_does_not_scaffold_baseline_next_to_user_spec(
+        self, runner: CliRunner, tmp_path: Path
+    ):
+        """astra.yaml + baseline are one unit: a user-authored spec must not
+        get the boilerplate baseline (it references the example decision)."""
+        project_dir = tmp_path / "user-spec"
+        project_dir.mkdir()
+        (project_dir / "astra.yaml").write_text("# user spec\n")
+
+        result = runner.invoke(
+            main,
+            ["init", str(project_dir), "--no-git"],
+        )
+        assert result.exit_code == 0
+        assert (project_dir / "astra.yaml").read_text() == "# user spec\n"
+        assert not (project_dir / "universes" / "baseline.yaml").exists()
+        # The bare directories are still converged.
+        assert (project_dir / "universes").is_dir()
+        assert (project_dir / "src").is_dir()
+
+    def test_init_check_reports_drift_without_writing(
+        self, runner: CliRunner, tmp_path: Path
+    ):
+        """--check exits 1 on drift and writes nothing, --json is parseable."""
+        project_dir = tmp_path / "check-test"
+        result = runner.invoke(
+            main,
+            ["init", str(project_dir), "--no-git", "--check", "--json"],
+        )
         assert result.exit_code == 1
-        assert "already an ASTRA project" in result.output
+        report = json.loads(result.output)
+        assert report["converged"] is False
+        assert "astra.yaml" in report["created"]
+        assert not project_dir.exists()
 
-    def test_init_refuses_if_astra_yaml_exists_current_dir(self, runner: CliRunner, tmp_path: Path):
-        """Test that init refuses to run in current dir if astra.yaml exists."""
-        old_cwd = os.getcwd()
-        try:
-            os.chdir(tmp_path)
-            # First init
-            result = runner.invoke(main, ["init", "--no-git"])
-            assert result.exit_code == 0
-
-            # Second init should fail
-            result = runner.invoke(main, ["init", "--no-git"])
-            assert result.exit_code == 1
-            assert "already an ASTRA project" in result.output
-        finally:
-            os.chdir(old_cwd)
+    def test_init_check_passes_on_converged_project(
+        self, runner: CliRunner, tmp_path: Path
+    ):
+        project_dir = tmp_path / "check-ok"
+        result = runner.invoke(main, ["init", str(project_dir), "--no-git"])
+        assert result.exit_code == 0
+        result = runner.invoke(main, ["init", str(project_dir), "--no-git", "--check"])
+        assert result.exit_code == 0
 
     def test_init_existing_empty_dir_succeeds(self, runner: CliRunner, tmp_path: Path):
         """Test that init succeeds on existing empty directory."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -651,6 +651,37 @@ class TestInitCommand:
         assert not (project_dir / ".git").exists()
 
 
+class TestCreateBoilerplate:
+    """Tests for the public create_boilerplate scaffold helper."""
+
+    def test_writes_spec_scaffold(self, tmp_path: Path):
+        """Creates universes/, src/, astra.yaml, and baseline.yaml."""
+        from astra.cli import create_boilerplate
+
+        project_dir = tmp_path / "proj"
+        create_boilerplate(project_dir)
+        assert (project_dir / "astra.yaml").exists()
+        assert (project_dir / "universes" / "baseline.yaml").exists()
+        assert (project_dir / "src").is_dir()
+        # No side effects beyond the spec scaffold.
+        assert not (project_dir / ".gitignore").exists()
+        assert not (project_dir / ".git").exists()
+
+    def test_scaffolds_into_nonempty_directory(self, tmp_path: Path):
+        """Unlike `astra init`, works in a directory with existing files
+        (downstream tools adopt existing codebases) and leaves them alone."""
+        from astra.cli import create_boilerplate
+
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        (project_dir / "notes.txt").write_text("keep me")
+        (project_dir / ".gitignore").write_text("*.log\n")
+        create_boilerplate(project_dir)
+        assert (project_dir / "astra.yaml").exists()
+        assert (project_dir / "notes.txt").read_text() == "keep me"
+        assert (project_dir / ".gitignore").read_text() == "*.log\n"
+
+
 class TestBatchQuoteVerification:
     """Tests for the batch quote verification command (astra paper verify-quotes)."""
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -582,9 +582,7 @@ class TestInitCommand:
         assert (project_dir / "universes").is_dir()
         assert (project_dir / "src").is_dir()
 
-    def test_init_check_reports_drift_without_writing(
-        self, runner: CliRunner, tmp_path: Path
-    ):
+    def test_init_check_reports_drift_without_writing(self, runner: CliRunner, tmp_path: Path):
         """--check exits 1 on drift and writes nothing, --json is parseable."""
         project_dir = tmp_path / "check-test"
         result = runner.invoke(
@@ -597,9 +595,7 @@ class TestInitCommand:
         assert "astra.yaml" in report["created"]
         assert not project_dir.exists()
 
-    def test_init_check_passes_on_converged_project(
-        self, runner: CliRunner, tmp_path: Path
-    ):
+    def test_init_check_passes_on_converged_project(self, runner: CliRunner, tmp_path: Path):
         project_dir = tmp_path / "check-ok"
         result = runner.invoke(main, ["init", str(project_dir), "--no-git"])
         assert result.exit_code == 0


### PR DESCRIPTION
## Summary

Companion to LightconeResearch/lightcone-cli#168, which turns `lc init` into an idempotent converger. This PR brings `astra init` in line with the same philosophy and exposes the scaffold writer as a public API.

**`astra init` is now an idempotent converger.** Each run creates whatever is missing (`astra.yaml` + `universes/baseline.yaml`, `universes/`, `src/`, `.gitignore`, git repo) and never overwrites existing files. The old refusals — "already an ASTRA project" and "directory not empty" — are gone; those directories are adopted instead. Two new flags, matching the `lc init` contract:

- `--check` — report what a run would create, write nothing, exit 1 when not converged
- `--json` — emit the report as `{converged, created, repaired, unchanged, warnings}`

One deliberate subtlety: the boilerplate `astra.yaml` and `universes/baseline.yaml` are treated as a single unit keyed on `astra.yaml` presence — a user-authored spec never gets the boilerplate baseline written next to it (it references the boilerplate's example decision).

**`create_boilerplate(directory)` is public.** It writes only `universes/`, `src/`, `astra.yaml`, and `universes/baseline.yaml` — no `.gitignore`, no git init, no policy — so downstream tools (lightcone-cli's `lc init`) can scaffold the spec under their own conventions. `astra init` delegates to it.

## Test plan

- [x] New tests: adoption of non-empty directories (existing files and `.gitignore` untouched), idempotent re-run (byte-identical tree, `converged: true`), user-spec-without-baseline invariant, `--check` drift/no-write/exit-code behavior, `create_boilerplate` contents and side-effect freedom
- [x] `uv run pytest` — 221 passed, 21 skipped (existing scaffold-content, validation, and git tests unchanged and green)
- [x] `ruff check` clean
- [x] Manual smoke test: converge into a non-empty directory, re-run with `--json`, `--check` exit codes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016EL5bESx3CqfMNZNPA1KHJ