### PR TITLE
Stop scaffolding an empty src/ directory

### DIFF
--- a/src/astra/cli.py
+++ b/src/astra/cli.py
@@ -103,7 +103,7 @@ def init(directory: Path, no_git: bool, check_only: bool, as_json: bool) -> None
     """Converge DIRECTORY into a minimal ASTRA analysis scaffold (idempotent).
 
     Safe to re-run at any time: creates whatever is missing (astra.yaml
-    + universes/baseline.yaml, src/, .gitignore, git repo) and never
+    + universes/baseline.yaml, .gitignore, git repo) and never
     overwrites existing files. A directory that already holds an
     astra.yaml — or any other files — is adopted, not rejected.
 
@@ -123,10 +123,10 @@ def init(directory: Path, no_git: bool, check_only: bool, as_json: bool) -> None
     }
 
     # Snapshot presence before scaffolding: create_boilerplate also
-    # makes universes/ and src/, and they must be attributed to this
-    # run, not reported as pre-existing.
+    # makes universes/, and it must be attributed to this run, not
+    # reported as pre-existing.
     had_spec = (directory / "astra.yaml").exists()
-    had_dir = {sub: (directory / sub).is_dir() for sub in ("universes", "src")}
+    had_dir = {sub: (directory / sub).is_dir() for sub in ("universes",)}
 
     # The boilerplate astra.yaml and universes/baseline.yaml are one
     # unit: baseline references the boilerplate's example decision, so
@@ -194,8 +194,8 @@ __pycache__/
 def create_boilerplate(directory: Path) -> None:
     """Write the boilerplate spec scaffold into ``directory``.
 
-    Creates ``universes/`` and ``src/`` and writes the boilerplate
-    ``astra.yaml`` and ``universes/baseline.yaml``. Touches nothing
+    Creates ``universes/`` and writes the boilerplate ``astra.yaml``
+    and ``universes/baseline.yaml``. Touches nothing
     else — no ``.gitignore``, no git init, no emptiness checks — so
     downstream tools (e.g. lightcone-cli) can scaffold into existing
     directories under their own conventions. Existing files are
@@ -203,7 +203,6 @@ def create_boilerplate(directory: Path) -> None:
     """
     directory.mkdir(parents=True, exist_ok=True)
     (directory / "universes").mkdir(parents=True, exist_ok=True)
-    (directory / "src").mkdir(parents=True, exist_ok=True)
     _create_boilerplate_astra_yaml(directory)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -484,9 +484,11 @@ class TestInitCommand:
         assert (project_dir / ".gitignore").exists()
         assert (project_dir / "universes").is_dir()
         assert (project_dir / "universes" / "baseline.yaml").exists()
-        assert (project_dir / "src").is_dir()
 
-        # Agentic scaffolding NOT created (init produces only the minimal spec scaffold)
+        # User-owned layout NOT created (init produces only the minimal spec
+        # scaffold; where code lives is the user's choice — recipes name
+        # their paths explicitly)
+        assert not (project_dir / "src").exists()
         assert not (project_dir / ".claude").exists()
         assert not (project_dir / "CLAUDE.md").exists()
         assert not (project_dir / "workflows").exists()
@@ -578,9 +580,8 @@ class TestInitCommand:
         assert result.exit_code == 0
         assert (project_dir / "astra.yaml").read_text() == "# user spec\n"
         assert not (project_dir / "universes" / "baseline.yaml").exists()
-        # The bare directories are still converged.
+        # The bare universes/ directory is still converged.
         assert (project_dir / "universes").is_dir()
-        assert (project_dir / "src").is_dir()
 
     def test_init_check_reports_drift_without_writing(self, runner: CliRunner, tmp_path: Path):
         """--check exits 1 on drift and writes nothing, --json is parseable."""
@@ -683,15 +684,15 @@ class TestCreateBoilerplate:
     """Tests for the public create_boilerplate scaffold helper."""
 
     def test_writes_spec_scaffold(self, tmp_path: Path):
-        """Creates universes/, src/, astra.yaml, and baseline.yaml."""
+        """Creates universes/, astra.yaml, and baseline.yaml."""
         from astra.cli import create_boilerplate
 
         project_dir = tmp_path / "proj"
         create_boilerplate(project_dir)
         assert (project_dir / "astra.yaml").exists()
         assert (project_dir / "universes" / "baseline.yaml").exists()
-        assert (project_dir / "src").is_dir()
         # No side effects beyond the spec scaffold.
+        assert not (project_dir / "src").exists()
         assert not (project_dir / ".gitignore").exists()
         assert not (project_dir / ".git").exists()
 


### PR DESCRIPTION
## Summary

Follow-up to #99. `astra init` / `create_boilerplate()` no longer create an empty `src/` directory.

The rationale: where analysis code lives is user-owned layout, not spec-owned substrate. Recipes name their paths explicitly (the boilerplate's `python src/main.py` is a TODO placeholder either way), and git doesn't track empty directories, so `src/` vanished from the initial commit and any clone regardless. The scaffold now creates only what the spec owns: `astra.yaml` + `universes/baseline.yaml` as one unit, `.gitignore`, and the git repo.

## Test plan

- [x] Updated assertions: `src/` absent after `init` and after `create_boilerplate()`; adoption test no longer expects it
- [x] `uv run pytest tests/test_cli.py` — 88 passed
- [x] `ruff check` and `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016EL5bESx3CqfMNZNPA1KHJ