### PR TITLE
Add astra.resolve: what a universe actually produces

### DIFF
--- a/src/astra/helpers.py
+++ b/src/astra/helpers.py
@@ -8,9 +8,9 @@ from __future__ import annotations
 
 import logging
 import re
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping, Sequence
 from pathlib import Path
-from typing import Any
+from typing import Any, TypeVar
 
 import yaml
 
@@ -19,6 +19,13 @@ logger = logging.getLogger(__name__)
 #: The id grammar the schema enforces. It is what makes ``.`` an
 #: unambiguous separator in a ``from:`` reference or a qualified id.
 ID_PATTERN = re.compile(r"^[a-z][a-z0-9_]*$")
+
+#: An analysis path: the sub-analysis ids descended through to reach a
+#: node, empty at the root. Joined with ``.`` it qualifies any id declared
+#: there, e.g. ``classification.accuracy``.
+Scope = tuple[str, ...]
+
+_T = TypeVar("_T")
 
 
 # A unified path expression that any `from:` slot can take:
@@ -107,18 +114,64 @@ def external_spec_path(base_path: Path, sub_path: str) -> Path:
     return (base_path / sub_path).resolve() / "astra.yaml"
 
 
+def iter_analysis_nodes(data: Mapping[str, Any]) -> Iterator[tuple[Scope, dict[str, Any]]]:
+    """Yield every node in the analysis tree with the scope it sits at.
+
+    The root comes first, with an empty scope, then each sub-analysis
+    depth-first. The scope path is what lets anything declared inside a
+    sub-analysis be named unambiguously; where it does not matter,
+    ``iter_sub_analyses`` is the same walk without it.
+
+    An external (``path:``) sub-analysis is descended into like any other:
+    before ``resolve_analysis_tree`` runs it has no content to descend
+    into, and after it runs that content is the sub-analysis.
+
+    Args:
+        data: The analysis, external sub-analyses resolved or not.
+
+    Yields:
+        ``(scope, node)`` pairs, root first.
+    """
+    yield ((), dict(data))
+    yield from _descend_nodes(data, ())
+
+
+def _descend_nodes(node: Mapping[str, Any], scope: Scope) -> Iterator[tuple[Scope, dict[str, Any]]]:
+    for sub_id, sub in (node.get("analyses") or {}).items():
+        if not isinstance(sub, dict):
+            continue
+        here = (*scope, str(sub_id))
+        yield (here, sub)
+        yield from _descend_nodes(sub, here)
+
+
 def iter_sub_analyses(node: dict[str, Any]) -> Iterator[dict[str, Any]]:
     """Yield every sub-analysis dict declared in ``node``'s ``analyses`` tree.
 
-    Recurses into inline sub-analyses only; external (``path:``) sub-analyses
-    are yielded but not read — their own tree is not visible from this spec.
+    Depth-first, parents before children; the node itself is not yielded.
     """
-    for sub in (node.get("analyses") or {}).values():
-        if not isinstance(sub, dict):
-            continue
+    for _, sub in _descend_nodes(node, ()):
         yield sub
-        if not sub.get("path"):
-            yield from iter_sub_analyses(sub)
+
+
+def ancestor_at(chain: Sequence[_T], up: int) -> _T | None:
+    """The entry ``up`` scopes above the current node in a root-first chain.
+
+    What every ``../`` in a ``from:`` reference counts against, whether the
+    chain holds ancestor nodes, ancestor universes, or what each ancestor
+    settled: ``chain[-1]`` is the immediate parent, so ``up=1`` selects it.
+
+    Args:
+        chain: The ancestors of the current node, root first.
+        up: The number of ``../`` steps taken.
+
+    Returns:
+        The entry that many scopes up, or ``None`` if the reference escapes
+        past the root — which the validator reports and the resolver skips.
+    """
+    if up <= 0 or up > len(chain):
+        return None
+    return chain[len(chain) - up]
 
 
 def resolve_analysis_tree(data: dict[str, Any], base_path: Path) -> dict[str, Any]:

--- a/src/astra/helpers.py
+++ b/src/astra/helpers.py
@@ -7,6 +7,7 @@ avoiding the need for Pydantic model imports in the validation path.
 from __future__ import annotations
 
 import logging
+import re
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
@@ -14,6 +15,46 @@ from typing import Any
 import yaml
 
 logger = logging.getLogger(__name__)
