### PR TITLE
Support Output.format from astra-spec 0.0.14

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,9 @@ ASTRA/
 1. **Validation** (`src/astra/validation/`)
    - `schema.py`: Structural validation using Pydantic models from `astra.datamodel`
    - `semantic.py`: Cross-reference validation (IDs, constraints, universe coverage)
+   - `schema.collect_recommendations`: advisory pass for fields the schema marks
+     `recommended` rather than `required` (currently `Output.format`, mandatory
+     from ASTRA 0.1.0). Reported as warnings; never affects the exit code.
 
 2. **CLI** (`src/astra/cli.py`)
    - Built with Click and Rich

--- a/examples/iris/astra.yaml
+++ b/examples/iris/astra.yaml
@@ -27,6 +27,7 @@ inputs:
 outputs:
   - id: trained_output
     type: data
+    format: pkl
     description: Best performing classifier
     decisions: [scaling, model, test_size, random_seed]
     recipe:
@@ -40,6 +41,7 @@ outputs:
 
   - id: accuracy
     type: metric
+    format: json
     description: Classification accuracy on held-out test set
     inputs: [trained_output]
     recipe:
@@ -51,6 +53,7 @@ outputs:
 
   - id: f1_score
     type: metric
+    format: json
     description: Macro-averaged F1 score
     inputs: [trained_output]
     recipe:
@@ -62,6 +65,7 @@ outputs:
 
   - id: confusion_matrix
     type: figure
+    format: png
     description: Confusion matrix heatmap
     inputs: [trained_output]
     recipe:
@@ -73,6 +77,7 @@ outputs:
 
   - id: model_comparison
     type: table
+    format: csv
     description: Accuracy by model and preprocessing combination
     inputs: [trained_output]
     recipe:
@@ -84,6 +89,7 @@ outputs:
 
   - id: conclusion
     type: report
+    format: md
     description: Summary of classifier performance and suitability for the application
     inputs: [trained_output]
     recipe:

--- a/examples/iris/astra.yaml
+++ b/examples/iris/astra.yaml
@@ -1,5 +1,5 @@
 id: iris_classification
-version: "0.0.11"
+version: "0.0.14"
 name: Iris Classification Study
 container: python:3.12-slim
 description: |

--- a/examples/iris_pipeline/astra.yaml
+++ b/examples/iris_pipeline/astra.yaml
@@ -1,5 +1,5 @@
 id: iris_pipeline
-version: "0.0.11"
+version: "0.0.14"
 name: Iris Two-Stage Classification
 container: python:3.12-slim
 description: |

--- a/examples/iris_pipeline/astra.yaml
+++ b/examples/iris_pipeline/astra.yaml
@@ -30,6 +30,7 @@ outputs:
 
   - id: pipeline_summary
     type: report
+    format: md
     description: End-to-end comparison of feature extraction methods
     recipe:
       command: python src/summarize.py --out {output}
@@ -74,6 +75,7 @@ analyses:
     outputs:
       - id: features
         type: data
+        format: npy
         description: Transformed feature matrix (n_samples x n_components)
         inputs: [raw_features]
         decisions: [method, n_components, seed]
@@ -88,6 +90,7 @@ analyses:
 
       - id: feature_plot
         type: figure
+        format: png
         description: Scatter plot of extracted features
         inputs: [features]
         decisions: [method, n_components]
@@ -145,6 +148,7 @@ analyses:
     outputs:
       - id: predictions
         type: data
+        format: csv
         description: Predicted class labels for the test set
         inputs: [features]
         decisions: [classifier, split]
@@ -158,6 +162,7 @@ analyses:
 
       - id: accuracy
         type: metric
