### PR TITLE
Pay for a heavy import when you use it, not when you import a module

### DIFF
--- a/src/astra/cli.py
+++ b/src/astra/cli.py
@@ -30,13 +30,15 @@ from astra.helpers import (
     load_yaml,
     save_yaml,
 )
+from astra.scaffold import create_boilerplate
 from astra.validation.schema import (
     check_spec_version,
-    installed_spec_version,
     validate_analysis_data,
     validate_universe_data,
 )
 from astra.validation.semantic import validate_analysis, validate_universe_file
+
+__all__ = ["create_boilerplate", "main"]
 
 console = Console()
 
@@ -189,86 +191,6 @@ __pycache__/
 
     if check_only and not converged:
         raise SystemExit(1)
-
-
-def create_boilerplate(directory: Path) -> None:
-    """Write the boilerplate spec scaffold into ``directory``.
-
-    Creates ``universes/`` and writes the boilerplate ``astra.yaml``
-    and ``universes/baseline.yaml``. Touches nothing
-    else — no ``.gitignore``, no git init, no emptiness checks — so
-    downstream tools (e.g. lightcone-cli) can scaffold into existing
-    directories under their own conventions. Existing files are
-    overwritten; callers guard on ``astra.yaml`` presence.
-    """
-    directory.mkdir(parents=True, exist_ok=True)
-    (directory / "universes").mkdir(parents=True, exist_ok=True)
-    _create_boilerplate_astra_yaml(directory)
-
-
-def _create_boilerplate_astra_yaml(directory: Path) -> None:
-    """Create boilerplate astra.yaml with TODOs."""
-    name = directory.name if directory != Path(".") else "My Analysis"
-    spec_version = installed_spec_version() or "1.0"
-
-    astra_yaml = f"""# ASTRA Analysis Specification
-
-version: "{spec_version}"
-name: "{name}"
-container: python:3.12-slim
-description: |
-  TODO: One-paragraph overview of the analysis — its question,
-  scope, and what the reader should take away. A richer write-up
-  (figures, citations, multi-page structure) is authored separately
-  as a report that references this analysis's elements; see the
-  ASTRA documentation.
-
-inputs:
-  - id: primary_data
-    type: data
-    description: "TODO: Describe your primary data source"
-
-outputs:
-  - id: main_result
-    type: metric
-    description: "TODO: Describe your primary output metric"
-    decisions: [example_method]
-    recipe:
-      command: python src/main.py --method {{decisions.example_method}} --out {{output}}
-
-  - id: conclusion
-    type: report
-    description: "Summary of analysis findings"
-    inputs: [main_result]
-    recipe:
-      command: python src/main.py --result {{inputs.main_result}} --out {{output}}
-
-decisions:
-  example_method:
-    label: "Example Method Choice"
-    rationale: "TODO: Explain why this decision matters"
-    default: option_a
-    options:
-      option_a:
-        label: "Option A"
-        description: "TODO: Describe option A"
-      option_b:
-        label: "Option B"
-        description: "TODO: Describe option B"
-"""
-    (directory / "astra.yaml").write_text(astra_yaml)
-
-    # Create baseline universe
-    baseline_universe = """# Baseline Universe
-# Default configuration using standard practices
-
-id: baseline
-description: "Default configuration using standard practices"
-
-decisions:
-  example_method: option_a
-"""
-    (directory / "universes" / "baseline.yaml").write_text(baseline_universe)
 
 
 def _init_git_repo(directory: Path, no_git: bool, quiet: bool = False) -> None:

--- a/src/astra/cli.py
+++ b/src/astra/cli.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 import os
 import re
-import subprocess
 import sys
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -197,6 +196,8 @@ def _init_git_repo(directory: Path, no_git: bool, quiet: bool = False) -> None:
     """Initialize git repository if requested."""
     if no_git or (directory / ".git").exists():
         return