+
+#: The id grammar the schema enforces. It is what makes ``.`` an
+#: unambiguous separator in a ``from:`` reference or a qualified id.
+ID_PATTERN = re.compile(r"^[a-z][a-z0-9_]*$")
+
+
+# A unified path expression that any `from:` slot can take:
+#
+#   ../id              -- escape one scope upward, then `id`
+#   ../../id           -- escape two scopes upward, then `id`
+#   ../scope.id        -- escape upward, then descend into a named child
+#   scope.id           -- descend from current scope into a named child
+#   scope.sub.id       -- descend through nested children
+#
+# Direction restrictions are per-slot and belong to the validator, not here.
+def parse_from_path(ref: str) -> tuple[int, list[str]] | None:
+    """Parse a ``from:`` reference into ``(up_levels, descent_segments)``.
+
+    Args:
+        ref: The reference as written, e.g. ``"../feature_extraction.features"``.
+
+    Returns:
+        The number of ``../`` steps and the remaining dotted segments, or
+        ``None`` if the reference is malformed (empty or invalid segments).
+
+    Examples:
+        ``"../id"`` → ``(1, ["id"])``; ``"../scope.id"`` → ``(1, ["scope",
+        "id"])``; ``"scope.sub.id"`` → ``(0, ["scope", "sub", "id"])``.
+    """
+    up = 0
+    rest = ref
+    while rest.startswith("../"):
+        up += 1
+        rest = rest[3:]
+    if not rest or rest.startswith(".") or rest.endswith("."):
+        return None
+    segments = rest.split(".")
+    if not all(ID_PATTERN.match(seg) for seg in segments):
+        return None
+    return (up, segments)
 
 
 def is_condition_met(

--- a/src/astra/resolve.py
+++ b/src/astra/resolve.py
@@ -35,12 +35,22 @@ from __future__ import annotations
 
 import logging
 import string
-from collections.abc import Iterator, Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from astra.helpers import external_spec_path, is_condition_met, load_yaml, parse_from_path
+from astra.helpers import (
+    Scope,
+    ancestor_at,
+    external_spec_path,
+    get_input,
+    get_output_ids,
+    is_condition_met,
+    iter_analysis_nodes,
+    load_yaml,
+    parse_from_path,
+)
 
 __all__ = [
     "ResolvedInput",
@@ -56,8 +66,6 @@ logger = logging.getLogger(__name__)
 
 _FORMATTER = string.Formatter()
 
-Scope = tuple[str, ...]
-
 
 def qualify(scope: Scope, local_id: str) -> str:
     """Join a scope path and a local id into a qualified id.
@@ -70,35 +78,6 @@ def qualify(scope: Scope, local_id: str) -> str:
         ``"a.b.id"`` inside sub-analyses, or ``"id"`` at the root.
     """
     return ".".join((*scope, local_id))
-
-
-def iter_analysis_nodes(data: Mapping[str, Any]) -> Iterator[tuple[Scope, dict[str, Any]]]:
-    """Yield every node in the analysis tree with the scope it sits at.
-
-    The root comes first, with an empty scope, then each sub-analysis
-    depth-first. Unlike ``iter_sub_analyses`` this yields the scope path —
-    which is what lets anything declared inside a sub-analysis be named
-    unambiguously — and it descends into external (``path:``)
-    sub-analyses, whose content ``resolve_analysis_tree`` has already
-    inlined by the time this runs.
-
-    Args:
-        data: The analysis, with external sub-analyses already resolved.
-
-    Yields:
-        ``(scope, node)`` pairs, root first.
-    """
-    yield ((), dict(data))
-    yield from _descend(data, ())
-
-
-def _descend(node: Mapping[str, Any], scope: Scope) -> Iterator[tuple[Scope, dict[str, Any]]]:
-    for sub_id, sub in (node.get("analyses") or {}).items():
-        if not isinstance(sub, dict):
-            continue
-        here = (*scope, str(sub_id))
-        yield (here, sub)
-        yield from _descend(sub, here)
 
 
 # =============================================================================
@@ -164,7 +143,10 @@ def _selected_universe(
             "universe '%s' selected for '%s' but %s does not exist", name, sub_path, path
         )
         return universe_node
-    return load_yaml(path)
+    loaded = load_yaml(path)
+    # An empty or comment-only file parses to `None`; that is the
+    # validator's to report, and this module promises not to raise on it.
+    return loaded if isinstance(loaded, Mapping) else universe_node
 
 
 def _settle(
@@ -198,18 +180,20 @@ def _settle(
         if parsed is None:
             continue
         up, segments = parsed
-        if len(segments) != 1 or not 0 < up <= len(chain):
-            continue
-        target = chain[len(chain) - up]
-        if segments[0] in target:
+        target = ancestor_at(chain, up) if len(segments) == 1 else None
+        if target is not None and segments[0] in target:
             here[str(decision_id)] = target[segments[0]]
 
+    # A condition reads everything this universe settles at or above this
+    # node, not just what happens to be declared before it — which is what
+    # `_validate_universe_node` compares against.
+    in_scope = {**ancestors, **chosen}
     for decision_id, decision in declared.items():
         name = str(decision_id)
         if name in here or name not in chosen:
             continue
         when = decision.get("when") if isinstance(decision, dict) else None
-        if when and not is_condition_met(when, {**ancestors, **here}):
+        if when and not is_condition_met(when, {**in_scope, **here}):
             continue
         here[name] = chosen[name]
 
@@ -295,7 +279,7 @@ def resolve_outputs(
     """
     settled = resolve_universe(data, universe, base_path)
     nodes = dict(iter_analysis_nodes(data))
-    resolved: list[ResolvedOutput] = []
+    declared_here: list[tuple[str, Scope, dict[str, Any], dict[str, str]]] = []
     reexports: dict[str, str] = {}
 
     for scope, node in nodes.items():
@@ -305,30 +289,51 @@ def resolve_outputs(
                 continue
             if not is_condition_met(declared.get("when") or None, local):
                 continue
-            output_id = str(declared["id"])
+            qualified = qualify(scope, str(declared["id"]))
             target = _reexport_target(scope, str(declared.get("from") or ""))
             if target:
-                reexports[qualify(scope, output_id)] = target
-            resolved.append(
-                ResolvedOutput(
-                    id=qualify(scope, output_id),
-                    scope=scope,
-                    definition=declared,
-                    command=(declared.get("recipe") or {}).get("command") or None,
-                    decisions={
-                        name: local[name]
-                        for name in declared.get("decisions") or []
-                        if name in local
-                    },
-                    inputs=tuple(
-                        _resolve_input(nodes, scope, str(name))
-                        for name in declared.get("inputs") or []
-                    ),
-                    reexports=target,
-                )
-            )
+                reexports[qualified] = target
+            declared_here.append((qualified, scope, declared, local))
+
+    live = _live_ids({entry[0] for entry in declared_here}, reexports)
+    resolved = [
+        ResolvedOutput(
+            id=qualified,
+            scope=scope,
+            definition=declared,
+            command=(declared.get("recipe") or {}).get("command") or None,
+            decisions={
+                name: local[name] for name in declared.get("decisions") or [] if name in local
+            },
+            inputs=tuple(
+                _resolve_input(nodes, scope, str(name)) for name in declared.get("inputs") or []
+            ),
+            reexports=reexports.get(qualified),
+        )
+        for qualified, scope, declared, local in declared_here
+        if qualified in live
+    ]
 
     return [_follow(out, reexports) for out in resolved]
+
+
+def _live_ids(declared: set[str], reexports: Mapping[str, str]) -> set[str]:
+    """Drop every re-export of an output this universe does not produce.
+
+    A re-export carries no ``when:`` of its own — it is exactly as
+    conditional as the output it stands for, and returning one whose target
+    was conditioned away would hand a runner a target it cannot build.
+    Dropping cascades, since a re-export may stand for another.
+    """
+    live = set(declared)
+    dropping = True
+    while dropping:
+        dropping = False
+        for qualified, target in reexports.items():
+            if qualified in live and target not in live:
+                live.discard(qualified)
+                dropping = True
+    return live
 
 
 def _scope_decisions(settled: Mapping[str, str], scope: Scope) -> dict[str, str]:
@@ -340,6 +345,11 @@ def _scope_decisions(settled: Mapping[str, str], scope: Scope) -> dict[str, str]
     }
 
 
+def _descent_target(scope: Scope, segments: Sequence[str]) -> tuple[Scope, str]:
+    """Split a downward path into the scope it lands in and the id there."""
+    return ((*scope, *(str(seg) for seg in segments[:-1])), str(segments[-1]))
+
+
 def _reexport_target(scope: Scope, ref: str) -> str | None:
     """The qualified id an ``Output.from`` re-export stands for."""
     parsed = parse_from_path(ref) if ref else None
@@ -348,28 +358,41 @@ def _reexport_target(scope: Scope, ref: str) -> str | None:
     up, segments = parsed
     if up or len(segments) < 2:
         return None
-    return qualify((*scope, *segments[:-1]), segments[-1])
+    return qualify(*_descent_target(scope, segments))
 
 
-def _resolve_input(
-    nodes: Mapping[Scope, Mapping[str, Any]], scope: Scope, name: str
-) -> ResolvedInput:
+def _resolve_input(nodes: Mapping[Scope, dict[str, Any]], scope: Scope, name: str) -> ResolvedInput:
     """What supplies *name* for an output declared at *scope*.
 
-    An input naming an output of its own scope is that output. Otherwise
-    it is one of the scope's declared inputs, which either carries a
-    ``source:`` or points elsewhere with ``from:`` — upward to an
-    ancestor's input, which is resolved in turn, or across to a
-    sub-analysis's output.
+    An output may name one of its own scope's outputs, or a sub-analysis's
+    output qualified as ``sub.out_id``. Otherwise the name is one of the
+    scope's declared inputs, which either carries a ``source:`` or points
+    elsewhere with ``from:`` — upward to an ancestor's input, which is
+    resolved in turn, or across to a sub-analysis's output.
     """
-    node = nodes.get(scope) or {}
-    if any(str(o.get("id")) == name for o in node.get("outputs") or [] if isinstance(o, dict)):
-        return ResolvedInput(id=name, produced_by=qualify(scope, name), source=None)
+    if "." in name:
+        # Ids match `^[a-z][a-z0-9_]*$`, so a dot only ever separates the
+        # sub-analyses descended through from the output at the end.
+        target, output_id = _descent_target(scope, name.split("."))
+        if output_id in get_output_ids(nodes.get(target) or {}):
+            return ResolvedInput(id=name, produced_by=qualify(target, output_id), source=None)
+        return ResolvedInput(id=name, produced_by=None, source=None)
 
-    declared = next(
-        (i for i in node.get("inputs") or [] if isinstance(i, dict) and str(i.get("id")) == name),
-        None,
-    )
+    if name in get_output_ids(nodes.get(scope) or {}):
+        return ResolvedInput(id=name, produced_by=qualify(scope, name), source=None)
+    return _resolve_declared_input(nodes, scope, name)
+
+
+def _resolve_declared_input(
+    nodes: Mapping[Scope, dict[str, Any]], scope: Scope, name: str
+) -> ResolvedInput:
+    """What supplies one of *scope*'s own declared inputs.
+
+    Kept apart from `_resolve_input` because ``from: ../id`` names an
+    *input* of the ancestor scope — which `_validate_input_from` checks it
+    against — and a same-named output there must not stand in for it.
+    """
+    declared = get_input(nodes.get(scope) or {}, name)
     if declared is None:
         return ResolvedInput(id=name, produced_by=None, source=None)
 
@@ -381,14 +404,12 @@ def _resolve_input(
         target = scope[: len(scope) - up]
         if len(segments) == 1:
             # An ancestor's input, which may itself be sourced or aliased.
-            inherited = _resolve_input(nodes, target, segments[0])
+            inherited = _resolve_declared_input(nodes, target, segments[0])
             return ResolvedInput(
                 id=name, produced_by=inherited.produced_by, source=inherited.source
             )
         return ResolvedInput(
-            id=name,
-            produced_by=qualify((*target, *segments[:-1]), segments[-1]),
-            source=None,
+            id=name, produced_by=qualify(*_descent_target(target, segments)), source=None
         )
 
     source = declared.get("source")

--- a/src/astra/resolve.py
+++ b/src/astra/resolve.py
@@ -1,0 +1,435 @@
+"""Resolve an analysis into what a universe actually produces.
+
+The rest of ASTRA answers questions *about* a spec: is it valid, what ids
+does it declare, what are the defaults. This module answers the question a
+consumer asks when it is about to act on one — **given this analysis and
+this universe, what outputs are produced, from what, under which
+decisions?**
+
+Every rule applied here is already specified and already enforced by
+``astra.validation.semantic``; what was missing is the resolving half. A
+consumer that needs the answer has otherwise had to re-derive scoping,
+``from:`` references, conditional outputs and the recipe grammar from the
+schema — which is how two implementations of one specification start
+disagreeing.
+
+Scope and naming
+----------------
+
+Sub-analyses nest arbitrarily, so every resolved thing is named by its
+**qualified id**: the scope path and the local id joined with ``.``, e.g.
+``classification.accuracy``. A root-level id is unqualified. Since ids
+match ``^[a-z][a-z0-9_]*$``, the dot is unambiguous.
+
+Validity is assumed
+-------------------
+
+These functions resolve a spec that passes ``astra validate``. They do not
+re-report validation errors: an input that nothing supplies resolves to a
+``ResolvedInput`` with neither ``produced_by`` nor ``source``, rather than
+raising. Diagnosis belongs to the validator, and duplicating it here would
+be the same duplication this module exists to remove.
+"""
+
+from __future__ import annotations
+
+import string
+from collections.abc import Iterator, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from astra.helpers import is_condition_met, parse_from_path
+
+__all__ = [
+    "ResolvedInput",
+    "ResolvedOutput",
+    "iter_analysis_nodes",
+    "parse_from_path",
+    "render_command",
+    "resolve_outputs",
+    "resolve_universe",
+]
+
+_FORMATTER = string.Formatter()
+
+Scope = tuple[str, ...]
+
+
+def qualify(scope: Scope, local_id: str) -> str:
+    """Join a scope path and a local id into a qualified id.
+
+    Args:
+        scope: The analysis path the id was declared in; empty at the root.
+        local_id: The id as declared.
+
+    Returns:
+        ``"a.b.id"`` inside sub-analyses, or ``"id"`` at the root.
+    """
+    return ".".join((*scope, local_id))
+
+
+def iter_analysis_nodes(data: Mapping[str, Any]) -> Iterator[tuple[Scope, dict[str, Any]]]:
+    """Yield every node in the analysis tree with the scope it sits at.
+
+    The root comes first, with an empty scope, then each sub-analysis
+    depth-first. Unlike ``iter_sub_analyses`` this yields the scope path —
+    which is what lets anything declared inside a sub-analysis be named
+    unambiguously — and it descends into external (``path:``)
+    sub-analyses, whose content ``resolve_analysis_tree`` has already
+    inlined by the time this runs.
+
+    Args:
+        data: The analysis, with external sub-analyses already resolved.
+
+    Yields:
+        ``(scope, node)`` pairs, root first.
+    """
+    yield ((), dict(data))
+    yield from _descend(data, ())
+
+
+def _descend(node: Mapping[str, Any], scope: Scope) -> Iterator[tuple[Scope, dict[str, Any]]]:
+    for sub_id, sub in (node.get("analyses") or {}).items():
+        if not isinstance(sub, dict):
+            continue
+        here = (*scope, str(sub_id))
+        yield (here, sub)
+        yield from _descend(sub, here)
+
+
+# =============================================================================
+# Universes
+# =============================================================================
+
+
+def resolve_universe(data: Mapping[str, Any], universe: Mapping[str, Any]) -> dict[str, str]:
+    """Resolve a universe into every decision it settles, by qualified id.
+
+    Three things are applied that a universe file does not state outright.
+    A decision declared ``from: ../id`` takes the ancestor's chosen option,
+    so an inherited decision has a value in the scope that uses it. A
+    decision carrying ``when:`` is included only where its condition holds
+    against the decisions already settled above it. And a sub-analysis's
+    decisions come from the ``analyses.<id>.decisions`` block of the same
+    universe file, nested to whatever depth the tree has.
+
+    Args:
+        data: The analysis, with external sub-analyses already resolved.
+        universe: The universe, as loaded from ``universes/<id>.yaml``.
+
+    Returns:
+        Qualified decision id → chosen option id. Root decisions are
+        unqualified; a sub-analysis's are ``"<scope>.<decision_id>"``.
+    """
+    settled: dict[str, str] = {}
+    _settle(data, universe, (), [], settled)
+    return settled
+
+
+def _settle(
+    node: Mapping[str, Any],
+    universe_node: Mapping[str, Any],
+    scope: Scope,
+    chain: list[dict[str, str]],
+    settled: dict[str, str],
+) -> None:
+    """Settle one node's decisions, then recurse into its sub-analyses.
+
+    *chain* is what each ancestor settled, by that ancestor's **local**
+    ids, root first — the view ``from:`` reads, since ``../`` counts
+    scopes rather than searching them. ``when:`` reads the whole chain
+    flattened, which is what the validator compares against.
+    """
+    declared = node.get("decisions") or {}
+    chosen = {str(k): str(v) for k, v in (universe_node.get("decisions") or {}).items()}
+    ancestors: dict[str, str] = {}
+    for level in chain:
+        ancestors.update(level)
+    here: dict[str, str] = {}
+
+    # `from:` first: an inherited decision is settled wherever its ancestor
+    # settled it, and a conditional decision below may depend on one.
+    for decision_id, decision in declared.items():
+        if not isinstance(decision, dict):
+            continue
+        parsed = parse_from_path(str(decision.get("from") or "")) if decision.get("from") else None
+        if parsed is None:
+            continue
+        up, segments = parsed
+        if len(segments) != 1 or not 0 < up <= len(chain):
+            continue
+        target = chain[len(chain) - up]
+        if segments[0] in target:
+            here[str(decision_id)] = target[segments[0]]
+
+    for decision_id, decision in declared.items():
+        name = str(decision_id)
+        if name in here or name not in chosen:
+            continue
+        when = decision.get("when") if isinstance(decision, dict) else None
+        if when and not is_condition_met(when, {**ancestors, **here}):
+            continue
+        here[name] = chosen[name]
+
+    for name, option in here.items():
+        settled[qualify(scope, name)] = option
+
+    for sub_id, sub in (node.get("analyses") or {}).items():
+        if not isinstance(sub, dict):
+            continue
+        sub_universe = (universe_node.get("analyses") or {}).get(str(sub_id)) or {}
+        _settle(sub, sub_universe, (*scope, str(sub_id)), [*chain, here], settled)
+
+
+# =============================================================================
+# Outputs
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class ResolvedInput:
+    """One of an output's declared inputs, resolved to what supplies it.
+
+    Exactly one of ``produced_by`` and ``source`` is set for a spec that
+    validates; both are ``None`` when nothing supplies the input, which is
+    ``UNKNOWN_INPUT``'s business rather than this module's.
+    """
+
+    #: The id as the consuming output declares it.
+    id: str
+    #: The qualified id of the output that makes it, re-exports followed
+    #: through to whatever carries the recipe.
+    produced_by: str | None
+    #: The external source, for an input the analysis does not compute.
+    source: str | None
+
+
+@dataclass(frozen=True)
+class ResolvedOutput:
+    """One output of one universe, with everything it needs resolved."""
+
+    #: The qualified id: ``"classification.accuracy"``.
+    id: str
+    #: The analysis path it was declared in; empty at the root.
+    scope: Scope
+    #: The output as the spec declares it.
+    definition: dict[str, Any]
+    #: ``recipe.command``, or ``None`` for a re-export or a declared-only
+    #: output. This is the test of whether the output is executable.
+    command: str | None
+    #: The declared decisions and the options this universe chose, by the
+    #: **local** id a recipe writes as ``{decisions.<id>}``.
+    decisions: dict[str, str]
+    #: The declared inputs, in declaration order.
+    inputs: tuple[ResolvedInput, ...]
+    #: For a re-export, the qualified id it stands for; ``None`` otherwise.
+    reexports: str | None
+
+
+def resolve_outputs(data: Mapping[str, Any], universe: Mapping[str, Any]) -> list[ResolvedOutput]:
+    """Resolve every output this universe produces, anywhere in the tree.
+
+    Outputs whose ``when:`` condition does not hold in this universe are
+    **left out** — that is what makes them conditional. Everything else is
+    returned, re-exports included, so ``command`` is the test of what a
+    runner has to execute.
+
+    Args:
+        data: The analysis, with external sub-analyses already resolved.
+        universe: The universe, as loaded from ``universes/<id>.yaml``.
+
+    Returns:
+        Every active output, root scope first, in declaration order.
+    """
+    settled = resolve_universe(data, universe)
+    nodes = dict(iter_analysis_nodes(data))
+    resolved: list[ResolvedOutput] = []
+    reexports: dict[str, str] = {}
+
+    for scope, node in nodes.items():
+        local = _scope_decisions(settled, scope)
+        for declared in node.get("outputs") or []:
+            if not isinstance(declared, dict) or not declared.get("id"):
+                continue
+            if not is_condition_met(declared.get("when") or None, local):
+                continue
+            output_id = str(declared["id"])
+            target = _reexport_target(scope, str(declared.get("from") or ""))
+            if target:
+                reexports[qualify(scope, output_id)] = target
+            resolved.append(
+                ResolvedOutput(
+                    id=qualify(scope, output_id),
+                    scope=scope,
+                    definition=declared,
+                    command=(declared.get("recipe") or {}).get("command") or None,
+                    decisions={
+                        name: local[name]
+                        for name in declared.get("decisions") or []
+                        if name in local
+                    },
+                    inputs=tuple(
+                        _resolve_input(nodes, scope, str(name))
+                        for name in declared.get("inputs") or []
+                    ),
+                    reexports=target,
+                )
+            )
+
+    return [_follow(out, reexports) for out in resolved]
+
+
+def _scope_decisions(settled: Mapping[str, str], scope: Scope) -> dict[str, str]:
+    """The decisions settled *in* one scope, by their local ids."""
+    return {
+        key.rsplit(".", 1)[-1]: value
+        for key, value in settled.items()
+        if tuple(key.split(".")[:-1]) == scope
+    }
+
+
+def _reexport_target(scope: Scope, ref: str) -> str | None:
+    """The qualified id an ``Output.from`` re-export stands for."""
+    parsed = parse_from_path(ref) if ref else None
+    if parsed is None:
+        return None
+    up, segments = parsed
+    if up or len(segments) < 2:
+        return None
+    return qualify((*scope, *segments[:-1]), segments[-1])
+
+
+def _resolve_input(
+    nodes: Mapping[Scope, Mapping[str, Any]], scope: Scope, name: str
+) -> ResolvedInput:
+    """What supplies *name* for an output declared at *scope*.
+
+    An input naming an output of its own scope is that output. Otherwise
+    it is one of the scope's declared inputs, which either carries a
+    ``source:`` or points elsewhere with ``from:`` — upward to an
+    ancestor's input, which is resolved in turn, or across to a
+    sub-analysis's output.
+    """
+    node = nodes.get(scope) or {}
+    if any(str(o.get("id")) == name for o in node.get("outputs") or [] if isinstance(o, dict)):
+        return ResolvedInput(id=name, produced_by=qualify(scope, name), source=None)
+
+    declared = next(
+        (i for i in node.get("inputs") or [] if isinstance(i, dict) and str(i.get("id")) == name),
+        None,
+    )
+    if declared is None:
+        return ResolvedInput(id=name, produced_by=None, source=None)
+
+    if ref := declared.get("from"):
+        parsed = parse_from_path(str(ref))
+        if parsed is None or not 0 < parsed[0] <= len(scope):
+            return ResolvedInput(id=name, produced_by=None, source=None)
+        up, segments = parsed
+        target = scope[: len(scope) - up]
+        if len(segments) == 1:
+            # An ancestor's input, which may itself be sourced or aliased.
+            inherited = _resolve_input(nodes, target, segments[0])
+            return ResolvedInput(
+                id=name, produced_by=inherited.produced_by, source=inherited.source
+            )
+        return ResolvedInput(
+            id=name,
+            produced_by=qualify((*target, *segments[:-1]), segments[-1]),
+            source=None,
+        )
+
+    source = declared.get("source")
+    return ResolvedInput(id=name, produced_by=None, source=str(source) if source else None)
+
+
+def _follow(out: ResolvedOutput, reexports: Mapping[str, str]) -> ResolvedOutput:
+    """Point every ``produced_by`` past re-exports at what carries the recipe."""
+    if not reexports:
+        return out
+    inputs = tuple(
+        ResolvedInput(id=i.id, produced_by=_terminal(i.produced_by, reexports), source=i.source)
+        for i in out.inputs
+    )
+    return ResolvedOutput(
+        id=out.id,
+        scope=out.scope,
+        definition=out.definition,
+        command=out.command,
+        decisions=out.decisions,
+        inputs=inputs,
+        reexports=_terminal(out.reexports, reexports),
+    )
+
+
+def _terminal(qualified: str | None, reexports: Mapping[str, str]) -> str | None:
+    """Chase a re-export chain to the output that actually produces bytes."""
+    seen: set[str] = set()
+    while qualified is not None and qualified in reexports and qualified not in seen:
+        seen.add(qualified)
+        qualified = reexports[qualified]
+    return qualified
+
+
+# =============================================================================
+# Recipes
+# =============================================================================
+
+
+def render_command(
+    command: str,
+    *,
+    inputs: Mapping[str, str],
+    decisions: Mapping[str, str],
+    output: str,
+) -> str:
+    """Substitute a recipe command's placeholders.
+
+    The grammar ``_validate_command_template`` checks: ``{output}`` is
+    where the output is written, ``{inputs}`` is every input's value in
+    declaration order, and ``{inputs.<id>}`` / ``{decisions.<id>}`` are one
+    of each. ``{{`` and ``}}`` are literal braces.
+
+    Args:
+        command: The command template as the spec declares it.
+        inputs: Declared input id → the value to substitute, in
+            declaration order.
+        decisions: Decision id → the option this universe chose, by the
+            local id the recipe writes.
+        output: Where the output is written.
+
+    Returns:
+        The command with every placeholder substituted.
+
+    Raises:
+        ValueError: On an unknown placeholder, a reference the output does
+            not declare, or a format spec. Substituting nothing silently
+            would produce a command that runs and means something else.
+    """
+    pieces: list[str] = []
+    available = {"inputs": inputs, "decisions": decisions}
+    for literal, name, spec, conversion in _FORMATTER.parse(command):
+        pieces.append(literal)
+        if name is None:
+            continue
+        if spec or conversion:
+            raise ValueError(f"command placeholder '{{{name}}}' takes no format spec")
+        if name == "output":
+            pieces.append(output)
+            continue
+        if name == "inputs":
+            pieces.append(" ".join(inputs.values()))
+            continue
+        head, dot, tail = name.partition(".")
+        if not dot or head not in available:
+            raise ValueError(
+                f"unknown command placeholder '{{{name}}}' (use {{inputs}}, "
+                "{inputs.<id>}, {decisions.<id>}, or {output})"
+            )
+        if tail not in available[head]:
+            raise ValueError(
+                f"command placeholder '{{{name}}}' references undeclared "
+                f"{head[:-1]} '{tail}' (add it to Output.{head})"
+            )
+        pieces.append(available[head][tail])
+    return "".join(pieces)

--- a/src/astra/resolve.py
+++ b/src/astra/resolve.py
@@ -33,12 +33,14 @@ be the same duplication this module exists to remove.
 
 from __future__ import annotations
 
+import logging
 import string
 from collections.abc import Iterator, Mapping
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
-from astra.helpers import is_condition_met, parse_from_path
+from astra.helpers import external_spec_path, is_condition_met, load_yaml, parse_from_path
 
 __all__ = [
     "ResolvedInput",
@@ -49,6 +51,8 @@ __all__ = [
     "resolve_outputs",
     "resolve_universe",
 ]
+
+logger = logging.getLogger(__name__)
 
 _FORMATTER = string.Formatter()
 
@@ -102,7 +106,11 @@ def _descend(node: Mapping[str, Any], scope: Scope) -> Iterator[tuple[Scope, dic
 # =============================================================================
 
 
-def resolve_universe(data: Mapping[str, Any], universe: Mapping[str, Any]) -> dict[str, str]:
+def resolve_universe(
+    data: Mapping[str, Any],
+    universe: Mapping[str, Any],
+    base_path: Path | None = None,
+) -> dict[str, str]:
     """Resolve a universe into every decision it settles, by qualified id.
 
     Three things are applied that a universe file does not state outright.
@@ -113,17 +121,50 @@ def resolve_universe(data: Mapping[str, Any], universe: Mapping[str, Any]) -> di
     decisions come from the ``analyses.<id>.decisions`` block of the same
     universe file, nested to whatever depth the tree has.
 
+    A sub-analysis node may also say ``universe: <name>`` instead of
+    listing decisions inline, naming one of the universes in that
+    sub-analysis's own ``universes/`` directory. Loading it needs
+    *base_path*; without one the reference is skipped, since there is
+    nothing to resolve it against.
+
     Args:
         data: The analysis, with external sub-analyses already resolved.
         universe: The universe, as loaded from ``universes/<id>.yaml``.
+        base_path: The directory the analysis was loaded from, needed only
+            to follow a sub-analysis's ``universe:`` reference.
 
     Returns:
         Qualified decision id → chosen option id. Root decisions are
         unqualified; a sub-analysis's are ``"<scope>.<decision_id>"``.
     """
     settled: dict[str, str] = {}
-    _settle(data, universe, (), [], settled)
+    _settle(data, universe, (), [], settled, base_path)
     return settled
+
+
+def _selected_universe(
+    node: Mapping[str, Any],
+    universe_node: Mapping[str, Any],
+    base_path: Path | None,
+) -> Mapping[str, Any]:
+    """Follow a ``universe:`` reference to the file it names.
+
+    Only an external (``path:``) sub-analysis has a ``universes/``
+    directory of its own, so only one can be referred to this way.
+    Anything unresolvable leaves the node as it stands — a missing file is
+    the validator's to report, not this module's to raise on.
+    """
+    name = universe_node.get("universe")
+    sub_path = node.get("path")
+    if not name or not sub_path or base_path is None:
+        return universe_node
+    path = external_spec_path(base_path, str(sub_path)).parent / "universes" / f"{name}.yaml"
+    if not path.is_file():
+        logger.warning(
+            "universe '%s' selected for '%s' but %s does not exist", name, sub_path, path
+        )
+        return universe_node
+    return load_yaml(path)
 
 
 def _settle(
@@ -132,6 +173,7 @@ def _settle(
     scope: Scope,
     chain: list[dict[str, str]],
     settled: dict[str, str],
+    base_path: Path | None,
 ) -> None:
     """Settle one node's decisions, then recurse into its sub-analyses.
 
@@ -178,7 +220,11 @@ def _settle(
         if not isinstance(sub, dict):
             continue
         sub_universe = (universe_node.get("analyses") or {}).get(str(sub_id)) or {}
-        _settle(sub, sub_universe, (*scope, str(sub_id)), [*chain, here], settled)
+        sub_universe = _selected_universe(sub, sub_universe, base_path)
+        sub_base = base_path
+        if base_path is not None and sub.get("path"):
+            sub_base = external_spec_path(base_path, str(sub["path"])).parent
+        _settle(sub, sub_universe, (*scope, str(sub_id)), [*chain, here], settled, sub_base)
 
 
 # =============================================================================
@@ -226,7 +272,11 @@ class ResolvedOutput:
     reexports: str | None
 
 
-def resolve_outputs(data: Mapping[str, Any], universe: Mapping[str, Any]) -> list[ResolvedOutput]:
+def resolve_outputs(
+    data: Mapping[str, Any],
+    universe: Mapping[str, Any],
+    base_path: Path | None = None,
+) -> list[ResolvedOutput]:
     """Resolve every output this universe produces, anywhere in the tree.
 
     Outputs whose ``when:`` condition does not hold in this universe are
@@ -237,11 +287,13 @@ def resolve_outputs(data: Mapping[str, Any], universe: Mapping[str, Any]) -> lis
     Args:
         data: The analysis, with external sub-analyses already resolved.
         universe: The universe, as loaded from ``universes/<id>.yaml``.
+        base_path: The directory the analysis was loaded from, needed only
+            to follow a sub-analysis's ``universe:`` reference.
 
     Returns:
         Every active output, root scope first, in declaration order.
     """
-    settled = resolve_universe(data, universe)
+    settled = resolve_universe(data, universe, base_path)
     nodes = dict(iter_analysis_nodes(data))
     resolved: list[ResolvedOutput] = []
     reexports: dict[str, str] = {}

--- a/src/astra/validation/semantic.py
+++ b/src/astra/validation/semantic.py
@@ -12,6 +12,7 @@ from typing import Any
 
 from astra.helpers import (
     _collect_node_decisions,
+    ancestor_at,
     get_input_ids,
     get_output_ids,
     is_condition_met,
@@ -171,15 +172,7 @@ def validate_analysis(data: dict[str, Any], base_path: Path | None = None) -> li
         _validate_insight_artifacts(data.get("findings") or {}, output_ids, "", "findings")
     )
 
-    # Collect qualified sub-analysis output IDs so root recipes can
-    # reference them (e.g. ``inputs: [hod_fitting.galaxy_mesh]``).
-    sub_analyses = data.get("analyses") or {}
-    sub_output_ids: set[str] = set()
-    for analysis_id, analysis_node in sub_analyses.items():
-        for out in analysis_node.get("outputs") or []:
-            out_id = out.get("id")
-            if out_id:
-                sub_output_ids.add(f"{analysis_id}.{out_id}")
+    sub_output_ids = _sub_output_ids(data)
 
     # `from:` re-exports must be checked before output dependencies, which
     # rely on knowing which output ids are real.
@@ -197,7 +190,7 @@ def validate_analysis(data: dict[str, Any], base_path: Path | None = None) -> li
 
     # Validate output when conditions
     errors.extend(_validate_output_when(outputs, root_decisions, ""))
-    for analysis_id, analysis_node in sub_analyses.items():
+    for analysis_id, analysis_node in (data.get("analyses") or {}).items():
         errors.extend(
             _validate_analysis_node(
                 analysis_id,
@@ -301,7 +294,7 @@ def _validate_analysis_node(
         up, segments = parsed
         if up <= 0 or len(segments) != 1:
             continue
-        target_scope = _resolve_ancestor_scope(ancestor_chain, up)
+        target_scope = ancestor_at(ancestor_chain, up)
         if target_scope is None:
             continue
         target_decisions = target_scope.get("decisions") or {}
@@ -334,15 +327,8 @@ def _validate_analysis_node(
         )
     )
 
-    # Sub-analysis output IDs are exposed as qualified ids so this node's
-    # outputs can declare them as inputs (e.g. ``inputs: [child.out]``).
     sub_analyses = node.get("analyses") or {}
-    sub_output_ids: set[str] = set()
-    for sub_id, sub_node in sub_analyses.items():
-        for out in sub_node.get("outputs") or []:
-            out_id = out.get("id")
-            if out_id:
-                sub_output_ids.add(f"{sub_id}.{out_id}")
+    sub_output_ids = _sub_output_ids(node)
 
     errors.extend(
         _validate_output_dependencies(
@@ -366,6 +352,20 @@ def _validate_analysis_node(
         )
 
     return errors
+
+
+def _sub_output_ids(node: dict[str, Any]) -> set[str]:
+    """The qualified ids a node's outputs may name as inputs.
+
+    A sub-analysis's outputs are exposed one level up as ``child.out_id``
+    (e.g. ``inputs: [hod_fitting.galaxy_mesh]``), which is how an output
+    consumes what a sub-analysis produces without a re-export.
+    """
+    return {
+        f"{sub_id}.{out_id}"
+        for sub_id, sub_node in (node.get("analyses") or {}).items()
+        for out_id in get_output_ids(sub_node)
+    }
 
 
 def _validate_outputs_from(
@@ -812,21 +812,6 @@ def _detect_output_cycle(dep_graph: dict[str, list[str]]) -> list[str] | None:
     return None
 
 
-def _resolve_ancestor_scope(
-    ancestor_chain: list[dict[str, Any]],
-    up_levels: int,
-) -> dict[str, Any] | None:
-    """Walk ``up_levels`` scopes up from the current node.
-
-    ``ancestor_chain`` is ordered root-first: ``ancestor_chain[-1]`` is the
-    immediate parent. Returns the target scope, or ``None`` if the chain is
-    not deep enough.
-    """
-    if up_levels <= 0 or up_levels > len(ancestor_chain):
-        return None
-    return ancestor_chain[len(ancestor_chain) - up_levels]
-
-
 def _validate_decision_from(
     decision_id: str,
     ref: str,
@@ -858,7 +843,7 @@ def _validate_decision_from(
             "lift the decision to a common ancestor instead)"
         )
 
-    target_scope = _resolve_ancestor_scope(ancestor_chain, up)
+    target_scope = ancestor_at(ancestor_chain, up)
     if target_scope is None:
         return _error(
             f"Decision.from '{ref}' escapes {up} level(s) but only "
@@ -905,7 +890,7 @@ def _validate_option_insight_ref(
         target_insights = prior_insights
         scope_desc = "this node's prior_insights"
     else:
-        target_scope = _resolve_ancestor_scope(ancestor_chain, up)
+        target_scope = ancestor_at(ancestor_chain, up)
         if target_scope is None:
             return _error(
                 f"Option insight '{ref}' escapes {up} level(s) but only "
@@ -951,7 +936,7 @@ def _validate_input_from(
             "consume sub outputs via Output re-export)"
         )
 
-    target_scope = _resolve_ancestor_scope(ancestor_chain, up)
+    target_scope = ancestor_at(ancestor_chain, up)
     if target_scope is None:
         return _error(
             f"Input.from '{ref}' escapes {up} level(s) but only "
@@ -1222,9 +1207,9 @@ def _validate_universe_node(
         if up <= 0 or len(segments) != 1:
             continue
         # The ancestor universe is `up` levels above us in the universe chain.
-        if up > len(ancestor_universe_chain):
+        target_universe = ancestor_at(ancestor_universe_chain, up)
+        if target_universe is None:
             continue
-        target_universe = ancestor_universe_chain[len(ancestor_universe_chain) - up]
         target_decision_id = segments[0]
         if target_decision_id in target_universe:
             effective_decisions[decision_id] = target_universe[target_decision_id]

--- a/src/astra/validation/semantic.py
+++ b/src/astra/validation/semantic.py
@@ -6,7 +6,6 @@ using dict-based data structures loaded from YAML files.
 
 from __future__ import annotations
 
-import re
 import string
 from pathlib import Path
 from typing import Any
@@ -17,6 +16,7 @@ from astra.helpers import (
     get_output_ids,
     is_condition_met,
     load_yaml,
+    parse_from_path,
     resolve_analysis_tree,
 )
 
@@ -38,52 +38,15 @@ class SemanticError:
 
 
 # ---------------------------------------------------------------------------
-# `from:` path grammar
+# `from:` direction restrictions
 # ---------------------------------------------------------------------------
 #
-# A unified path expression that any `from:` slot can take:
+# The path grammar itself is `helpers.parse_from_path`. Which directions a
+# slot may take is this module's to enforce, per slot:
 #
-#   ../id              -- escape one scope upward, then `id`
-#   ../../id           -- escape two scopes upward, then `id`
-#   ../scope.id        -- escape upward, then descend into a named child
-#   scope.id           -- descend from current scope into a named child
-#   scope.sub.id       -- descend through nested children
-#
-# Direction restrictions are applied per-slot by the caller:
 #   Input.from    : up, or up-then-into-sibling
 #   Output.from   : down (re-export)
 #   Decision.from : up only
-#
-# The Pydantic schema validator already enforces the regex grammar at load
-# time; the helper here is for resolution against the actual analysis tree.
-
-_ID_PATTERN = re.compile(r"^[a-z][a-z0-9_]*$")
-
-
-def _parse_from_path(ref: str) -> tuple[int, list[str]] | None:
-    """Parse a `from:` path into ``(up_levels, descent_segments)``.
-
-    Returns ``None`` if the path is malformed (empty segments, invalid
-    identifier characters, etc.). Examples:
-
-        "../id"               -> (1, ["id"])
-        "../../id"            -> (2, ["id"])
-        "../scope.id"         -> (1, ["scope", "id"])
-        "scope.id"            -> (0, ["scope", "id"])
-        "scope.sub.id"        -> (0, ["scope", "sub", "id"])
-    """
-    up = 0
-    rest = ref
-    while rest.startswith("../"):
-        up += 1
-        rest = rest[3:]
-    if not rest or rest.startswith(".") or rest.endswith("."):
-        return None
-    segments = rest.split(".")
-    for seg in segments:
-        if not _ID_PATTERN.match(seg):
-            return None
-    return (up, segments)
 
 
 def _check_path_exclusivity(
@@ -332,7 +295,7 @@ def _validate_analysis_node(
         ref = decision.get("from")
         if not ref:
             continue
-        parsed = _parse_from_path(ref)
+        parsed = parse_from_path(ref)
         if parsed is None:
             continue
         up, segments = parsed
@@ -880,7 +843,7 @@ def _validate_decision_from(
     def _error(message: str) -> list[SemanticError]:
         return [SemanticError("INVALID_DECISION_FROM", message, decision_path)]
 
-    parsed = _parse_from_path(ref)
+    parsed = parse_from_path(ref)
     if parsed is None:
         return _error(f"Decision.from '{ref}' has invalid path syntax")
     up, segments = parsed
@@ -927,7 +890,7 @@ def _validate_option_insight_ref(
     def _error(message: str) -> list[SemanticError]:
         return [SemanticError("INVALID_INSIGHT_REF", message, ref_path)]
 
-    parsed = _parse_from_path(ref)
+    parsed = parse_from_path(ref)
     if parsed is None:
         return _error(f"Option insight '{ref}' has invalid path syntax")
     up, segments = parsed
@@ -977,7 +940,7 @@ def _validate_input_from(
     def _error(message: str) -> list[SemanticError]:
         return [SemanticError("INVALID_FROM", message, node_path)]
 
-    parsed = _parse_from_path(ref)
+    parsed = parse_from_path(ref)
     if parsed is None:
         return _error(f"Input.from '{ref}' has invalid path syntax")
     up, segments = parsed
@@ -1037,7 +1000,7 @@ def _validate_output_from(
     def _error(message: str) -> list[SemanticError]:
         return [SemanticError("INVALID_OUTPUT_FROM", message, output_path)]
 
-    parsed = _parse_from_path(ref)
+    parsed = parse_from_path(ref)
     if parsed is None:
         return _error(f"Output.from '{ref}' has invalid path syntax")
     up, segments = parsed
@@ -1252,7 +1215,7 @@ def _validate_universe_node(
     effective_decisions = dict(universe_decisions)
     for decision_id in from_decision_ids:
         ref = all_analysis_decisions[decision_id].get("from", "")
-        parsed = _parse_from_path(ref)
+        parsed = parse_from_path(ref)
         if parsed is None:
             continue
         up, segments = parsed

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -231,3 +231,46 @@ class TestRenderCommand:
         and means something else."""
         with pytest.raises(ValueError):
             render_command(command, inputs={"data": "d"}, decisions={"seed": "s"}, output="o")
+
+
+class TestSelectedUniverse:
+    """A sub-analysis node may name one of its *own* universes instead of
+    listing decisions inline. Loading that file is what `semantic.py` says
+    is "done by the caller/resolver"."""
+
+    def _project(self, tmp_path: Path) -> tuple[dict, Path]:
+        sub = tmp_path / "stage"
+        (sub / "universes").mkdir(parents=True)
+        (sub / "astra.yaml").write_text(
+            "id: stage\nversion: '1.0'\nname: Stage\n"
+            "decisions:\n  method:\n    options:\n      pca: {}\n      mlp: {}\n"
+            "outputs:\n  - id: features\n    type: data\n    decisions: [method]\n"
+            "    recipe:\n      command: run --method {decisions.method}\n"
+        )
+        (sub / "universes" / "fast.yaml").write_text("id: fast\ndecisions:\n  method: pca\n")
+        (sub / "universes" / "deep.yaml").write_text("id: deep\ndecisions:\n  method: mlp\n")
+        data = {"analyses": {"stage": {"path": "stage", **load_yaml(sub / "astra.yaml")}}}
+        return data, tmp_path
+
+    def test_the_named_universe_supplies_the_decisions(self, tmp_path: Path):
+        data, base = self._project(tmp_path)
+        chosen = {"analyses": {"stage": {"universe": "deep"}}}
+        assert resolve_universe(data, chosen, base) == {"stage.method": "mlp"}
+
+    def test_a_different_name_selects_differently(self, tmp_path: Path):
+        data, base = self._project(tmp_path)
+        chosen = {"analyses": {"stage": {"universe": "fast"}}}
+        assert resolve_universe(data, chosen, base) == {"stage.method": "pca"}
+        outputs = by_id(resolve_outputs(data, chosen, base))
+        assert outputs["stage.features"].decisions == {"method": "pca"}
+
+    def test_without_a_base_path_the_reference_is_skipped(self, tmp_path: Path):
+        """There is nothing to resolve it against, and inventing a root
+        would be worse than leaving the decision unsettled."""
+        data, _ = self._project(tmp_path)
+        assert resolve_universe(data, {"analyses": {"stage": {"universe": "deep"}}}) == {}
+
+    def test_inline_decisions_still_work_beside_it(self, tmp_path: Path):
+        data, base = self._project(tmp_path)
+        chosen = {"analyses": {"stage": {"decisions": {"method": "pca"}}}}
+        assert resolve_universe(data, chosen, base) == {"stage.method": "pca"}

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 import pytest
 
-from astra.helpers import load_yaml, parse_from_path
+from astra.helpers import iter_sub_analyses, load_yaml, parse_from_path
 from astra.resolve import (
     iter_analysis_nodes,
     render_command,
@@ -60,6 +60,24 @@ class TestIterAnalysisNodes:
         node = nodes[("classification",)]
         assert {o["id"] for o in node["outputs"]} == {"predictions", "accuracy"}
 
+    def test_iter_sub_analyses_is_the_same_walk_without_the_scope(self, pipeline: dict):
+        """Two views of one walker, so what counts as a sub-analysis cannot
+        drift between the tooling that needs the scope and the tooling that
+        does not."""
+        scoped = [node for scope, node in iter_analysis_nodes(pipeline) if scope]
+        assert list(iter_sub_analyses(pipeline)) == scoped
+
+    def test_a_resolved_externals_children_are_reached_too(self):
+        """An external sub-analysis is descended into like any other: before
+        `resolve_analysis_tree` it has nothing to descend into, and after it
+        that content is the sub-analysis."""
+        data = {"analyses": {"stage": {"path": "stage", "analyses": {"inner": {"id": "inner"}}}}}
+        assert [scope for scope, _ in iter_analysis_nodes(data)] == [
+            (),
+            ("stage",),
+            ("stage", "inner"),
+        ]
+
 
 class TestResolveUniverse:
     def test_a_sub_analysis_decision_is_qualified(self, pipeline: dict):
@@ -74,6 +92,29 @@ class TestResolveUniverse:
         assert settled["random_seed"] == "seed_42"
         assert settled["feature_extraction.seed"] == "seed_42"
         assert settled["classification.split"] == settled["test_split"]
+
+    def test_a_conditional_decision_declared_before_its_condition_is_kept(self):
+        """`when:` reads the whole universe, not the decisions that happen
+        to be declared above it — which is what the validator compares
+        against, so the two must agree on what a universe settles."""
+        spec = {
+            "decisions": {
+                "trees": {"when": "model.forest", "options": {"fifty": {}, "hundred": {}}},
+                "model": {"options": {"forest": {}, "logistic": {}}},
+            }
+        }
+        chosen = {"decisions": {"model": "forest", "trees": "fifty"}}
+        assert resolve_universe(spec, chosen) == {"model": "forest", "trees": "fifty"}
+
+    def test_an_unmet_condition_still_drops_the_decision(self):
+        spec = {
+            "decisions": {
+                "trees": {"when": "model.forest", "options": {"fifty": {}}},
+                "model": {"options": {"forest": {}, "logistic": {}}},
+            }
+        }
+        chosen = {"decisions": {"model": "logistic", "trees": "fifty"}}
+        assert resolve_universe(spec, chosen) == {"model": "logistic"}
 
     def test_universes_differ_where_the_universe_file_differs(self, pipeline: dict):
         baseline = resolve_universe(pipeline, universe("baseline"))
@@ -133,6 +174,53 @@ class TestResolveOutputs:
         found = by_id(resolve_outputs(pipeline, universe("baseline")))
         (predictions,) = found["classification.accuracy"].inputs
         assert predictions.produced_by == "classification.predictions"
+
+    def test_an_input_naming_a_sub_analysis_output_resolves_to_it(self):
+        """`inputs: [stage.features]` is the qualified form the validator
+        accepts alongside a plain sibling id — a consumer building a DAG
+        loses the edge if it does not resolve."""
+        spec = {
+            "outputs": [{"id": "report", "inputs": ["stage.features"], "recipe": {"command": "x"}}],
+            "analyses": {"stage": {"outputs": [{"id": "features", "recipe": {"command": "y"}}]}},
+        }
+        found = by_id(resolve_outputs(spec, {}))
+        (features,) = found["report"].inputs
+        assert features.id == "stage.features"
+        assert features.produced_by == "stage.features"
+        assert features.source is None
+
+    def test_a_qualified_input_follows_the_re_export_beneath_it(self):
+        spec = {
+            "outputs": [{"id": "report", "inputs": ["stage.features"], "recipe": {"command": "x"}}],
+            "analyses": {
+                "stage": {
+                    "outputs": [{"id": "features", "from": "inner.features"}],
+                    "analyses": {
+                        "inner": {"outputs": [{"id": "features", "recipe": {"command": "y"}}]}
+                    },
+                }
+            },
+        }
+        (features,) = by_id(resolve_outputs(spec, {}))["report"].inputs
+        assert features.produced_by == "stage.inner.features"
+
+    def test_an_ancestor_alias_reads_that_scopes_inputs_not_its_outputs(self):
+        """`from: ../data` names an ancestor *input*, which is what
+        `_validate_input_from` checks it against — a same-named output
+        there must not stand in for it and lose the source."""
+        spec = {
+            "inputs": [{"id": "data", "source": "s3://raw"}],
+            "outputs": [{"id": "data", "recipe": {"command": "x"}}],
+            "analyses": {
+                "stage": {
+                    "inputs": [{"id": "d", "from": "../data"}],
+                    "outputs": [{"id": "fit", "inputs": ["d"], "recipe": {"command": "y"}}],
+                }
+            },
+        }
+        (d,) = by_id(resolve_outputs(spec, {}))["stage.fit"].inputs
+        assert d.source == "s3://raw"
+        assert d.produced_by is None
 
     def test_decisions_are_keyed_by_the_id_the_recipe_writes(self, pipeline: dict):
         """A recipe inside a sub-analysis writes `{decisions.method}`, not
@@ -202,6 +290,50 @@ class TestConditionalOutputs:
         assert "fe.loadings" not in by_id(resolve_outputs(spec, other))
 
 
+class TestConditionalReExports:
+    """A re-export carries no `when:` of its own, so it is exactly as
+    conditional as the output it stands for. Returning one whose target was
+    conditioned away hands a runner a target it cannot build."""
+
+    SPEC = {
+        "outputs": [{"id": "plot", "from": "stage.plot"}],
+        "analyses": {
+            "stage": {
+                "decisions": {"m": {"options": {"a": {}, "b": {}}}},
+                "outputs": [{"id": "plot", "when": "m.a", "recipe": {"command": "x"}}],
+            }
+        },
+    }
+
+    def test_the_re_export_goes_when_its_target_goes(self):
+        chosen = {"analyses": {"stage": {"decisions": {"m": "b"}}}}
+        assert by_id(resolve_outputs(self.SPEC, chosen)) == {}
+
+    def test_and_stays_when_its_target_stays(self):
+        chosen = {"analyses": {"stage": {"decisions": {"m": "a"}}}}
+        found = by_id(resolve_outputs(self.SPEC, chosen))
+        assert set(found) == {"plot", "stage.plot"}
+        assert found["plot"].reexports == "stage.plot"
+
+    def test_dropping_cascades_through_a_chain_of_re_exports(self):
+        spec = {
+            "outputs": [{"id": "plot", "from": "stage.plot"}],
+            "analyses": {
+                "stage": {
+                    "outputs": [{"id": "plot", "from": "inner.plot"}],
+                    "analyses": {
+                        "inner": {
+                            "decisions": {"m": {"options": {"a": {}, "b": {}}}},
+                            "outputs": [{"id": "plot", "when": "m.a", "recipe": {"command": "x"}}],
+                        }
+                    },
+                }
+            },
+        }
+        chosen = {"analyses": {"stage": {"analyses": {"inner": {"decisions": {"m": "b"}}}}}}
+        assert by_id(resolve_outputs(spec, chosen)) == {}
+
+
 class TestRenderCommand:
     def test_every_placeholder_form(self):
         rendered = render_command(
@@ -269,6 +401,14 @@ class TestSelectedUniverse:
         would be worse than leaving the decision unsettled."""
         data, _ = self._project(tmp_path)
         assert resolve_universe(data, {"analyses": {"stage": {"universe": "deep"}}}) == {}
+
+    def test_an_empty_universe_file_leaves_the_node_as_it_stands(self, tmp_path: Path):
+        """A file that parses to `None` is the validator's to report; this
+        module promises not to raise on anything unresolvable."""
+        data, base = self._project(tmp_path)
+        (base / "stage" / "universes" / "blank.yaml").write_text("# nothing here\n")
+        chosen = {"analyses": {"stage": {"universe": "blank"}}}
+        assert resolve_universe(data, chosen, base) == {}
 
     def test_inline_decisions_still_work_beside_it(self, tmp_path: Path):
         data, base = self._project(tmp_path)

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -1,0 +1,233 @@
+"""Tests for `astra.resolve` — what a universe actually produces.
+
+The canonical nested example (`examples/iris_pipeline`) is the fixture
+that matters: it is the only place the whole set of cross-scope rules
+appears together — an inherited decision, an input reaching sideways into
+a sibling sub-analysis, and a root output re-exporting a grandchild's.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from astra.helpers import load_yaml, parse_from_path
+from astra.resolve import (
+    iter_analysis_nodes,
+    render_command,
+    resolve_outputs,
+    resolve_universe,
+)
+
+EXAMPLES = Path(__file__).parent.parent / "examples"
+
+
+@pytest.fixture
+def pipeline() -> dict:
+    return load_yaml(EXAMPLES / "iris_pipeline" / "astra.yaml")
+
+
+def universe(name: str) -> dict:
+    return load_yaml(EXAMPLES / "iris_pipeline" / "universes" / f"{name}.yaml")
+
+
+def by_id(outputs):
+    return {o.id: o for o in outputs}
+
+
+class TestParseFromPath:
+    def test_upward_and_descent(self):
+        assert parse_from_path("../id") == (1, ["id"])
+        assert parse_from_path("../../id") == (2, ["id"])
+        assert parse_from_path("../scope.id") == (1, ["scope", "id"])
+        assert parse_from_path("scope.sub.id") == (0, ["scope", "sub", "id"])
+
+    def test_malformed(self):
+        assert parse_from_path("") is None
+        assert parse_from_path("../") is None
+        assert parse_from_path("a..b") is None
+        assert parse_from_path("Bad.Id") is None
+
+
+class TestIterAnalysisNodes:
+    def test_root_comes_first_with_an_empty_scope(self, pipeline: dict):
+        scopes = [scope for scope, _ in iter_analysis_nodes(pipeline)]
+        assert scopes[0] == ()
+        assert ("feature_extraction",) in scopes
+        assert ("classification",) in scopes
+
+    def test_the_scope_is_what_names_a_nested_id(self, pipeline: dict):
+        nodes = dict(iter_analysis_nodes(pipeline))
+        node = nodes[("classification",)]
+        assert {o["id"] for o in node["outputs"]} == {"predictions", "accuracy"}
+
+
+class TestResolveUniverse:
+    def test_a_sub_analysis_decision_is_qualified(self, pipeline: dict):
+        settled = resolve_universe(pipeline, universe("baseline"))
+        assert settled["feature_extraction.method"] == "pca"
+        assert settled["classification.classifier"] == "logistic"
+
+    def test_an_inherited_decision_takes_the_ancestors_option(self, pipeline: dict):
+        """`seed: from: ../random_seed` — the sub-analysis names it `seed`
+        and never states a value, so nothing but resolution supplies one."""
+        settled = resolve_universe(pipeline, universe("baseline"))
+        assert settled["random_seed"] == "seed_42"
+        assert settled["feature_extraction.seed"] == "seed_42"
+        assert settled["classification.split"] == settled["test_split"]
+
+    def test_universes_differ_where_the_universe_file_differs(self, pipeline: dict):
+        baseline = resolve_universe(pipeline, universe("baseline"))
+        mlp = resolve_universe(pipeline, universe("mlp_svm"))
+        assert baseline["feature_extraction.method"] == "pca"
+        assert mlp["feature_extraction.method"] == "mlp_encoder"
+        assert baseline["random_seed"] == mlp["random_seed"]
+
+    def test_a_conditional_decision_is_left_out_where_it_is_inactive(self):
+        data = {
+            "decisions": {
+                "model": {"options": {"linear": {}, "forest": {}}},
+                "trees": {"when": "model.forest", "options": {"ten": {}, "fifty": {}}},
+            }
+        }
+        active = resolve_universe(data, {"decisions": {"model": "forest", "trees": "fifty"}})
+        assert active == {"model": "forest", "trees": "fifty"}
+        inactive = resolve_universe(data, {"decisions": {"model": "linear", "trees": "fifty"}})
+        assert inactive == {"model": "linear"}
+
+
+class TestResolveOutputs:
+    def test_every_output_in_the_tree_is_returned_qualified(self, pipeline: dict):
+        found = by_id(resolve_outputs(pipeline, universe("baseline")))
+        assert "feature_extraction.features" in found
+        assert "classification.accuracy" in found
+        assert "pipeline_summary" in found
+
+    def test_a_recipe_is_what_marks_an_output_executable(self, pipeline: dict):
+        found = by_id(resolve_outputs(pipeline, universe("baseline")))
+        assert found["classification.accuracy"].command
+        assert found["accuracy"].command is None  # a re-export computes nothing
+
+    def test_a_re_export_names_what_actually_produces_it(self, pipeline: dict):
+        found = by_id(resolve_outputs(pipeline, universe("baseline")))
+        assert found["accuracy"].reexports == "classification.accuracy"
+        assert found["feature_plot"].reexports == "feature_extraction.feature_plot"
+
+    def test_an_input_reaching_into_a_sibling_resolves_to_that_output(self, pipeline: dict):
+        """`classification.features` is `from: ../feature_extraction.features`
+        — the seam between the two stages, and the whole point of the
+        example."""
+        found = by_id(resolve_outputs(pipeline, universe("baseline")))
+        (features,) = found["classification.predictions"].inputs
+        assert features.id == "features"
+        assert features.produced_by == "feature_extraction.features"
+        assert features.source is None
+
+    def test_an_input_aliasing_an_ancestors_input_inherits_its_source(self, pipeline: dict):
+        """`raw_features` is `from: ../iris_data`, which carries the source."""
+        found = by_id(resolve_outputs(pipeline, universe("baseline")))
+        (raw,) = found["feature_extraction.features"].inputs
+        assert raw.source == "sklearn.datasets.load_iris"
+        assert raw.produced_by is None
+
+    def test_an_input_naming_a_sibling_output_resolves_within_the_scope(self, pipeline: dict):
+        found = by_id(resolve_outputs(pipeline, universe("baseline")))
+        (predictions,) = found["classification.accuracy"].inputs
+        assert predictions.produced_by == "classification.predictions"
+
+    def test_decisions_are_keyed_by_the_id_the_recipe_writes(self, pipeline: dict):
+        """A recipe inside a sub-analysis writes `{decisions.method}`, not
+        the qualified id — so that is the key it gets."""
+        found = by_id(resolve_outputs(pipeline, universe("mlp_svm")))
+        assert found["feature_extraction.features"].decisions == {
+            "method": "mlp_encoder",
+            "n_components": "two",
+            "seed": "seed_42",
+        }
+
+    def test_the_flat_example_resolves_too(self):
+        root = EXAMPLES / "iris"
+        data = load_yaml(root / "astra.yaml")
+        found = by_id(resolve_outputs(data, load_yaml(root / "universes" / "baseline.yaml")))
+        assert found["trained_output"].command
+        assert all(o.scope == () for o in found.values())
+
+
+class TestConditionalOutputs:
+    """`when:` on an output, which decides whether it exists at all here."""
+
+    SPEC = {
+        "decisions": {"method": {"options": {"bayesian": {}, "frequentist": {}}}},
+        "outputs": [
+            {"id": "always", "recipe": {"command": "echo a"}},
+            {"id": "only_bayes", "when": "method.bayesian", "recipe": {"command": "echo b"}},
+            {"id": "not_bayes", "when": "~method.bayesian", "recipe": {"command": "echo c"}},
+        ],
+    }
+
+    def test_an_inactive_output_is_not_produced(self):
+        found = by_id(resolve_outputs(self.SPEC, {"decisions": {"method": "frequentist"}}))
+        assert set(found) == {"always", "not_bayes"}
+
+    def test_the_same_spec_produces_the_other_one_elsewhere(self):
+        found = by_id(resolve_outputs(self.SPEC, {"decisions": {"method": "bayesian"}}))
+        assert set(found) == {"always", "only_bayes"}
+
+    def test_conditions_are_anded(self):
+        spec = {
+            "decisions": {
+                "a": {"options": {"yes": {}, "no": {}}},
+                "b": {"options": {"yes": {}, "no": {}}},
+            },
+            "outputs": [{"id": "both", "when": ["a.yes", "b.yes"], "recipe": {"command": "x"}}],
+        }
+        assert by_id(resolve_outputs(spec, {"decisions": {"a": "yes", "b": "yes"}}))
+        assert not by_id(resolve_outputs(spec, {"decisions": {"a": "yes", "b": "no"}}))
+
+    def test_a_condition_is_read_in_the_scope_that_wrote_it(self):
+        """A sub-analysis's `when: method.pca` names its own decision, not
+        a qualified one — the scope is where the condition is written."""
+        spec = {
+            "analyses": {
+                "fe": {
+                    "decisions": {"method": {"options": {"pca": {}, "mlp": {}}}},
+                    "outputs": [
+                        {"id": "loadings", "when": "method.pca", "recipe": {"command": "x"}}
+                    ],
+                }
+            }
+        }
+        chosen = {"analyses": {"fe": {"decisions": {"method": "pca"}}}}
+        assert "fe.loadings" in by_id(resolve_outputs(spec, chosen))
+        other = {"analyses": {"fe": {"decisions": {"method": "mlp"}}}}
+        assert "fe.loadings" not in by_id(resolve_outputs(spec, other))
+
+
+class TestRenderCommand:
+    def test_every_placeholder_form(self):
+        rendered = render_command(
+            "run {inputs.data} --seed {decisions.seed} --all {inputs} --out {output}",
+            inputs={"data": "data/x.csv", "extra": "data/y.csv"},
+            decisions={"seed": "seed_42"},
+            output="results/baseline/fit",
+        )
+        assert rendered == (
+            "run data/x.csv --seed seed_42 --all data/x.csv data/y.csv --out results/baseline/fit"
+        )
+
+    def test_literal_braces_survive(self):
+        assert render_command("echo {{x}}", inputs={}, decisions={}, output="o") == "echo {x}"
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "run {nonsense}",
+            "run {inputs.missing}",
+            "run {decisions.missing}",
+            "run {output:>10}",
+        ],
+    )
+    def test_a_placeholder_that_cannot_be_filled_is_an_error(self, command: str):
+        """Substituting nothing silently would produce a command that runs
+        and means something else."""
+        with pytest.raises(ValueError):
+            render_command(command, inputs={"data": "d"}, decisions={"seed": "s"}, output="o")


### PR DESCRIPTION
## Why

ASTRA can say whether a spec is **valid** and what ids it **declares**. It cannot say what a spec **means** in a given universe.

So a consumer that needs to act on a spec — run it, visualise it, diff two universes — re-derives scoping, `from:` references, conditional outputs and the recipe grammar for itself. That is how two implementations of one specification start disagreeing, and it is already happening: `lightcone-cli` hand-rolled all of it and gets `examples/iris_pipeline` wrong (it cannot resolve `from: ../feature_extraction.features`, never reads `analyses.<id>.decisions` from a universe file, and ignores `when:` on outputs entirely).

Every rule in this PR is **already specified and already enforced** by `validation/semantic.py`. What was missing is the resolving half — the validator answers "is this legal?", nothing answered "so what is it?".

## What

New module `astra/resolve.py`:

| | |
|---|---|
| `iter_analysis_nodes(data)` | walks the tree yielding each node **with its scope**, so anything declared in a sub-analysis can be named unambiguously |
| `resolve_universe(data, universe)` | every decision settled, by qualified id — applying `from:` inheritance, `when:` conditions, and nested `analyses.<id>.decisions` blocks |
| `resolve_outputs(data, universe)` | the outputs a universe produces, each with its command, its decisions keyed by the local id the recipe writes, and its inputs resolved to the output that produces them or an external source |
| `render_command(...)` | substitutes the placeholders `_validate_command_template` already validates |

`iter_sub_analyses` could not serve the first row: it drops the analysis ids, and it stops at `path:` sub-analyses even after `resolve_analysis_tree` has inlined their content (the `path` key survives resolution).

On `examples/iris_pipeline`, `resolve_outputs` now yields:

```
accuracy                          [re-export] -> classification.accuracy
feature_plot                      [re-export] -> feature_extraction.feature_plot
pipeline_summary                  [recipe]
feature_extraction.features       [recipe]  decisions={method: pca, n_components: two, seed: seed_42}
                                            input raw_features  source=sklearn.datasets.load_iris
feature_extraction.feature_plot   [recipe]  input features  produced_by=feature_extraction.features
classification.predictions        [recipe]  input features  produced_by=feature_extraction.features
classification.accuracy           [recipe]  input predictions  produced_by=classification.predictions
```

Note `feature_extraction.seed` → `seed_42` inherited from the root's `random_seed`, and `classification.features` reaching sideways into a sibling sub-analysis.

## Design notes

**Validity is assumed.** These functions resolve a spec that passes `astra validate`; they do not re-report validation errors. An input nothing supplies resolves to a `ResolvedInput` with neither `produced_by` nor `source`, rather than raising — diagnosis belongs to the validator, and duplicating it here would be the same duplication this module exists to remove.

**Qualified ids** are the scope path and local id joined with `.`. Unambiguous because ids match `^[a-z][a-z0-9_]*$`.

**Conditional outputs are omitted, not flagged.** `resolve_outputs` leaves out an output whose `when:` does not hold — that is what makes it conditional. `is_condition_met` stays public for anyone wanting the raw test.

**One parser, not two.** `_parse_from_path` moves to `helpers.parse_from_path`, so the validator and the resolver share the grammar instead of holding a copy each. The direction restrictions (Input up, Output down, Decision up-only) stay in `semantic.py`, which is where they are enforced.

## Tests

26 new tests in `tests/test_resolve.py`, driven mainly by `examples/iris_pipeline` — the only fixture where the cross-scope rules appear together. Existing suite unchanged and green (247 passed, 21 skipped); `astra validate` still passes on both examples.

`ruff check`, `ruff format`, `mypy src/` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GaahDTd6djz9PCm1Rh6SP4