+        format: json
         description: Classification accuracy on held-out test set
         inputs: [predictions]
         decisions: [classifier, split]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,9 +40,6 @@ classifiers = [
 ]
 
 dependencies = [
-    # >=0.0.14: first release with Output.format, which the scaffold emits and
-    # the recommended-field check reports on. Earlier models reject it outright
-    # (the generated Pydantic models forbid extra fields).
     "astra-spec>=0.0.14",
     "linkml-runtime>=1.8",
     "click>=8.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,10 @@ classifiers = [
 ]
 
 dependencies = [
-    # >=0.0.13: first release shipping the packaged agent guide (astra guide)
-    "astra-spec>=0.0.13",
+    # >=0.0.14: first release with Output.format, which the scaffold emits and
+    # the recommended-field check reports on. Earlier models reject it outright
+    # (the generated Pydantic models forbid extra fields).
+    "astra-spec>=0.0.14",
     "linkml-runtime>=1.8",
     "click>=8.0",
     "pydantic>=2.0",

--- a/src/astra/cli.py
+++ b/src/astra/cli.py
@@ -32,6 +32,7 @@ from astra.helpers import (
 from astra.scaffold import create_boilerplate
 from astra.validation.schema import (
     check_spec_version,
+    collect_recommendations,
     validate_analysis_data,
     validate_universe_data,
 )
@@ -452,6 +453,13 @@ def _validate_one(
         raise SystemExit(1)
 
     console.print("[green]✓[/green] Semantic validation passed")
+
+    # Recommended-but-absent fields. Not errors: the analysis is valid, and the
+    # exit code is unaffected. They are surfaced so an author hears about a
+    # field before the release that makes it mandatory, not after.
+    if not is_universe:
+        for recommendation in collect_recommendations(data):
+            console.print(f"[yellow]⚠[/yellow]  [yellow]{escape(recommendation)}[/yellow]")
 
     # Evidence verification (for analysis files with prior insights and/or findings)
     if not is_universe and not skip_evidence:

--- a/src/astra/cli.py
+++ b/src/astra/cli.py
@@ -27,6 +27,7 @@ from astra.helpers import (
     get_outputs,
     iter_sub_analyses,
     load_yaml,
+    resolve_analysis_tree,
     save_yaml,
 )
 from astra.scaffold import create_boilerplate
@@ -457,8 +458,12 @@ def _validate_one(
     # Recommended-but-absent fields. Not errors: the analysis is valid, and the
     # exit code is unaffected. They are surfaced so an author hears about a
     # field before the release that makes it mandatory, not after.
+    #
+    # Walked over the *resolved* tree, as semantic validation is: an external
+    # `path:` sub-analysis is a bare stub here otherwise, and it is skipped as
+    # a standalone target too, so its outputs would be checked nowhere at all.
     if not is_universe:
-        for recommendation in collect_recommendations(data):
+        for recommendation in collect_recommendations(resolve_analysis_tree(data, file.parent)):
             console.print(f"[yellow]⚠[/yellow]  [yellow]{escape(recommendation)}[/yellow]")
 
     # Evidence verification (for analysis files with prior insights and/or findings)

--- a/src/astra/resolve.py
+++ b/src/astra/resolve.py
@@ -256,6 +256,11 @@ class ResolvedOutput:
     scope: Scope
     #: The output as the spec declares it.
     definition: dict[str, Any]
+    #: The declared serialization (``png``, ``csv``, ``parquet``, …), or
+    #: ``None`` when the spec omits it. A re-export inherits the format of
+    #: the output it stands for, so this is the terminal output's format,
+    #: not the (necessarily absent) one on the alias.
+    format: str | None
     #: ``recipe.command``, or ``None`` for a re-export or a declared-only
     #: output. This is the test of whether the output is executable.
     command: str | None
@@ -320,12 +325,14 @@ def resolve_outputs(
                 _resolve_input(tree, scope, str(name)) for name in declared.get("inputs") or []
             ),
             reexports=reexports.get(qualified),
+            format=None,  # filled in by _follow, which knows the terminal output
         )
         for qualified, scope, declared, local in declared_here
         if qualified in live
     ]
 
-    return [_follow(out, reexports) for out in resolved]
+    definitions = {qualified: declared for qualified, _, declared, _ in declared_here}
+    return [_follow(out, reexports, definitions) for out in resolved]
 
 
 def _live_ids(declared: set[str], reexports: Mapping[str, str]) -> set[str]:
@@ -449,10 +456,19 @@ def _resolve_declared_input(tree: _Index, scope: Scope, name: str) -> ResolvedIn
     return ResolvedInput(id=name, produced_by=None, source=str(source) if source else None)
 
 
-def _follow(out: ResolvedOutput, reexports: Mapping[str, str]) -> ResolvedOutput:
-    """Point every ``produced_by`` past re-exports at what carries the recipe."""
-    if not reexports:
-        return out
+def _follow(
+    out: ResolvedOutput,
+    reexports: Mapping[str, str],
+    definitions: Mapping[str, Mapping[str, Any]],
+) -> ResolvedOutput:
+    """Point every ``produced_by`` past re-exports at what carries the recipe.
+
+    Also settles ``format``: a re-export declares none of its own — the
+    schema forbids it — so it takes the terminal output's.
+    """
+    terminal = _terminal(out.reexports, reexports)
+    source = definitions.get(terminal, out.definition) if terminal else out.definition
+    declared_format = source.get("format")
     inputs = tuple(
         ResolvedInput(id=i.id, produced_by=_terminal(i.produced_by, reexports), source=i.source)
         for i in out.inputs
@@ -464,7 +480,8 @@ def _follow(out: ResolvedOutput, reexports: Mapping[str, str]) -> ResolvedOutput
         command=out.command,
         decisions=out.decisions,
         inputs=inputs,
-        reexports=_terminal(out.reexports, reexports),
+        reexports=terminal,
+        format=str(declared_format) if declared_format else None,
     )
 
 

--- a/src/astra/scaffold.py
+++ b/src/astra/scaffold.py
@@ -58,6 +58,7 @@ inputs:
 outputs:
   - id: main_result
     type: metric
+    format: json
     description: "TODO: Describe your primary output metric"
     decisions: [example_method]
     recipe:
@@ -65,6 +66,7 @@ outputs:
 
   - id: conclusion
     type: report
+    format: md
     description: "Summary of analysis findings"
     inputs: [main_result]
     recipe:

--- a/src/astra/validation/__init__.py
+++ b/src/astra/validation/__init__.py
@@ -3,6 +3,7 @@
 from astra.spec_version import installed_spec_version
 from astra.validation.schema import (
     check_spec_version,
+    collect_recommendations,
     is_valid_analysis,
     is_valid_universe,
     validate_analysis_data,
@@ -21,6 +22,7 @@ from astra.validation.semantic import (
 __all__ = [
     "SemanticError",
     "check_spec_version",
+    "collect_recommendations",
     "installed_spec_version",
     "is_valid_analysis",
     "is_valid_universe",

--- a/src/astra/validation/schema.py
+++ b/src/astra/validation/schema.py
@@ -94,10 +94,32 @@ def validate_analysis_data(data: dict[str, Any]) -> list[str]:
 #
 # `format` is forbidden on a re-exported Output (`from:`), which inherits it
 # from its source, so aliases are skipped rather than flagged for a field they
-# are not allowed to declare. astra-spec's schema is the source of truth; this
-# check exists because the generated Pydantic models carry `recommended` only
-# as prose in the field description.
+# are not allowed to declare.
+#
+# The deadline is read off the installed spec rather than restated here:
+# astra-spec carries it structurally on the generated model, as the LinkML
+# `required_in` annotation, so a spec that moves the date moves this warning
+# with it. The constant below is only the fallback for a spec that stops
+# publishing the annotation.
 _RECOMMENDED_UNTIL = "0.1.0"
+
+
+def _required_in(field_name: str) -> str:
+    """The spec version *field_name* stops being merely recommended in.
+
+    Read from ``Output``'s LinkML metadata
+    (``linkml_meta.annotations.required_in``); falls back to
+    `_RECOMMENDED_UNTIL` if the installed spec does not carry it.
+    """
+    from astra.datamodel.astra_pydantic import Output
+
+    field = Output.model_fields.get(field_name)
+    node: Any = getattr(field, "json_schema_extra", None)
+    for key in ("linkml_meta", "annotations", "required_in", "value"):
+        if not isinstance(node, dict):
+            return _RECOMMENDED_UNTIL
+        node = node.get(key)
+    return node if isinstance(node, str) and node else _RECOMMENDED_UNTIL
 
 
 def collect_recommendations(data: dict[str, Any]) -> list[str]:
@@ -105,6 +127,10 @@ def collect_recommendations(data: dict[str, Any]) -> list[str]:
 
     Returns a list of human-readable messages (empty when nothing to say).
     These are warnings: they never make an analysis invalid.
+
+    The whole tree is walked, so *data* should have its external (``path:``)
+    sub-analyses already resolved — otherwise their outputs are stubs here
+    and would go unreported, having also been skipped as standalone files.
     """
     missing_format: list[str] = []
     for scope, node in iter_analysis_nodes(data):
@@ -124,7 +150,7 @@ def collect_recommendations(data: dict[str, Any]) -> list[str]:
     return [
         f"{len(missing_format)} {subject} without a 'format': "
         f"{', '.join(missing_format)}. Optional today, required from ASTRA "
-        f"{_RECOMMENDED_UNTIL} — add the artifact's file extension, e.g. 'format: png'."
+        f"{_required_in('format')} — add the artifact's file extension, e.g. 'format: png'."
     ]
 
 

--- a/src/astra/validation/schema.py
+++ b/src/astra/validation/schema.py
@@ -19,7 +19,7 @@ import copy
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from astra.helpers import load_yaml
+from astra.helpers import iter_analysis_nodes, load_yaml
 
 if TYPE_CHECKING:
     from pydantic import ValidationError as PydanticValidationError
@@ -86,6 +86,46 @@ def validate_analysis_data(data: dict[str, Any]) -> list[str]:
         return []
     except PydanticValidationError as exc:
         return _format_pydantic_errors(exc)
+
+
+# Fields the schema marks `recommended: true` rather than `required`. Omitting
+# one is not an error — the document validates — but it will become one, so the
+# validator says so while there is still time to act.
+#
+# `format` is forbidden on a re-exported Output (`from:`), which inherits it
+# from its source, so aliases are skipped rather than flagged for a field they
+# are not allowed to declare. astra-spec's schema is the source of truth; this
+# check exists because the generated Pydantic models carry `recommended` only
+# as prose in the field description.
+_RECOMMENDED_UNTIL = "0.1.0"
+
+
+def collect_recommendations(data: dict[str, Any]) -> list[str]:
+    """Report recommended-but-absent fields anywhere in the analysis tree.
+
+    Returns a list of human-readable messages (empty when nothing to say).
+    These are warnings: they never make an analysis invalid.
+    """
+    missing_format: list[str] = []
+    for scope, node in iter_analysis_nodes(data):
+        for output in node.get("outputs") or []:
+            if not isinstance(output, dict):
+                continue
+            if output.get("from") or output.get("format"):
+                continue
+            local_id = output.get("id")
+            if not local_id:
+                continue
+            missing_format.append(".".join((*scope, str(local_id))))
+
+    if not missing_format:
+        return []
+    subject = "output" if len(missing_format) == 1 else "outputs"
+    return [
+        f"{len(missing_format)} {subject} without a 'format': "
+        f"{', '.join(missing_format)}. Optional today, required from ASTRA "
+        f"{_RECOMMENDED_UNTIL} — add the artifact's file extension, e.g. 'format: png'."
+    ]
 
 
 def validate_universe_schema(path: str | Path) -> list[str]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -65,6 +65,38 @@ class TestValidateCommand:
         result = runner.invoke(main, ["validate", "nonexistent.yaml"])
         assert result.exit_code != 0
 
+    def test_an_external_sub_analysis_is_checked_for_recommended_fields(
+        self, runner: CliRunner, tmp_path: Path, minimal_analysis_path: Path
+    ):
+        """A `path:` sub-analysis is skipped as a standalone target, so if the
+        recommendation pass ran on the unresolved tree its outputs would be
+        checked nowhere at all — and hard-fail at 0.1.0 with no warning."""
+        child = tmp_path / "child"
+        child.mkdir()
+        save_yaml(
+            {
+                "inputs": [{"id": "raw", "type": "data", "source": "data/raw.csv"}],
+                "outputs": [
+                    {
+                        "id": "child_out",
+                        "type": "metric",
+                        "description": "No format declared",
+                        "inputs": ["raw"],
+                        "recipe": {"command": "python c.py --out {output}"},
+                    }
+                ],
+            },
+            child / "astra.yaml",
+        )
+        root = load_yaml(minimal_analysis_path)
+        root["analyses"] = {"child": {"path": "child"}}
+        save_yaml(root, tmp_path / "astra.yaml")
+
+        result = runner.invoke(main, ["validate", str(tmp_path / "astra.yaml")])
+        assert result.exit_code == 0  # advisory only, never fatal
+        assert "child.child_out" in result.output
+        assert "without a 'format'" in result.output
+
 
 class TestValidateProjectMode:
     """Tests for `astra validate` with no FILE (whole-project validation)."""

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -154,6 +154,30 @@ class TestResolveOutputs:
         assert found["accuracy"].reexports == "classification.accuracy"
         assert found["feature_plot"].reexports == "feature_extraction.feature_plot"
 
+    def test_format_is_the_declared_serialization(self, pipeline: dict):
+        found = by_id(resolve_outputs(pipeline, universe("baseline")))
+        assert found["classification.accuracy"].format == "json"
+        assert found["feature_extraction.feature_plot"].format == "png"
+
+    def test_a_re_export_inherits_the_format_it_stands_for(self, pipeline: dict):
+        """The schema forbids `format` on an alias, so resolving has to
+        supply the terminal output's — otherwise a consumer holding a
+        re-export cannot tell what it is about to open."""
+        found = by_id(resolve_outputs(pipeline, universe("baseline")))
+        assert found["accuracy"].definition.get("format") is None  # never declared
+        assert found["accuracy"].format == "json"
+        assert found["feature_plot"].format == "png"
+
+    def test_format_is_none_where_the_spec_omits_it(self):
+        """`format` is recommended, not required, so resolving must cope."""
+        data = {
+            "version": "1.0",
+            "name": "No format",
+            "outputs": [{"id": "result", "type": "metric"}],
+        }
+        found = by_id(resolve_outputs(data, {"id": "u", "decisions": {}}))
+        assert found["result"].format is None
+
     def test_an_input_reaching_into_a_sibling_resolves_to_that_output(self, pipeline: dict):
         """`classification.features` is `from: ../feature_extraction.features`
         — the seam between the two stages, and the whole point of the

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -99,6 +99,23 @@ class TestRecommendations:
         assert "a" in messages[0] and "c" in messages[0]
         assert "2 outputs" in messages[0]
 
+    def test_the_deadline_is_read_off_the_installed_spec(self):
+        """Not restated in this repo: astra-spec carries `required_in` on the
+        generated model, so a spec that moves the date moves the warning."""
+        from astra.datamodel.astra_pydantic import Output
+
+        meta = Output.model_fields["format"].json_schema_extra["linkml_meta"]
+        declared = meta["annotations"]["required_in"]["value"]
+        messages = collect_recommendations(self._analysis([{"id": "result", "type": "metric"}]))
+        assert declared in messages[0]
+
+    def test_a_field_without_the_annotation_falls_back(self):
+        """`description` carries no `required_in`, so the pinned constant stands
+        in rather than the message going blank."""
+        from astra.validation.schema import _RECOMMENDED_UNTIL, _required_in
+
+        assert _required_in("description") == _RECOMMENDED_UNTIL
+
     def test_a_missing_format_does_not_make_the_analysis_invalid(self, tmp_path: Path):
         """The whole contract of `recommended`: advisory, never fatal."""
         from astra.validation.schema import validate_analysis_data

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -6,6 +6,7 @@ import pytest
 
 from astra.helpers import load_yaml
 from astra.validation.schema import (
+    collect_recommendations,
     is_valid_analysis,
     is_valid_universe,
     validate_analysis_schema,
@@ -48,6 +49,63 @@ class TestSchemaValidation:
     def test_invalid_output_type(self, invalid_dir: Path):
         errors = validate_analysis_schema(invalid_dir / "invalid_output_type.yaml")
         assert len(errors) > 0
+
+
+class TestRecommendations:
+    """`Output.format` is recommended, not required, until ASTRA 0.1.0.
+
+    The point of these is the *severity*: an analysis without `format` must
+    stay valid. Only the advisory channel is allowed to notice.
+    """
+
+    def _analysis(self, outputs: list[dict]) -> dict:
+        return {"version": "1.0", "name": "Recommendations", "outputs": outputs}
+
+    def test_an_output_without_a_format_is_reported(self):
+        data = self._analysis([{"id": "result", "type": "metric"}])
+        messages = collect_recommendations(data)
+        assert len(messages) == 1
+        assert "result" in messages[0] and "format" in messages[0]
+
+    def test_an_output_with_a_format_is_not(self):
+        data = self._analysis([{"id": "result", "type": "metric", "format": "json"}])
+        assert collect_recommendations(data) == []
+
+    def test_a_re_export_is_never_reported(self):
+        """An alias inherits `format` and is forbidden from declaring one,
+        so asking it for a format would be asking for a schema violation."""
+        data = self._analysis([{"id": "result", "from": "child.result"}])
+        assert collect_recommendations(data) == []
+
+    def test_a_nested_output_is_named_by_its_qualified_id(self):
+        data = self._analysis([])
+        data["analyses"] = {
+            "child": {"outputs": [{"id": "result", "type": "metric"}]},
+        }
+        messages = collect_recommendations(data)
+        assert len(messages) == 1
+        assert "child.result" in messages[0]
+
+    def test_every_offender_is_named_in_one_message(self):
+        data = self._analysis(
+            [
+                {"id": "a", "type": "metric"},
+                {"id": "b", "type": "figure", "format": "png"},
+                {"id": "c", "type": "table"},
+            ]
+        )
+        messages = collect_recommendations(data)
+        assert len(messages) == 1
+        assert "a" in messages[0] and "c" in messages[0]
+        assert "2 outputs" in messages[0]
+
+    def test_a_missing_format_does_not_make_the_analysis_invalid(self, tmp_path: Path):
+        """The whole contract of `recommended`: advisory, never fatal."""
+        from astra.validation.schema import validate_analysis_data
+
+        data = self._analysis([{"id": "result", "type": "metric"}])
+        assert validate_analysis_data(data) == []
+        assert collect_recommendations(data)
 
 
 class TestSemanticValidation:


### PR DESCRIPTION
Brings the tooling up to `Output.format`, added in astra-spec 0.0.14 ([astra-spec#73](https://github.com/LightconeResearch/astra-spec/pull/73)). It is the artifact's serialization as a lowercase extension token — `png`, `csv`, `parquet`, `fits` — recommended rather than required until ASTRA 0.1.0.

## `astra.resolve` — `ResolvedOutput.format`

Resolved **through** re-export chains, not read off the local definition:

```python
found["accuracy"].definition.get("format")  # None — an alias never declares one
found["accuracy"].format                    # "json" — from classification.accuracy
```

The schema forbids `format` on an alias (it inherits its source's, like `type`), so a consumer holding a re-export would otherwise have no way to tell what it is about to open. That is exactly the resolving half this module exists to supply.

## `astra validate` — an advisory pass

`collect_recommendations` reports non-aliased outputs with no `format`, naming every offender in a single message rather than one line each:

```
✓ Schema validation passed
✓ Semantic validation passed
⚠  6 outputs without a 'format': trained_output, accuracy, f1_score,
   confusion_matrix, model_comparison, conclusion. Optional today, required
   from ASTRA 0.1.0 — add the artifact's file extension, e.g. 'format: png'.

Validation successful!
```

Two properties this deliberately holds to:

- **Never fatal.** The analysis stays valid and the exit code is untouched (verified at exit 0). The point is that an author hears about the field before the release that makes it mandatory, not after.
- **Aliases are skipped.** Asking a re-export for a `format` is asking for a schema violation, so they are never flagged.

This also fills in a gap worth noting: `astra validate` had no warnings channel at all — only `astra init --json` emitted `warnings`. It now follows the same yellow-⚠ pattern `check_spec_version` already established.

## Dependency bump

`astra-spec>=0.0.13` → `>=0.0.14`, and this one is a hard floor rather than a nicety. The generated Pydantic models are `extra="forbid"`, so 0.0.13 rejects `format:` outright:

```
Schema validation errors:
  • outputs.0.format: Extra inputs are not permitted
```

Since the scaffold and both examples now declare `format`, the package cannot work against an earlier spec.

## Changes

- `src/astra/resolve.py` — `ResolvedOutput.format`, settled in `_follow` alongside the existing re-export chasing
- `src/astra/validation/schema.py` — `collect_recommendations`, exported from `astra.validation`
- `src/astra/cli.py` — prints recommendations after semantic validation
- `src/astra/scaffold.py` — `astra init` template declares `format`
- `examples/iris`, `examples/iris_pipeline` — `format` on every non-aliased output
- `pyproject.toml`, `CLAUDE.md`
- `tests/` — `TestRecommendations` (6 cases, incl. that a missing format leaves the analysis valid) and 3 resolve cases covering inheritance through re-export

Existing fixtures are left alone: `format` is optional, they stay valid, and adding it to each would obscure the rule each one exists to test.

## Testing

Against the published astra-spec 0.0.14: **299 passed, 21 skipped**. `ruff check`, `ruff format --check`, and `mypy src` all clean.

Both examples validate with no warnings — which is also what confirms the alias skip works on `iris_pipeline`, the only fixture with real re-exports. Stripping `format` back out of a copy reproduces the warning at exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QYEKquixMtej2uLGG1afAD