+
+    import subprocess
 
     try:
         subprocess.run(

--- a/src/astra/helpers.py
+++ b/src/astra/helpers.py
@@ -2,6 +2,11 @@
 
 These utilities work with raw dict data structures loaded from YAML files,
 avoiding the need for Pydantic model imports in the validation path.
+
+Everything here but ``load_yaml`` and ``save_yaml`` operates on dicts that
+are already in hand, so PyYAML — ~18 ms, more than the rest of this module
+put together — is imported by those two functions rather than by everyone
+who imports this one.
 """
 
 from __future__ import annotations
@@ -11,8 +16,6 @@ import re
 from collections.abc import Iterator, Mapping, Sequence
 from pathlib import Path
 from typing import Any, TypeVar
-
-import yaml
 
 logger = logging.getLogger(__name__)
 
@@ -242,6 +245,8 @@ def load_yaml(path: str | Path) -> dict[str, Any]:
     Returns:
         The parsed YAML content as a dictionary.
     """
+    import yaml
+
     with open(path) as f:
         data: dict[str, Any] = yaml.safe_load(f)
     return data
@@ -254,6 +259,8 @@ def save_yaml(data: dict[str, Any], path: str | Path) -> None:
         data: The data to save.
         path: Path to write the YAML file.
     """
+    import yaml
+
     with open(path, "w") as f:
         yaml.safe_dump(data, f, sort_keys=False, allow_unicode=True)
 

--- a/src/astra/helpers.py
+++ b/src/astra/helpers.py
@@ -67,6 +67,28 @@ def parse_from_path(ref: str) -> tuple[int, list[str]] | None:
     return (up, segments)
 
 
+def parse_option_ref(ref: str) -> tuple[str, str] | None:
+    """Parse a ``decision_id.option_id`` reference.
+
+    The grammar behind ``when:``, ``requires:`` and ``incompatible_with:``:
+    one decision, one of its options. Negation (``~``) belongs to the
+    condition rather than the reference, so callers strip it first.
+
+    Args:
+        ref: The reference as written, e.g. ``"scaling.standard"``.
+
+    Returns:
+        ``(decision_id, option_id)``, or ``None`` if the reference is not
+        exactly two dot-separated parts. Malformed is the validator's to
+        report — ``INVALID_WHEN_REF``, ``INVALID_CONSTRAINT_FORMAT`` —
+        which it cannot do if parsing raises first.
+    """
+    decision_id, dot, option_id = ref.partition(".")
+    if not dot or "." in option_id:
+        return None
+    return (decision_id, option_id)
+
+
 def is_condition_met(
     when: str | list[str] | None,
     universe_decisions: dict[str, str],
@@ -81,16 +103,20 @@ def is_condition_met(
 
     Returns:
         True if the condition is met (or when is None), False otherwise.
+        A malformed reference is a condition nothing can satisfy, negated
+        or not — reporting it belongs to the validator, and raising here
+        took `astra universe check` down on a typo.
     """
     if when is None:
         return True
     conditions = [when] if isinstance(when, str) else when
     for cond in conditions:
         negate = cond.startswith("~")
-        ref = cond.lstrip("~")
-        decision_id, option_id = ref.split(".")
-        selected = universe_decisions.get(decision_id)
-        match = selected == option_id
+        parsed = parse_option_ref(cond.lstrip("~"))
+        if parsed is None:
+            return False
+        decision_id, option_id = parsed
+        match = universe_decisions.get(decision_id) == option_id
         if negate:
             match = not match
         if not match:

--- a/src/astra/papers/download.py
+++ b/src/astra/papers/download.py
@@ -9,23 +9,24 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-# Optional dependency for HTTP requests
+# Optional dependency for HTTP requests, bound on first use by
+# `_require_httpx`. Importing it costs ~60 ms, which every reader of the
+# paper cache would otherwise pay to reach a class that only touches disk.
 httpx: Any = None
 
-try:
-    import httpx as _httpx  # type: ignore[import-not-found,unused-ignore]
 
-    httpx = _httpx
-except ImportError:
-    pass
-
-
-def _check_httpx() -> None:
-    """Raise ImportError if httpx is not installed."""
-    if httpx is None:
+def _require_httpx() -> None:
+    """Import httpx on first use, or explain how to install it."""
+    global httpx
+    if httpx is not None:
+        return
+    try:
+        import httpx as _httpx  # type: ignore[import-not-found,unused-ignore]
+    except ImportError:
         raise ImportError(
             "httpx is required for paper downloading. Install with: pip install astra[verify]"
-        )
+        ) from None
+    httpx = _httpx
 
 
 @dataclass
@@ -61,7 +62,7 @@ def fetch_doi_metadata(doi: str) -> DOIMetadata:
     Returns:
         DOIMetadata with title, authors, etc. Fields may be None if not available.
     """
-    _check_httpx()
+    _require_httpx()
 
     url = f"https://doi.org/{doi}"
     headers = {"Accept": "application/vnd.citationstyles.csl+json"}
@@ -172,7 +173,7 @@ def _download_arxiv_pdf(arxiv_id: str, doi: str, version: int | None = None) -> 
     Returns:
         PaperDownloadResult with PDF content or error.
     """
-    _check_httpx()
+    _require_httpx()
 
     # Construct URL
     if version is not None:
@@ -233,7 +234,7 @@ def _try_unpaywall(doi: str) -> PaperDownloadResult:
     Returns:
         PaperDownloadResult with PDF content or error.
     """
-    _check_httpx()
+    _require_httpx()
 
     # Unpaywall requires an email for polite use
     # Using a generic ASTRA email - users should configure their own
@@ -324,7 +325,7 @@ def resolve_doi(doi: str) -> str:
     Returns:
         Target URL.
     """
-    _check_httpx()
+    _require_httpx()
 
     url = f"https://doi.org/{doi}"
     response = httpx.head(url, follow_redirects=True, timeout=30.0)

--- a/src/astra/resolve.py
+++ b/src/astra/resolve.py
@@ -125,23 +125,35 @@ def _selected_universe(
     node: Mapping[str, Any],
     universe_node: Mapping[str, Any],
     base_path: Path | None,
+    where: str,
 ) -> Mapping[str, Any]:
     """Follow a ``universe:`` reference to the file it names.
 
     Only an external (``path:``) sub-analysis has a ``universes/``
     directory of its own, so only one can be referred to this way.
     Anything unresolvable leaves the node as it stands — a missing file is
-    the validator's to report, not this module's to raise on.
+    the validator's to report, not this module's to raise on — but it is
+    logged, because ``semantic.py`` validates nothing about ``universe:``
+    and silence here would leave a whole subtree unsettled with no
+    diagnostic from either layer.
     """
     name = universe_node.get("universe")
+    if not name:
+        return universe_node
     sub_path = node.get("path")
-    if not name or not sub_path or base_path is None:
+    if not sub_path:
+        logger.warning(
+            "universe '%s' selected for '%s', which is an inline sub-analysis "
+            "and has no universes/ directory to name it in",
+            name,
+            where,
+        )
+        return universe_node
+    if base_path is None:
         return universe_node
     path = external_spec_path(base_path, str(sub_path)).parent / "universes" / f"{name}.yaml"
     if not path.is_file():
-        logger.warning(
-            "universe '%s' selected for '%s' but %s does not exist", name, sub_path, path
-        )
+        logger.warning("universe '%s' selected for '%s' but %s does not exist", name, where, path)
         return universe_node
     loaded = load_yaml(path)
     # An empty or comment-only file parses to `None`; that is the
