### PR TITLE
universe generate: add --force to allow overwrite

### DIFF
--- a/src/astra/cli.py
+++ b/src/astra/cli.py
@@ -741,11 +741,18 @@ def universe() -> None:
     help="Output file (default: universes/<name>.yaml)",
 )
 @click.option("--description", "-d", help="Universe description")
+@click.option(
+    "--force",
+    "-f",
+    is_flag=True,
+    help="Overwrite the output file if it already exists",
+)
 def generate_universe(
     name: str,
     analysis: Path | None,
     output: Path | None,
     description: str | None,
+    force: bool,
 ) -> None:
     """Generate a universe from analysis defaults."""
     analysis_path = _require_analysis(analysis)
@@ -764,6 +771,11 @@ def generate_universe(
 
     if output is None:
         output = analysis_path.parent / "universes" / f"{name}.yaml"
+
+    if output.exists() and not force:
+        console.print(f"[red]Error:[/red] [cyan]{output}[/cyan] already exists.")
+        console.print("Use [cyan]--force[/cyan] to overwrite it.")
+        raise SystemExit(1)
 
     output.parent.mkdir(parents=True, exist_ok=True)
     save_yaml(uni, output)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -365,6 +365,54 @@ class TestUniverseCommands:
         assert result.exit_code == 0
         assert (tmp_path / "universes" / "baseline.yaml").exists()
 
+    def test_universe_generate_refuses_to_overwrite(
+        self, runner: CliRunner, full_analysis_path: Path, tmp_path: Path
+    ):
+        output_path = tmp_path / "generated.yaml"
+        output_path.write_text("id: hand-edited\n")
+
+        result = runner.invoke(
+            main,
+            [
+                "universe",
+                "generate",
+                "-a",
+                str(full_analysis_path),
+                "-n",
+                "test-universe",
+                "-o",
+                str(output_path),
+            ],
+        )
+        assert result.exit_code != 0
+        assert "already exists" in result.output
+        # The hand-edited file must be left untouched.
+        assert output_path.read_text() == "id: hand-edited\n"
+
+    def test_universe_generate_force_overwrites(
+        self, runner: CliRunner, full_analysis_path: Path, tmp_path: Path
+    ):
+        output_path = tmp_path / "generated.yaml"
+        output_path.write_text("id: hand-edited\n")
+
+        result = runner.invoke(
+            main,
+            [
+                "universe",
+                "generate",
+                "-a",
+                str(full_analysis_path),
+                "-n",
+                "test-universe",
+                "-o",
+                str(output_path),
+                "--force",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "Generated universe" in result.output
+        assert load_yaml(output_path)["id"] == "test-universe"
+
     def test_universe_check_valid(
         self,
         runner: CliRunner,


### PR DESCRIPTION
Adds a `--force/-f` flag to `astra universe generate`. Without it, generate now refuses to overwrite an existing output file instead of silently clobbering it; with it, behavior is unchanged. This lets you regenerate a stale placeholder file like `universes/baseline.yaml` (e.g. `astra universe generate -n baseline --force`) without having to `rm` it first, while protecting hand-edited universe variants from accidental loss.

Addresses the "no overwrite" half of #108 (the `--set` half is intentionally out of scope per maintainer request).

Generated with [Claude Code](https://claude.ai/code)