### PR TITLE
Bump gh-action-pypi-publish to v1.14.2 for metadata 2.5 support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,6 @@ jobs:
           path: dist
 
       - name: Publish package to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.14.0
+        uses: pypa/gh-action-pypi-publish@v1.14.2
         with:
           verbose: true


### PR DESCRIPTION
## Summary
The v0.2.14 PyPI publish failed with `InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version`. Unpinned hatchling now emits `Metadata-Version: 2.5`, which the Twine bundled in `gh-action-pypi-publish@v1.14.0` rejects. v1.14.2 updates to Twine v7, which accepts metadata 2.5 ([release notes](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.14.2)).

Release workflows run the workflow file as of the tagged commit, so this must land on main before re-tagging v0.2.14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WB7fWq1S2JwxtqSMLPCAV