@@ -204,7 +216,7 @@ def _settle(
         if not isinstance(sub, dict):
             continue
         sub_universe = (universe_node.get("analyses") or {}).get(str(sub_id)) or {}
-        sub_universe = _selected_universe(sub, sub_universe, base_path)
+        sub_universe = _selected_universe(sub, sub_universe, base_path, qualify(scope, str(sub_id)))
         sub_base = base_path
         if base_path is not None and sub.get("path"):
             sub_base = external_spec_path(base_path, str(sub["path"])).parent

--- a/src/astra/scaffold.py
+++ b/src/astra/scaffold.py
@@ -1,0 +1,98 @@
+"""The boilerplate spec scaffold: ``astra.yaml`` + ``universes/baseline.yaml``.
+
+Its own module rather than part of :mod:`astra.cli`, so that scaffolding
+costs what writing two template files should cost. Importing ``astra.cli``
+pulls in Click, Rich and the validation stack — and through the datamodel,
+``linkml_runtime`` — about half a second, none of which writing a template
+needs. This module imports stdlib only.
+
+``astra init`` and downstream tools (e.g. lightcone-cli) both scaffold
+through :func:`create_boilerplate`, so this is the one definition of what
+a fresh ASTRA project contains.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from astra.spec_version import installed_spec_version
+
+
+def create_boilerplate(directory: Path) -> None:
+    """Write the boilerplate spec scaffold into ``directory``.
+
+    Creates ``universes/`` and writes the boilerplate ``astra.yaml``
+    and ``universes/baseline.yaml``. Touches nothing
+    else — no ``.gitignore``, no git init, no emptiness checks — so
+    downstream tools (e.g. lightcone-cli) can scaffold into existing
+    directories under their own conventions. Existing files are
+    overwritten; callers guard on ``astra.yaml`` presence.
+    """
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "universes").mkdir(parents=True, exist_ok=True)
+    _create_boilerplate_astra_yaml(directory)
+
+
+def _create_boilerplate_astra_yaml(directory: Path) -> None:
+    """Create boilerplate astra.yaml with TODOs."""
+    name = directory.name if directory != Path(".") else "My Analysis"
+    spec_version = installed_spec_version() or "1.0"
+
+    astra_yaml = f"""# ASTRA Analysis Specification
+
+version: "{spec_version}"
+name: "{name}"
+container: python:3.12-slim
+description: |
+  TODO: One-paragraph overview of the analysis — its question,
+  scope, and what the reader should take away. A richer write-up
+  (figures, citations, multi-page structure) is authored separately
+  as a report that references this analysis's elements; see the
+  ASTRA documentation.
+
+inputs:
+  - id: primary_data
+    type: data
+    description: "TODO: Describe your primary data source"
+
+outputs:
+  - id: main_result
+    type: metric
+    description: "TODO: Describe your primary output metric"
+    decisions: [example_method]
+    recipe:
+      command: python src/main.py --method {{decisions.example_method}} --out {{output}}
+
+  - id: conclusion
+    type: report
+    description: "Summary of analysis findings"
+    inputs: [main_result]
+    recipe:
+      command: python src/main.py --result {{inputs.main_result}} --out {{output}}
+
+decisions:
+  example_method:
+    label: "Example Method Choice"
+    rationale: "TODO: Explain why this decision matters"
+    default: option_a
+    options:
+      option_a:
+        label: "Option A"
+        description: "TODO: Describe option A"
+      option_b:
+        label: "Option B"
+        description: "TODO: Describe option B"
+"""
+    (directory / "astra.yaml").write_text(astra_yaml)
+
+    # Create baseline universe
+    baseline_universe = """# Baseline Universe
+# Default configuration using standard practices
+
+id: baseline
+description: "Default configuration using standard practices"
+
+decisions:
+  example_method: option_a
+"""
+    (directory / "universes" / "baseline.yaml").write_text(baseline_universe)

--- a/src/astra/spec_render.py
+++ b/src/astra/spec_render.py
@@ -10,10 +10,10 @@ import os
 import shutil
 import textwrap
 from functools import lru_cache
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from astra.datamodel import SCHEMA_DIRECTORY
-from linkml_runtime.utils.schemaview import SchemaView
+if TYPE_CHECKING:
+    from linkml_runtime.utils.schemaview import SchemaView
 
 # The three schema files map to the three conceptual layers ASTRA groups by.
 # `from_schema` on each class carries the source schema URI; we key on its tail.
@@ -22,6 +22,12 @@ SCHEMA_ORDER = ["analysis", "universe", "insight"]
 
 @lru_cache(maxsize=1)
 def _view() -> SchemaView:
+    # Imported here rather than at module scope: `linkml_runtime` costs
+    # ~200 ms to import, and every renderer below goes through this cache,
+    # so nothing pays it until a `spec` command actually renders.
+    from astra.datamodel import SCHEMA_DIRECTORY
+    from linkml_runtime.utils.schemaview import SchemaView
+
     # analysis.yaml imports insight + universe, so one load closes over all three.
     return SchemaView(os.path.join(SCHEMA_DIRECTORY, "analysis.yaml"))
 

--- a/src/astra/spec_version.py
+++ b/src/astra/spec_version.py
@@ -1,6 +1,6 @@
 """The installed astra-spec version.
 
-Its own module, importing stdlib only, so callers that just need the
+Its own module, importing nothing at all, so callers that just need the
 version string are not forced through the validation stack — see
 :mod:`astra.scaffold`. Re-exported from :mod:`astra.validation` for
 backward compatibility.
@@ -8,13 +8,15 @@ backward compatibility.
 
 from __future__ import annotations
 
-from importlib.metadata import PackageNotFoundError
-from importlib.metadata import version as _pkg_version
-
 
 def installed_spec_version() -> str | None:
     """Return the installed ``astra-spec`` package version, or None if unknown."""
+    # `importlib.metadata` costs ~13 ms and drags in email, inspect and
+    # zipfile behind it. Asking for the version pays that; importing a
+    # module that could ask for it does not.
+    from importlib.metadata import PackageNotFoundError, version
+
     try:
-        return _pkg_version("astra-spec")
+        return version("astra-spec")
     except PackageNotFoundError:
         return None

--- a/src/astra/spec_version.py
+++ b/src/astra/spec_version.py
@@ -1,0 +1,20 @@
+"""The installed astra-spec version.
+
+Its own module, importing stdlib only, so callers that just need the
+version string are not forced through the validation stack — see
+:mod:`astra.scaffold`. Re-exported from :mod:`astra.validation` for
+backward compatibility.
+"""
+
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
+
+
+def installed_spec_version() -> str | None:
+    """Return the installed ``astra-spec`` package version, or None if unknown."""
+    try:
+        return _pkg_version("astra-spec")
+    except PackageNotFoundError:
+        return None

--- a/src/astra/validation/__init__.py
+++ b/src/astra/validation/__init__.py
@@ -1,8 +1,8 @@
 """Validation utilities for ASTRA specifications."""
 
+from astra.spec_version import installed_spec_version
 from astra.validation.schema import (
     check_spec_version,
-    installed_spec_version,
     is_valid_analysis,
     is_valid_universe,
     validate_analysis_data,

--- a/src/astra/validation/schema.py
+++ b/src/astra/validation/schema.py
@@ -4,18 +4,25 @@ Validates ASTRA YAML files using the Pydantic models from astra-spec.
 Dict keys are injected as ``id`` fields before validation, since ASTRA YAML
 uses keyed dicts (e.g., ``decisions: {scaling: ...}``) while the Pydantic
 models expect an explicit ``id`` on each object.
+
+The models are imported inside the two functions that validate against
+them. Reaching them costs ~200 ms — an order of magnitude more than the
+rest of ASTRA put together, because ``astra.datamodel`` loads
+``linkml_runtime`` — and the entry points here that every ``astra`` run
+touches (``check_spec_version``, ``installed_spec_version``) need nothing
+from them.
 """
 
 from __future__ import annotations
 
 import copy
 from pathlib import Path
-from typing import Any
-
-from astra.datamodel.astra_pydantic import Analysis, Universe
-from pydantic import ValidationError as PydanticValidationError
+from typing import TYPE_CHECKING, Any
 
 from astra.helpers import load_yaml
+
+if TYPE_CHECKING:
+    from pydantic import ValidationError as PydanticValidationError
 
 # Re-exported: `installed_spec_version` moved to its own stdlib-only module
 # so scaffolding can reach it without importing the datamodel, but it stays
@@ -68,6 +75,9 @@ def validate_analysis_data(data: dict[str, Any]) -> list[str]:
 
     Returns a list of error messages (empty if valid).
     """
+    from astra.datamodel.astra_pydantic import Analysis
+    from pydantic import ValidationError as PydanticValidationError
+
     preprocessed = copy.deepcopy(data)
     preprocessed.setdefault("id", "root")  # root analysis has no id in YAML
     _inject_ids_inplace(preprocessed)
@@ -103,6 +113,9 @@ def validate_universe_data(data: dict[str, Any]) -> list[str]:
 
     Returns a list of error messages (empty if valid).
     """
+    from astra.datamodel.astra_pydantic import Universe
+    from pydantic import ValidationError as PydanticValidationError
+
     preprocessed = copy.deepcopy(data)
     _inject_universe_ids_inplace(preprocessed)
     try:

--- a/src/astra/validation/schema.py
+++ b/src/astra/validation/schema.py
@@ -9,8 +9,6 @@ models expect an explicit ``id`` on each object.
 from __future__ import annotations
 
 import copy
-from importlib.metadata import PackageNotFoundError
-from importlib.metadata import version as _pkg_version
 from pathlib import Path
 from typing import Any
 
@@ -18,6 +16,11 @@ from astra.datamodel.astra_pydantic import Analysis, Universe
 from pydantic import ValidationError as PydanticValidationError
 
 from astra.helpers import load_yaml
+
+# Re-exported: `installed_spec_version` moved to its own stdlib-only module
+# so scaffolding can reach it without importing the datamodel, but it stays
+# importable from here — including for tests that patch it by this name.
+from astra.spec_version import installed_spec_version
 
 
 def _inject_ids_inplace(data: dict[str, Any]) -> None:
@@ -107,14 +110,6 @@ def validate_universe_data(data: dict[str, Any]) -> list[str]:
         return []
     except PydanticValidationError as exc:
         return _format_pydantic_errors(exc)
-
-
-def installed_spec_version() -> str | None:
-    """Return the installed ``astra-spec`` package version, or None if unknown."""
-    try:
-        return _pkg_version("astra-spec")
-    except PackageNotFoundError:
-        return None
 
 
 def _normalize_version(v: str) -> tuple[int, ...] | None:

--- a/src/astra/validation/semantic.py
+++ b/src/astra/validation/semantic.py
@@ -18,6 +18,7 @@ from astra.helpers import (
     is_condition_met,
     load_yaml,
     parse_from_path,
+    parse_option_ref,
     resolve_analysis_tree,
 )
 
@@ -467,9 +468,8 @@ def _validate_decisions(
         if when:
             conditions = [when] if isinstance(when, str) else when
             for cond in conditions:
-                ref = cond.lstrip("~")
-                when_parts = ref.split(".")
-                if len(when_parts) != 2:
+                parsed_when = parse_option_ref(cond.lstrip("~"))
+                if parsed_when is None:
                     errors.append(
                         SemanticError(
                             "INVALID_WHEN_REF",
@@ -478,7 +478,7 @@ def _validate_decisions(
                         )
                     )
                     continue
-                when_decision_id, when_option_id = when_parts
+                when_decision_id, when_option_id = parsed_when
                 scope = constraint_scope or {}
                 if when_decision_id not in decisions and when_decision_id not in scope:
                     errors.append(
@@ -594,9 +594,8 @@ def _validate_output_when(
         output_path = f"{outputs_prefix}.{out_id}"
 
         for cond in conditions:
-            ref = cond.lstrip("~")
-            parts = ref.split(".")
-            if len(parts) != 2:
+            parsed = parse_option_ref(cond.lstrip("~"))
+            if parsed is None:
                 errors.append(
                     SemanticError(
                         "INVALID_WHEN_REF",
@@ -605,7 +604,7 @@ def _validate_output_when(
                     )
                 )
                 continue
-            decision_id, option_id = parts
+            decision_id, option_id = parsed
             if decision_id not in decisions:
                 errors.append(
                     SemanticError(
@@ -1020,8 +1019,8 @@ def _validate_constraint_ref(
     option_path: str,
 ) -> list[SemanticError]:
     """Validate a constraint reference (decision.option format)."""
-    parts = ref.split(".")
-    if len(parts) != 2:
+    parsed = parse_option_ref(ref)
+    if parsed is None:
         return [
             SemanticError(
                 "INVALID_CONSTRAINT_FORMAT",
@@ -1030,7 +1029,7 @@ def _validate_constraint_ref(
             ),
         ]
 
-    decision_id, option_id = parts
+    decision_id, option_id = parsed
 
     if decision_id not in decisions:
         return [
@@ -1259,14 +1258,6 @@ def _validate_universe_node(
     return errors
 
 
-def _parse_constraint_ref(ref: str) -> tuple[str, str] | None:
-    """Parse a constraint reference into (decision_id, option_id)."""
-    parts = ref.split(".")
-    if len(parts) == 2:
-        return parts[0], parts[1]
-    return None
-
-
 def _validate_node_universe_constraints(
     universe_decisions: dict[str, str],
     analysis_decisions: dict[str, Any],
@@ -1288,7 +1279,7 @@ def _validate_node_universe_constraints(
 
         # Check incompatible_with
         for ref in option.get("incompatible_with") or []:
-            parsed = _parse_constraint_ref(ref)
+            parsed = parse_option_ref(ref)
             if parsed and universe_decisions.get(parsed[0]) == parsed[1]:
                 errors.append(
                     SemanticError(
@@ -1300,7 +1291,7 @@ def _validate_node_universe_constraints(
 
         # Check requires
         for ref in option.get("requires") or []:
-            parsed = _parse_constraint_ref(ref)
+            parsed = parse_option_ref(ref)
             if parsed and universe_decisions.get(parsed[0]) != parsed[1]:
                 actual = universe_decisions.get(parsed[0], "(not set)")
                 errors.append(

--- a/src/astra/verification/pdf.py
+++ b/src/astra/verification/pdf.py
@@ -206,21 +206,23 @@ def _normalize_processor(text: str) -> str:
     return default_process(normalized)
 
 
-# pypdf is an optional dependency
+# pypdf is an optional dependency, bound on first use by `_require_pypdf`.
+# Importing it costs ~50 ms, and only text extraction needs it.
 PdfReader: Any = None
 
-try:
-    from pypdf import PdfReader as _PdfReader
 
+def _require_pypdf() -> None:
+    """Import pypdf on first use, or explain how to install it."""
+    global PdfReader
+    if PdfReader is not None:
+        return
+    try:
+        from pypdf import PdfReader as _PdfReader
+    except ImportError:
+        raise ImportError(
+            "pypdf is required for PDF extraction. Install with: pip install pypdf"
+        ) from None
     PdfReader = _PdfReader
-except ImportError:
-    pass
-
-
-def _check_pypdf() -> None:
-    """Raise ImportError if pypdf is not installed."""
-    if PdfReader is None:
-        raise ImportError("pypdf is required for PDF extraction. Install with: pip install pypdf")
 
 
 @dataclass
@@ -344,7 +346,7 @@ def extract_text_from_pdf(pdf_path: Path) -> PDFDocument:
     Raises:
         ImportError: If pypdf is not installed.
     """
-    _check_pypdf()
+    _require_pypdf()
 
     # Read PDF content for SHA-256
     pdf_bytes = pdf_path.read_bytes()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,8 +3,6 @@
 import json
 import os
 import shutil
-import subprocess
-import sys
 from pathlib import Path
 
 import pytest
@@ -684,25 +682,6 @@ class TestInitCommand:
 
 class TestCreateBoilerplate:
     """Tests for the public create_boilerplate scaffold helper."""
-
-    def test_scaffolding_does_not_import_the_validation_stack(self):
-        """``astra.scaffold`` is stdlib-only, and must stay that way.
-
-        Writing two template files should not cost what importing the
-        datamodel costs: ``astra.datamodel`` pulls in linkml_runtime,
-        roughly half a second, which is the whole reason the scaffold lives
-        outside ``astra.cli``. A subprocess, since imports are
-        process-global and pytest has already loaded everything.
-        """
-        code = (
-            "import sys, astra.scaffold; "
-            "print(sorted(n for n in ('linkml_runtime', 'astra.datamodel', 'pydantic', 'click') "
-            "if n in sys.modules))"
-        )
-        proc = subprocess.run(
-            [sys.executable, "-c", code], capture_output=True, text=True, check=True
-        )
-        assert proc.stdout.strip() == "[]", f"astra.scaffold pulled in {proc.stdout.strip()}"
 
     def test_still_importable_from_astra_cli(self):
         """``astra.cli`` re-exports it: downstream tools imported it from

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,8 @@
 import json
 import os
 import shutil
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -683,9 +685,36 @@ class TestInitCommand:
 class TestCreateBoilerplate:
     """Tests for the public create_boilerplate scaffold helper."""
 
+    def test_scaffolding_does_not_import_the_validation_stack(self):
+        """``astra.scaffold`` is stdlib-only, and must stay that way.
+
+        Writing two template files should not cost what importing the
+        datamodel costs: ``astra.datamodel`` pulls in linkml_runtime,
+        roughly half a second, which is the whole reason the scaffold lives
+        outside ``astra.cli``. A subprocess, since imports are
+        process-global and pytest has already loaded everything.
+        """
+        code = (
+            "import sys, astra.scaffold; "
+            "print(sorted(n for n in ('linkml_runtime', 'astra.datamodel', 'pydantic', 'click') "
+            "if n in sys.modules))"
+        )
+        proc = subprocess.run(
+            [sys.executable, "-c", code], capture_output=True, text=True, check=True
+        )
+        assert proc.stdout.strip() == "[]", f"astra.scaffold pulled in {proc.stdout.strip()}"
+
+    def test_still_importable_from_astra_cli(self):
+        """``astra.cli`` re-exports it: downstream tools imported it from
+        there before it moved, and that path keeps working."""
+        from astra.cli import create_boilerplate as from_cli
+        from astra.scaffold import create_boilerplate as from_scaffold
+
+        assert from_cli is from_scaffold
+
     def test_writes_spec_scaffold(self, tmp_path: Path):
         """Creates universes/, astra.yaml, and baseline.yaml."""
-        from astra.cli import create_boilerplate
+        from astra.scaffold import create_boilerplate
 
         project_dir = tmp_path / "proj"
         create_boilerplate(project_dir)

--- a/tests/test_import_cost.py
+++ b/tests/test_import_cost.py
@@ -1,0 +1,72 @@
+"""What each public module is allowed to drag in when it is imported.
+
+Import cost is part of the API. A downstream tool that imports
+``astra.scaffold`` to write two template files, or ``astra.resolve`` to
+walk a dict it already has, should not pay for the datamodel — reaching
+``astra.datamodel`` loads ``linkml_runtime``, ~250 ms, an order of
+magnitude more than the rest of ASTRA put together. Whoever calls the
+function that needs a heavy dependency pays for it; whoever merely
+imports a module that could does not.
+
+The rule is one regrettable import away from being lost, and nothing
+about the import itself looks wrong when it happens — which is what this
+file is for. Subprocesses, because imports are process-global and pytest
+has already loaded everything.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+#: Every dependency whose import cost is worth a decision, cheapest last.
+WATCHED = (
+    "linkml_runtime",
+    "astra.datamodel",
+    "pydantic",
+    "httpx",
+    "pypdf",
+    "importlib.metadata",
+    "yaml",
+    "rich",
+    "click",
+    "rapidfuzz",
+)
+
+#: module → what importing it is allowed to pull in from `WATCHED`.
+#: A module may import what it *is*; it defers what a subset of its
+#: functions merely might need.
+ALLOWED: dict[str, tuple[str, ...]] = {
+    "astra.spec_version": (),
+    "astra.scaffold": (),
+    "astra.helpers": (),
+    "astra.resolve": (),
+    "astra.validation": (),
+    "astra.validation.schema": (),
+    "astra.validation.semantic": (),
+    "astra.papers": (),
+    "astra.spec_render": (),
+    # Fuzzy matching is what `verification.pdf` does, so it pays for it up
+    # front; `pypdf` and `httpx` are optional extras it may never touch.
+    "astra.verification": ("rapidfuzz",),
+    # The CLI cannot parse a command line or print without these.
+    "astra.cli": ("rich", "click"),
+}
+
+
+@pytest.mark.parametrize("module", sorted(ALLOWED))
+def test_import_pulls_in_nothing_it_does_not_need(module: str) -> None:
+    code = (
+        "import sys, importlib\n"
+        f"importlib.import_module({module!r})\n"
+        f"print(' '.join(n for n in {WATCHED!r} if n in sys.modules))\n"
+    )
+    proc = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, check=True)
+    pulled = set(proc.stdout.split())
+    assert pulled <= set(ALLOWED[module]), (
+        f"importing {module} pulled in {sorted(pulled - set(ALLOWED[module]))}; "
+        "import it inside the function that needs it, or add it to ALLOWED "
+        "with a note saying why the module is what it costs"
+    )

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -6,6 +6,7 @@ appears together — an inherited decision, an input reaching sideways into
 a sibling sub-analysis, and a root output re-exporting a grandchild's.
 """
 
+import logging
 from pathlib import Path
 
 import pytest
@@ -334,6 +335,27 @@ class TestConditionalReExports:
         assert by_id(resolve_outputs(spec, chosen)) == {}
 
 
+class TestMalformedConditions:
+    """A `when:` that does not parse resolves to nothing, rather than
+    raising. Diagnosis belongs to the validator, which reports it as
+    `INVALID_WHEN_REF` — and cannot, if parsing raises first."""
+
+    @pytest.mark.parametrize("when", ["method", "method.pca.extra", "~method"])
+    def test_an_unparseable_output_condition_leaves_the_output_out(self, when: str):
+        spec = {"outputs": [{"id": "out", "when": when, "recipe": {"command": "x"}}]}
+        assert by_id(resolve_outputs(spec, {})) == {}
+
+    def test_an_unparseable_decision_condition_leaves_the_decision_unsettled(self):
+        spec = {
+            "decisions": {
+                "method": {"options": {"pca": {}, "mlp": {}}},
+                "trees": {"when": "method", "options": {"fifty": {}}},
+            }
+        }
+        chosen = {"decisions": {"method": "pca", "trees": "fifty"}}
+        assert resolve_universe(spec, chosen) == {"method": "pca"}
+
+
 class TestRenderCommand:
     def test_every_placeholder_form(self):
         rendered = render_command(
@@ -409,6 +431,26 @@ class TestSelectedUniverse:
         (base / "stage" / "universes" / "blank.yaml").write_text("# nothing here\n")
         chosen = {"analyses": {"stage": {"universe": "blank"}}}
         assert resolve_universe(data, chosen, base) == {}
+
+    def test_an_inline_sub_analysis_cannot_name_one_and_says_so(self, caplog):
+        """Only an external sub-analysis has a `universes/` directory.
+        `semantic.py` validates nothing about `universe:`, so without this
+        line the whole subtree resolves to no decisions and neither layer
+        says why."""
+        spec = {"analyses": {"stage": {"decisions": {"m": {"options": {"a": {}, "b": {}}}}}}}
+        chosen = {"analyses": {"stage": {"universe": "fast"}}}
+        with caplog.at_level(logging.WARNING, logger="astra.resolve"):
+            assert resolve_universe(spec, chosen, Path(".")) == {}
+        assert "inline sub-analysis" in caplog.text
+        assert "stage" in caplog.text
+
+    def test_a_missing_file_names_the_scope_it_was_selected_for(self, tmp_path: Path, caplog):
+        data, base = self._project(tmp_path)
+        chosen = {"analyses": {"stage": {"universe": "nope"}}}
+        with caplog.at_level(logging.WARNING, logger="astra.resolve"):
+            assert resolve_universe(data, chosen, base) == {}
+        assert "does not exist" in caplog.text
+        assert "stage" in caplog.text
 
     def test_inline_decisions_still_work_beside_it(self, tmp_path: Path):
         data, base = self._project(tmp_path)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+import pytest
+
 from astra.helpers import load_yaml
 from astra.validation.schema import (
     is_valid_analysis,
@@ -800,6 +802,73 @@ class TestIsConditionMet:
 
         # ~model.svm with model not set: selected is None, match=(None==svm)=False, negated=True
         assert is_condition_met("~model.svm", {}) is True
+
+    @pytest.mark.parametrize("ref", ["model", "model.svm.extra", "", "~model", "~model.svm.extra"])
+    def test_a_malformed_reference_is_a_condition_nothing_satisfies(self, ref: str):
+        """Not an exception. `is_condition_met` is reached from the
+        validator as well as the resolver, so raising took `astra universe
+        check` and `astra universe generate` down on a typo the validator
+        is perfectly able to report."""
+        from astra.helpers import is_condition_met
+
+        assert is_condition_met(ref, {"model": "svm"}) is False
+
+    def test_a_malformed_reference_fails_the_whole_and(self):
+        from astra.helpers import is_condition_met
+
+        assert is_condition_met(["model.svm", "sample"], {"model": "svm"}) is False
+
+
+class TestMalformedWhenIsReportedNotRaised:
+    """A `when:` that does not parse is the validator's to report.
+
+    Every command that reads a spec goes through `is_condition_met`, so a
+    single typo used to surface as an uncaught `ValueError` traceback from
+    `astra universe check` and `astra universe generate` — while `astra
+    validate`, on the same file, described the problem precisely.
+    """
+
+    SPEC = {
+        "version": "1.0",
+        "name": "Malformed",
+        "inputs": [{"id": "seed", "type": "data", "source": "s3://raw"}],
+        "outputs": [{"id": "out", "type": "data", "recipe": {"command": "run {output}"}}],
+        "decisions": {
+            "method": {"options": {"pca": {}, "mlp": {}}, "default": "pca"},
+            "trees": {"when": ["method"], "options": {"fifty": {}}, "default": "fifty"},
+        },
+    }
+
+    def test_validate_universe_reports_instead_of_raising(self):
+        errors = validate_universe({"decisions": {"method": "pca", "trees": "fifty"}}, self.SPEC)
+        assert all(isinstance(e, SemanticError) for e in errors)
+
+    def test_the_analysis_validator_still_names_the_typo(self):
+        codes = {e.code for e in validate_analysis(self.SPEC)}
+        assert "INVALID_WHEN_REF" in codes
+
+    def test_an_output_when_is_reported_too(self):
+        spec = {
+            **self.SPEC,
+            "decisions": {"method": {"options": {"pca": {}}, "default": "pca"}},
+            "outputs": [
+                {
+                    "id": "out",
+                    "type": "data",
+                    "when": ["method.pca.extra"],
+                    "recipe": {"command": "run {output}"},
+                }
+            ],
+        }
+        codes = {e.code for e in validate_analysis(spec)}
+        assert "INVALID_WHEN_REF" in codes
+
+    def test_defaults_do_not_raise_either(self):
+        """`astra universe generate` reads `when:` through
+        `get_default_universe`."""
+        from astra.helpers import get_default_universe
+
+        assert get_default_universe(self.SPEC)["decisions"] == {"method": "pca"}
 
 
 class TestDefaultUniverseConditional:


### PR DESCRIPTION
## Problem

`create_boilerplate` is astra's public scaffold API (#99) — the entry point downstream tools use to scaffold an ASTRA spec into their own projects. Reaching it meant `from astra.cli import create_boilerplate`, which cost ~0.5 s.

None of that was astra's own code. The chain, from `python -X importtime`:

```
astra.cli                              509 ms
└─ astra.validation.schema             416 ms
   └─ astra.datamodel.astra_pydantic   406 ms
      └─ astra.datamodel.analysis      380 ms
         └─ linkml_runtime             346 ms
```

Investigating further, the scaffold was just the case someone happened to notice. The same import sat under **everything**: `astra --help` cost 355 ms, `astra guide` 407 ms, `astra viz` 411 ms — none of which touch the datamodel — because `astra/validation/__init__.py` imports `schema.py`, which imported the datamodel at module scope. Library consumers paid it too, including ones that only walk dicts they already have.

Measuring every public entry point (import, first call, warm call, in fresh processes) showed the shape of it: **warm calls are microseconds.** Everything in ASTRA except YAML parsing runs in under 0.2 ms. This library was import-bound, not compute-bound, so all the available time was in imports.

## Change

The rule applied throughout: **a module imports what it *is*, and defers what a subset of its functions merely might need.** `verification.pdf` still imports `rapidfuzz` at module scope — fuzzy matching is what it does — while `pypdf` and `httpx`, both optional extras, are bound on first use.

- **`astra/scaffold.py`** — `create_boilerplate` moved out of `astra.cli`, verbatim.
- **`astra/spec_version.py`** — `installed_spec_version()`, previously one module away from the entire datamodel. `importlib.metadata` (~13 ms; drags in email, inspect, zipfile) is now imported inside it.
- **`validation/schema.py`** — `astra.datamodel` + `pydantic` import inside `validate_analysis_data` / `validate_universe_data`. `check_spec_version` and `installed_spec_version`, which every run touches, needed nothing from them.
- **`spec_render.py`** — `SchemaView` and `SCHEMA_DIRECTORY` import inside the `lru_cache`d `_view()` that every renderer already goes through.
- **`papers/download.py`, `verification/pdf.py`** — the eager `try: import` availability probes become `_require_httpx()` / `_require_pypdf()`, binding the module global on first use. Patching those globals in tests still works: a patched value is simply already bound.
- **`helpers.py`** — PyYAML (~18 ms, more than the rest of the module) imports inside `load_yaml` / `save_yaml`. Everything else there takes a dict that is already in hand.
- **`cli.py`** — `subprocess` imports inside `_init_git_repo`.

## Measured

End-to-end `astra` invocations, wall clock, min of 12 interleaved runs:

| command | before | after |
|---|---:|---:|
| `astra --help` | 355 ms | **59 ms** |
| `astra --version` | 416 ms | **72 ms** |
| `astra init` | 371 ms | **76 ms** |
| `astra info` | 385 ms | **82 ms** |
| `astra universe check` | 367 ms | **75 ms** |
| `astra guide` | 407 ms | **59 ms** |
| `astra viz` | 411 ms | **74 ms** |
| `astra validate` | 380 ms | 335 ms |
| `astra spec` | 444 ms | 330 ms |

`validate` and `spec` are the two commands that genuinely need the datamodel and the LinkML schema. They still pay for it — and now nothing else does.

Cold module imports, same method, with the module count each one leaves in `sys.modules` (interpreter floor: 45):

| module | before | after |
|---|---:|---:|
| `astra.spec_version` | 25 ms / 151 | **0.3 ms / 48** |
| `astra.scaffold` | 25 ms / 152 | **6 ms / 66** |
| `astra.helpers` | 18 ms / 109 | **13 ms / 83** |
| `astra.resolve` | 23 ms / 122 | **19 ms / 96** |
| `astra.validation` | 241 ms / 606 | **14 ms / 88** |
| `astra.validation.semantic` | 242 ms / 606 | **13 ms / 88** |
| `astra.papers` | 67 ms / 282 | **19 ms / 107** |
| `astra.verification` | 102 ms / 405 | **28 ms / 158** |
| `astra.spec_render` | 226 ms / 600 | **8 ms / 72** |
| `astra.cli` | 273 ms / 668 | **46 ms / 187** |

Nothing got slower: the heavy import costs the same ~250 ms wherever it happens, so a caller who *does* validate against the Pydantic models pays what they paid before, just at the call rather than at the import.

## Compatibility

Nothing leaves the public surface.

- `from astra.cli import create_boilerplate` still works — `astra.cli` imports it and lists it in `__all__`, and it is what `astra init` calls.
- `astra.validation.installed_spec_version` still works, re-exported from `astra.spec_version`. `validation.schema` keeps the name in its namespace, so `patch("astra.validation.schema.installed_spec_version", …)` is unaffected.
- `patch("astra.papers.download.httpx", …)` is unaffected: `_require_httpx()` returns early when the global is already bound.
- The optional-dependency error messages are unchanged; they now raise from the call rather than leaving a `None` sentinel behind.

## Tests

`tests/test_import_cost.py` pins the contract as a table: for each public module, which of ten watched dependencies it is allowed to pull in. One regrettable import is all it takes to lose this, and nothing about that import looks wrong at the time. Verified it bites — adding `import yaml` back to `helpers.py` fails six of the eleven cases and names them.

It supersedes the scaffold-specific check in `test_cli.py`, which is removed.

## Deliberately not done

`logging` in `helpers.py` and `resolve.py` costs ~3.6 ms and 13 modules. Replacing a module-level `logger = logging.getLogger(__name__)` with a lazy shim is not worth 3.6 ms.


---

## Also here: a `when:` typo crashed two commands

Found while reviewing this branch, unrelated to the import work but committed here rather than split out.

`is_condition_met` did `decision_id, option_id = ref.split(".")`, and the validator reaches that function too. So a reference that is not exactly two parts raised `ValueError`:

```
$ astra universe check universes/baseline.yaml
  ...
  File ".../helpers.py", line 91, in is_condition_met
    decision_id, option_id = ref.split(".")
ValueError: not enough values to unpack (expected 2, got 1)
```

`astra universe generate` did the same, through `get_default_universe`. `astra validate` on the identical file reported it properly — `[INVALID_WHEN_REF] decisions.trees: Decision 'when' condition 'method' has invalid format` — so the diagnosis existed; two commands just died before reaching it.

The `decision.option` grammar was parsed in five places (`is_condition_met`, `_validate_decisions`, `_validate_output_when`, `_validate_constraint_ref`, `_parse_constraint_ref`), and exactly one raised instead of returning nothing. `helpers.parse_option_ref` is now that parser — next to `parse_from_path`, for the same reason — and every site reads the grammar through it. For `is_condition_met`, an unparseable reference is a condition nothing can satisfy, negated or not.

Reverting the fix fails 12 of the new tests, including both crash paths.

Separately, `_selected_universe` silently ignored a `universe:` reference on an **inline** sub-analysis — only an external one has a `universes/` directory to name a universe in. Since `semantic.py` validates nothing about `universe:`, the subtree resolved to no decisions with no diagnostic from either layer. It now warns, like the missing-file case beside it, and both warnings name the qualified scope instead of a path.
